### PR TITLE
fix: orient conventions warn entries are historical record (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,13 @@ changelog is the canonical record of what moved.
 ### Changed
 
 - `memory_orient` compact conventions now include a rule clarifying that
-  Munin entries are historical record, not current state. Models should
+  memory describes external artifacts at a point in time, so models should
   verify feature-level claims (UI copy, flows, exact behavior) against the
-  source artifact before asserting to the user. Backend capability ≠ UI
-  exposure. The full `meta/conventions` entry also gains an *Interpretation
-  Rules* section with the same guidance. Prompted by an external tester
-  report of an Opus 4.6 session hallucinating UI features despite accurate
-  Munin retrieval (#33).
+  current artifact — code, templates, running app — before asserting to
+  the user. Backend capability ≠ UI exposure. State entries remain the
+  current truth within Munin; the new rule is scoped to claims that depend
+  on external reality. Prompted by an external tester report of an Opus 4.6
+  session hallucinating UI features despite accurate Munin retrieval (#33).
 
 - `memory_insights` aggregates now include session-segmented reformulation
   context: `reformulation_rate_adjusted` (excludes single-event sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ changelog is the canonical record of what moved.
 
 ### Changed
 
+- `memory_orient` compact conventions now include a rule clarifying that
+  Munin entries are historical record, not current state. Models should
+  verify feature-level claims (UI copy, flows, exact behavior) against the
+  source artifact before asserting to the user. Backend capability ≠ UI
+  exposure. The full `meta/conventions` entry also gains an *Interpretation
+  Rules* section with the same guidance. Prompted by an external tester
+  report of an Opus 4.6 session hallucinating UI features despite accurate
+  Munin retrieval (#33).
+
 - `memory_insights` aggregates now include session-segmented reformulation
   context: `reformulation_rate_adjusted` (excludes single-event sessions
   from the denominator), `reformulation_explanation` (human-readable note

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3137,7 +3137,7 @@ function compactConventions(updatedAt: string): string {
     "- **State entries** = current truth (mutable). **Log entries** = chronological (append-only).",
     "- **Write vs update_status:** use `memory_update_status` for tracked `projects/*`/`clients/*` status entries; use `memory_write` for other state.",
     "- **Write protocol:** Log decisions first (memory_log), then update status with CAS (expected_updated_at).",
-    "- **Entries are historical record, not current state.** Verify feature-level claims (UI copy, flows, exact behavior) against the artifact — code, templates, running app — before asserting. Backend capability ≠ UI exposure.",
+    "- **Memory describes external artifacts at a point in time.** Before asserting feature-level claims (UI copy, flows, exact behavior), verify against the current artifact — code, templates, running app. Backend capability ≠ UI exposure. (State entries remain the current truth *within Munin*; this rule is about claims that depend on external reality.)",
     "- **Lifecycle tags** (required on status): active, blocked, completed, stopped, maintenance, archived.",
     "- **Tracked namespaces** (dashboard): projects/*, clients/*. Must have status key + lifecycle tag.",
     "- **Prefixed tags:** client:<name>, person:<name>, topic:<topic>, type:<artifact>, source:external/internal.",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3137,6 +3137,7 @@ function compactConventions(updatedAt: string): string {
     "- **State entries** = current truth (mutable). **Log entries** = chronological (append-only).",
     "- **Write vs update_status:** use `memory_update_status` for tracked `projects/*`/`clients/*` status entries; use `memory_write` for other state.",
     "- **Write protocol:** Log decisions first (memory_log), then update status with CAS (expected_updated_at).",
+    "- **Entries are historical record, not current state.** Verify feature-level claims (UI copy, flows, exact behavior) against the artifact — code, templates, running app — before asserting. Backend capability ≠ UI exposure.",
     "- **Lifecycle tags** (required on status): active, blocked, completed, stopped, maintenance, archived.",
     "- **Tracked namespaces** (dashboard): projects/*, clients/*. Must have status key + lifecycle tag.",
     "- **Prefixed tags:** client:<name>, person:<name>, topic:<topic>, type:<artifact>, source:external/internal.",

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2275,7 +2275,7 @@ describe("memory_orient", () => {
     // Default is compact conventions
     expect(result.conventions.content).toContain("# Quick Reference");
     expect(result.conventions.content).toContain("memory_read");
-    expect(result.conventions.content).toContain("historical record, not current state");
+    expect(result.conventions.content).toContain("external artifacts at a point in time");
     expect(result.conventions.updated_at).toBeTruthy();
     expect((result.conventions as any).compact).toBe(true);
     expect(result.dashboard).toBeDefined();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2275,6 +2275,7 @@ describe("memory_orient", () => {
     // Default is compact conventions
     expect(result.conventions.content).toContain("# Quick Reference");
     expect(result.conventions.content).toContain("memory_read");
+    expect(result.conventions.content).toContain("historical record, not current state");
     expect(result.conventions.updated_at).toBeTruthy();
     expect((result.conventions as any).compact).toBe(true);
     expect(result.dashboard).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds a new rule to the compact conventions returned by `memory_orient`: *"Entries are historical record, not current state. Verify feature-level claims (UI copy, flows, exact behavior) against the artifact — code, templates, running app — before asserting. Backend capability ≠ UI exposure."*
- Adds a matching *Interpretation Rules* section to the full `meta/conventions` entry.
- Test coverage: orient-compact assertion now checks the new line is present.

## Why

Issue #33 (external tester, Jonas Bååth): Opus 4.6 hallucinated three UI features (click-to-navigate on search results, "Ankare" as UI label instead of "Nyckelpassage", DOCX/ODT export dialog checkboxes) despite Munin retrieval returning accurate data. The devlog correctly described backend capabilities with file paths; the model inferred UI exposure from backend existence.

Root cause was interpretation, not representation. The lightweight fix is to make the distinction explicit in the handshake conventions that every Munin-connected model reads first.

Does not try to solve confidence calibration or detect unsupported claims — those are Phase 2 design concerns for the retrieval analytics layer. See my comment on #33 for the reasoning.

Closes #33.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1034 tests passing (1 orient-compact assertion added)
- [ ] Manual: call `memory_orient` and confirm the new rule appears in the compact conventions block