### PR TITLE
feat: MUNIN_CREDENTIALS_FILE for bridge secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ changelog is the canonical record of what moved.
 
 ### Added
 
+- **Bridge credentials file** — the MCP stdio-to-HTTP bridge now accepts
+  `MUNIN_CREDENTIALS_FILE`, a path to a `chmod 600` JSON file holding
+  `auth_token` / `cf_client_id` / `cf_client_secret`. The bridge refuses to
+  read the file if it has any group or world bits set, and logs a warning if
+  inline env vars are set but overridden by the file. This keeps Bearer tokens
+  and Cloudflare Access secrets out of MCP client config files (Codex CLI,
+  Claude Desktop, etc.), which typically land on disk as plaintext `0644`.
+  README has a new "Credential storage" section (#30).
+
 - **Orphan cross-reference discovery** — the consolidation worker now scans
   the unincorporated log window for mentions of other tracked namespaces
   (`projects/*`, `clients/*`, `people/*`, `decisions/*`) and checks whether

--- a/README.md
+++ b/README.md
@@ -162,6 +162,36 @@ All configuration is via environment variables. Copy `.env.example` for a starti
 
 See `.env.example` for the full list.
 
+## Credential storage (MCP bridge)
+
+The stdio-to-HTTP bridge (`dist/bridge.js`) needs a Bearer token and optionally Cloudflare Access client credentials to talk to a remote Munin server. MCP clients typically pass these via env vars in their config file, which means the secrets end up in plaintext on disk (often `0644`, syncable to dotfile repos, easy to screenshot).
+
+**Recommended: store secrets in a `chmod 600` JSON file, not in your MCP client config.**
+
+```bash
+mkdir -p ~/.config/munin
+cat > ~/.config/munin/credentials.json <<'JSON'
+{
+  "auth_token": "…",
+  "cf_client_id": "…",
+  "cf_client_secret": "…"
+}
+JSON
+chmod 600 ~/.config/munin/credentials.json
+```
+
+Then point the bridge at the file in your MCP client config (example: `~/.codex/config.toml`):
+
+```toml
+[mcp_servers.munin-memory.env]
+MUNIN_REMOTE_URL = "https://munin.example.com/mcp"
+MUNIN_CREDENTIALS_FILE = "/Users/you/.config/munin/credentials.json"
+```
+
+The bridge refuses to read a credentials file that is group- or world-accessible — fix perms with `chmod 600`. If both the file and inline env vars are set, the file wins and a stderr warning lists the env vars that were ignored.
+
+All three fields are optional; omit `cf_client_id` / `cf_client_secret` if you don't use Cloudflare Access. Rotate the Bearer token at a cadence that fits your threat model — once a quarter is a reasonable default for a personal deployment.
+
 ## Deploying to a Raspberry Pi
 
 This is how I run it today — a `full-node` deployment on a Pi 5 on my desk, accessible from anywhere via a Cloudflare Tunnel. The general pattern:

--- a/scripts/deploy-rpi.sh
+++ b/scripts/deploy-rpi.sh
@@ -75,33 +75,85 @@ fi
 
 # --- Bridge configuration for Claude Code ---
 
+PI_CREDS_PATH="/home/${USER}/.config/munin/credentials.json"
+
+sync_credentials_file() {
+  local local_path="$1"
+  # Expand a leading ~ on the local side
+  local_path="${local_path/#\~/$HOME}"
+  if [[ ! -r "$local_path" ]]; then
+    echo "  WARNING: MUNIN_CREDENTIALS_FILE=${local_path} is not readable locally; skipping sync"
+    return 1
+  fi
+  echo "  Syncing credentials file to ${HOST}:${PI_CREDS_PATH} (chmod 600)"
+  ssh "${USER}@${HOST}" "mkdir -p '$(dirname "${PI_CREDS_PATH}")' && chmod 700 '$(dirname "${PI_CREDS_PATH}")'"
+  scp -q "$local_path" "${USER}@${HOST}:${PI_CREDS_PATH}"
+  ssh "${USER}@${HOST}" "chmod 600 '${PI_CREDS_PATH}'"
+  return 0
+}
+
 if [[ "$MODE" != "--server-only" ]]; then
   echo ""
   echo "==> Configuring MCP bridge for Claude Code on Pi..."
 
   # Check if Claude Code is installed
   if ! ssh "${USER}@${HOST}" "command -v claude &>/dev/null"; then
-    echo "WARNING: 'claude' CLI not found on Pi. Install Claude Code first, then run:"
-    echo "  claude mcp add-json munin-memory '<config>' -s user"
+    echo "WARNING: 'claude' CLI not found on Pi. Install Claude Code first, then:"
+    echo "  1. Create ${PI_CREDS_PATH} (chmod 600) with keys auth_token / cf_client_id / cf_client_secret"
+    echo "  2. Register the bridge:"
+    echo "     claude mcp add-json munin-memory '<config>' -s user"
     echo ""
-    echo "Config JSON:"
-    cat <<'CONFIGEOF'
-{"type":"stdio","command":"node","args":["/home/<user>/munin-memory/dist/bridge.js"],"env":{"MUNIN_REMOTE_URL":"https://<your-domain>/mcp","MUNIN_AUTH_TOKEN":"<your-token>","MUNIN_REQUEST_TIMEOUT_MS":"60000"}}
+    echo "Config JSON (preferred — credentials in a chmod 600 file):"
+    cat <<CONFIGEOF
+{"type":"stdio","command":"node","args":["${REMOTE_DIR}/dist/bridge.js"],"env":{"MUNIN_REMOTE_URL":"https://<your-domain>/mcp","MUNIN_CREDENTIALS_FILE":"${PI_CREDS_PATH}","MUNIN_REQUEST_TIMEOUT_MS":"60000"}}
+CONFIGEOF
+    echo ""
+    echo "Fallback (less secure — inline plaintext token in MCP client config):"
+    cat <<CONFIGEOF
+{"type":"stdio","command":"node","args":["${REMOTE_DIR}/dist/bridge.js"],"env":{"MUNIN_REMOTE_URL":"https://<your-domain>/mcp","MUNIN_AUTH_TOKEN":"<your-token>","MUNIN_REQUEST_TIMEOUT_MS":"60000"}}
 CONFIGEOF
   else
-    # Read auth credentials from local config if available
-    BRIDGE_CONFIG=$(python3 -c "
+    # Read auth credentials from local config if available. If the local
+    # config references MUNIN_CREDENTIALS_FILE, sync the file to the Pi and
+    # rewrite the env value to the Pi-local path. Otherwise, copy the env
+    # block verbatim.
+    LOCAL_CREDS_PATH=$(python3 -c "
+import json, os
+try:
+    with open(os.path.expanduser('~/.claude.json')) as f:
+        d = json.load(f)
+    env = d.get('mcpServers', {}).get('munin-memory', {}).get('env', {})
+    print(env.get('MUNIN_CREDENTIALS_FILE', ''))
+except Exception:
+    pass
+" 2>/dev/null) || true
+
+    CREDS_SYNCED=false
+    if [[ -n "$LOCAL_CREDS_PATH" ]]; then
+      if sync_credentials_file "$LOCAL_CREDS_PATH"; then
+        CREDS_SYNCED=true
+      fi
+    fi
+
+    BRIDGE_CONFIG=$(CREDS_SYNCED="$CREDS_SYNCED" PI_CREDS_PATH="$PI_CREDS_PATH" REMOTE_DIR="$REMOTE_DIR" python3 -c "
 import json, os
 with open(os.path.expanduser('~/.claude.json')) as f:
     d = json.load(f)
 ms = d.get('mcpServers', {}).get('munin-memory', {})
-env = ms.get('env', {})
-# Rewrite path for Pi
+env = dict(ms.get('env', {}))
+creds_synced = os.environ.get('CREDS_SYNCED') == 'true'
+pi_creds_path = os.environ.get('PI_CREDS_PATH', '')
+if creds_synced and env.get('MUNIN_CREDENTIALS_FILE'):
+    env['MUNIN_CREDENTIALS_FILE'] = pi_creds_path
+elif env.get('MUNIN_CREDENTIALS_FILE'):
+    # Strip an unsynced workstation-local path so the Pi bridge does not
+    # start up pointing at a non-existent file.
+    env.pop('MUNIN_CREDENTIALS_FILE', None)
 config = {
     'type': 'stdio',
     'command': 'node',
-    'args': ['${REMOTE_DIR}/dist/bridge.js'],
-    'env': env
+    'args': [os.environ.get('REMOTE_DIR', '') + '/dist/bridge.js'],
+    'env': env,
 }
 print(json.dumps(config))
 " 2>/dev/null) || true

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,8 +13,17 @@
  *   MUNIN_AUTH_TOKEN           — Bearer token for Authorization header.
  *   MUNIN_CF_CLIENT_ID         — Cloudflare Access client ID.
  *   MUNIN_CF_CLIENT_SECRET     — Cloudflare Access client secret.
+ *   MUNIN_CREDENTIALS_FILE     — Optional path to a 0600 JSON file holding
+ *                                 auth_token / cf_client_id / cf_client_secret.
+ *                                 When set, these values are read from the
+ *                                 file instead of env vars, keeping secrets
+ *                                 out of MCP client config files.
  *   MUNIN_REQUEST_TIMEOUT_MS   — Per-request timeout in ms (default: 60000).
  */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -22,6 +31,142 @@ import {
   StreamableHTTPError,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+// --- Credential loading ---
+
+export interface BridgeCredentials {
+  authToken?: string;
+  cfClientId?: string;
+  cfClientSecret?: string;
+}
+
+interface CredentialsFileShape {
+  auth_token?: unknown;
+  cf_client_id?: unknown;
+  cf_client_secret?: unknown;
+}
+
+export interface CredentialsLoaderOptions {
+  env?: NodeJS.ProcessEnv;
+  readFile?: (filePath: string) => string;
+  stat?: (filePath: string) => { mode: number };
+  log?: (msg: string) => void;
+  platform?: NodeJS.Platform;
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+function readStringField(
+  source: CredentialsFileShape,
+  field: keyof CredentialsFileShape,
+  filePath: string,
+): string | undefined {
+  const value = source[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(
+      `MUNIN_CREDENTIALS_FILE at ${filePath}: field "${field}" must be a string.`,
+    );
+  }
+  return value;
+}
+
+export function loadBridgeCredentials(
+  options: CredentialsLoaderOptions = {},
+): BridgeCredentials {
+  const env = options.env ?? process.env;
+  const readFile =
+    options.readFile ?? ((p: string) => fs.readFileSync(p, "utf-8"));
+  const stat = options.stat ?? ((p: string) => fs.statSync(p));
+  const log =
+    options.log ??
+    ((msg: string) => process.stderr.write(`[munin-bridge] ${msg}\n`));
+  const platform = options.platform ?? process.platform;
+
+  const rawPath = env.MUNIN_CREDENTIALS_FILE;
+  if (!rawPath || rawPath.length === 0) {
+    return {
+      authToken: env.MUNIN_AUTH_TOKEN,
+      cfClientId: env.MUNIN_CF_CLIENT_ID,
+      cfClientSecret: env.MUNIN_CF_CLIENT_SECRET,
+    };
+  }
+
+  const filePath = expandHome(rawPath);
+
+  let stats: { mode: number };
+  try {
+    stats = stat(filePath);
+  } catch (err) {
+    throw new Error(
+      `MUNIN_CREDENTIALS_FILE set but file is not readable at ${filePath}: ${
+        (err as Error).message
+      }`,
+    );
+  }
+
+  if (platform !== "win32") {
+    const mode = stats.mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      throw new Error(
+        `MUNIN_CREDENTIALS_FILE at ${filePath} has mode 0${mode
+          .toString(8)
+          .padStart(3, "0")}; refusing to read a group/world-accessible credentials file (use \`chmod 600\`).`,
+      );
+    }
+  }
+
+  let raw: string;
+  try {
+    raw = readFile(filePath);
+  } catch (err) {
+    throw new Error(
+      `Failed to read MUNIN_CREDENTIALS_FILE at ${filePath}: ${
+        (err as Error).message
+      }`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `MUNIN_CREDENTIALS_FILE at ${filePath} is not valid JSON: ${
+        (err as Error).message
+      }`,
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `MUNIN_CREDENTIALS_FILE at ${filePath} must contain a JSON object at the top level.`,
+    );
+  }
+
+  const obj = parsed as CredentialsFileShape;
+  const authToken = readStringField(obj, "auth_token", filePath);
+  const cfClientId = readStringField(obj, "cf_client_id", filePath);
+  const cfClientSecret = readStringField(obj, "cf_client_secret", filePath);
+
+  const overriddenEnv: string[] = [];
+  if (env.MUNIN_AUTH_TOKEN) overriddenEnv.push("MUNIN_AUTH_TOKEN");
+  if (env.MUNIN_CF_CLIENT_ID) overriddenEnv.push("MUNIN_CF_CLIENT_ID");
+  if (env.MUNIN_CF_CLIENT_SECRET) overriddenEnv.push("MUNIN_CF_CLIENT_SECRET");
+  if (overriddenEnv.length > 0) {
+    log(
+      `MUNIN_CREDENTIALS_FILE is set; ignoring inline env vars: ${overriddenEnv.join(", ")}`,
+    );
+  }
+
+  log(`Credentials loaded from file: ${filePath}`);
+
+  return { authToken, cfClientId, cfClientSecret };
+}
 
 // --- Exported helpers (for testing) ---
 
@@ -349,16 +494,16 @@ async function main(): Promise<void> {
     10,
   );
 
+  const creds = loadBridgeCredentials({ log });
   const authHeaders: Record<string, string> = {};
-  if (process.env.MUNIN_AUTH_TOKEN) {
-    authHeaders["Authorization"] = `Bearer ${process.env.MUNIN_AUTH_TOKEN}`;
+  if (creds.authToken) {
+    authHeaders["Authorization"] = `Bearer ${creds.authToken}`;
   }
-  if (process.env.MUNIN_CF_CLIENT_ID) {
-    authHeaders["CF-Access-Client-Id"] = process.env.MUNIN_CF_CLIENT_ID;
+  if (creds.cfClientId) {
+    authHeaders["CF-Access-Client-Id"] = creds.cfClientId;
   }
-  if (process.env.MUNIN_CF_CLIENT_SECRET) {
-    authHeaders["CF-Access-Client-Secret"] =
-      process.env.MUNIN_CF_CLIENT_SECRET;
+  if (creds.cfClientSecret) {
+    authHeaders["CF-Access-Client-Secret"] = creds.cfClientSecret;
   }
 
   const fetchWithTimeout = createFetchWithTimeout(requestTimeoutMs);

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -5,6 +5,7 @@ import {
   isSessionExpiredError,
   isRequest,
   createBridge,
+  loadBridgeCredentials,
   type TransportLike,
 } from "../src/bridge.js";
 
@@ -449,5 +450,195 @@ describe("createBridge reconnection", () => {
 
     // No error response sent (notifications don't get error responses)
     expect(sentToStdio).toHaveLength(0);
+  });
+});
+
+// --- loadBridgeCredentials ---
+
+describe("loadBridgeCredentials", () => {
+  function fakeStat(mode: number): (p: string) => { mode: number } {
+    return () => ({ mode });
+  }
+
+  it("falls back to env vars when MUNIN_CREDENTIALS_FILE is unset", () => {
+    const creds = loadBridgeCredentials({
+      env: {
+        MUNIN_AUTH_TOKEN: "tok",
+        MUNIN_CF_CLIENT_ID: "cid",
+        MUNIN_CF_CLIENT_SECRET: "csec",
+      },
+      log: () => {},
+    });
+    expect(creds).toEqual({
+      authToken: "tok",
+      cfClientId: "cid",
+      cfClientSecret: "csec",
+    });
+  });
+
+  it("treats empty MUNIN_CREDENTIALS_FILE as unset", () => {
+    const creds = loadBridgeCredentials({
+      env: { MUNIN_CREDENTIALS_FILE: "", MUNIN_AUTH_TOKEN: "tok" },
+      log: () => {},
+    });
+    expect(creds.authToken).toBe("tok");
+  });
+
+  it("loads credentials from a 0600 JSON file", () => {
+    const logs: string[] = [];
+    const creds = loadBridgeCredentials({
+      env: { MUNIN_CREDENTIALS_FILE: "/tmp/fake-creds.json" },
+      stat: fakeStat(0o600),
+      readFile: () =>
+        JSON.stringify({
+          auth_token: "filetok",
+          cf_client_id: "filecid",
+          cf_client_secret: "filecsec",
+        }),
+      log: (m) => logs.push(m),
+      platform: "linux",
+    });
+    expect(creds).toEqual({
+      authToken: "filetok",
+      cfClientId: "filecid",
+      cfClientSecret: "filecsec",
+    });
+    expect(
+      logs.some((m) => m.startsWith("Credentials loaded from file:")),
+    ).toBe(true);
+  });
+
+  it("refuses a world-readable credentials file (0644)", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/tmp/creds.json" },
+        stat: fakeStat(0o644),
+        readFile: () => "{}",
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/mode 0644.*chmod 600/);
+  });
+
+  it("refuses a group-readable credentials file (0640)", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/tmp/creds.json" },
+        stat: fakeStat(0o640),
+        readFile: () => "{}",
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/mode 0640/);
+  });
+
+  it("accepts 0400 (read-only owner)", () => {
+    const creds = loadBridgeCredentials({
+      env: { MUNIN_CREDENTIALS_FILE: "/tmp/creds.json" },
+      stat: fakeStat(0o400),
+      readFile: () => JSON.stringify({ auth_token: "t" }),
+      log: () => {},
+      platform: "linux",
+    });
+    expect(creds.authToken).toBe("t");
+  });
+
+  it("skips mode check on win32", () => {
+    const creds = loadBridgeCredentials({
+      env: { MUNIN_CREDENTIALS_FILE: "C:\\creds.json" },
+      stat: fakeStat(0o777),
+      readFile: () => JSON.stringify({ auth_token: "wtok" }),
+      log: () => {},
+      platform: "win32",
+    });
+    expect(creds.authToken).toBe("wtok");
+  });
+
+  it("throws a clear error when stat fails", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/nope" },
+        stat: () => {
+          throw new Error("ENOENT: no such file");
+        },
+        readFile: () => "",
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/not readable at \/nope.*ENOENT/);
+  });
+
+  it("throws when the file is not valid JSON", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/tmp/bad.json" },
+        stat: fakeStat(0o600),
+        readFile: () => "not json",
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/not valid JSON/);
+  });
+
+  it("throws when the file is a JSON array", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/tmp/arr.json" },
+        stat: fakeStat(0o600),
+        readFile: () => "[]",
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/JSON object at the top level/);
+  });
+
+  it("throws when a field has the wrong type", () => {
+    expect(() =>
+      loadBridgeCredentials({
+        env: { MUNIN_CREDENTIALS_FILE: "/tmp/wrong.json" },
+        stat: fakeStat(0o600),
+        readFile: () => JSON.stringify({ auth_token: 42 }),
+        log: () => {},
+        platform: "linux",
+      }),
+    ).toThrow(/field "auth_token" must be a string/);
+  });
+
+  it("logs a warning when env vars are overridden by the file", () => {
+    const logs: string[] = [];
+    loadBridgeCredentials({
+      env: {
+        MUNIN_CREDENTIALS_FILE: "/tmp/creds.json",
+        MUNIN_AUTH_TOKEN: "envtok",
+        MUNIN_CF_CLIENT_ID: "envcid",
+      },
+      stat: fakeStat(0o600),
+      readFile: () => JSON.stringify({ auth_token: "filetok" }),
+      log: (m) => logs.push(m),
+      platform: "linux",
+    });
+    expect(
+      logs.some(
+        (m) =>
+          m.includes("ignoring inline env vars") &&
+          m.includes("MUNIN_AUTH_TOKEN") &&
+          m.includes("MUNIN_CF_CLIENT_ID"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a partial file (only auth_token)", () => {
+    const creds = loadBridgeCredentials({
+      env: { MUNIN_CREDENTIALS_FILE: "/tmp/partial.json" },
+      stat: fakeStat(0o600),
+      readFile: () => JSON.stringify({ auth_token: "t" }),
+      log: () => {},
+      platform: "linux",
+    });
+    expect(creds).toEqual({
+      authToken: "t",
+      cfClientId: undefined,
+      cfClientSecret: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Bridge now accepts `MUNIN_CREDENTIALS_FILE`, a path to a `chmod 600` JSON file holding `auth_token` / `cf_client_id` / `cf_client_secret`. Refuses to read if any group/world bits are set.
- Falls back to inline env vars when the path is unset; when both are set, the file wins and a stderr warning names the overridden env vars.
- README gains a "Credential storage (MCP bridge)" section with a worked Codex `config.toml` example and a rotation-cadence note.

Closes #30. Follow-up #35 tracks `munin-admin rotate-bearer`.

## Test plan
- [x] `npm test` — 1047 tests pass (13 new unit tests in `tests/bridge.test.ts` covering happy path, 0644/0640 refusal, 0400 accepted, win32 skip, ENOENT, bad JSON, array top-level, wrong field type, env-override warning, partial file).
- [x] `npm run build` — clean.
- [ ] Manual: point a local Codex config at a `chmod 600` credentials file; confirm the bridge connects. Then `chmod 644` the file and confirm it refuses with a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)