### PR TITLE
feat: diagnostic logging for 4xx /mcp responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ changelog is the canonical record of what moved.
 
 ### Added
 
+- **4xx diagnostic logging on `/mcp`** — when an HTTP MCP request returns a
+  4xx status, the request log entry now carries a `diagnostics` field with
+  redacted request headers and a 500-char body snippet. Sensitive headers
+  (`authorization`, `cookie`, `proxy-authorization`, `cf-access-client-secret`,
+  `x-api-key`) are replaced with `[REDACTED]`. Zero overhead on 2xx responses.
+  Helps capture minimal reproductions for client-side MCP quirks (#32).
+
 - **Bridge credentials file** — the MCP stdio-to-HTTP bridge now accepts
   `MUNIN_CREDENTIALS_FILE`, a path to a `chmod 600` JSON file holding
   `auth_token` / `cf_client_id` / `cf_client_secret`. The bridge refuses to

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,10 @@ export interface RequestLogEntry {
   sessionId?: string;
   status: number;
   durationMs: number;
+  diagnostics?: {
+    headers: Record<string, string | string[]>;
+    bodySnippet?: string;
+  };
 }
 
 export interface HttpAppOptions {
@@ -428,6 +432,38 @@ function deriveSessionId(clientId: string): string {
   return createHash("sha256").update(`${clientId}:${bucket}`).digest("hex").slice(0, 32);
 }
 
+const REDACTED_HEADER_KEYS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "cf-access-client-secret",
+  "x-api-key",
+]);
+
+const DIAGNOSTIC_BODY_SNIPPET_LIMIT = 500;
+
+function redactHeaders(headers: Request["headers"]): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    out[key] = REDACTED_HEADER_KEYS.has(key.toLowerCase()) ? "[REDACTED]" : value;
+  }
+  return out;
+}
+
+function buildBodySnippet(body: unknown): string | undefined {
+  if (body === undefined) return undefined;
+  try {
+    const serialized = typeof body === "string" ? body : JSON.stringify(body);
+    if (!serialized) return undefined;
+    return serialized.length > DIAGNOSTIC_BODY_SNIPPET_LIMIT
+      ? serialized.slice(0, DIAGNOSTIC_BODY_SNIPPET_LIMIT) + "...[truncated]"
+      : serialized;
+  } catch {
+    return undefined;
+  }
+}
+
 function attachRequestLogger(
   req: Request,
   res: Response,
@@ -438,9 +474,10 @@ function attachRequestLogger(
   const authContext = getRequestAuthLogContext(req.auth);
   let rpcMethod: string | undefined;
   let toolName: string | undefined;
+  let body: unknown;
 
   res.on("finish", () => {
-    requestLogger({
+    const entry: RequestLogEntry = {
       timestamp: new Date().toISOString(),
       method: req.method,
       path: req.path,
@@ -450,13 +487,21 @@ function attachRequestLogger(
       sessionId,
       status: res.statusCode,
       durationMs: Date.now() - startTime,
-    });
+    };
+    if (res.statusCode >= 400 && req.path === "/mcp") {
+      entry.diagnostics = {
+        headers: redactHeaders(req.headers),
+        bodySnippet: buildBodySnippet(body),
+      };
+    }
+    requestLogger(entry);
   });
 
   return {
-    setBody(body: unknown) {
-      rpcMethod = extractMethod(body);
-      toolName = extractToolName(body);
+    setBody(nextBody: unknown) {
+      body = nextBody;
+      rpcMethod = extractMethod(nextBody);
+      toolName = extractToolName(nextBody);
     },
   };
 }

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -212,6 +212,51 @@ describe("stateless HTTP transport", () => {
       }),
     ]);
   });
+
+  it("attaches diagnostics (redacted headers + body snippet) to 4xx /mcp logs", async () => {
+    const response = await supertest(app)
+      .post("/mcp")
+      .set({
+        Authorization: `Bearer ${LEGACY_API_KEY}`,
+        Host: "127.0.0.1:3030",
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "mcp-protocol-version": "2099-01-01",
+        Cookie: "session=supersecret",
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "memory_list", arguments: {} },
+      });
+
+    expect(response.status).toBe(400);
+
+    const entry = requestLogs.at(-1);
+    expect(entry?.status).toBe(400);
+    expect(entry?.path).toBe("/mcp");
+    expect(entry?.diagnostics).toBeDefined();
+    expect(entry?.diagnostics?.headers.authorization).toBe("[REDACTED]");
+    expect(entry?.diagnostics?.headers.cookie).toBe("[REDACTED]");
+    expect(entry?.diagnostics?.headers["mcp-protocol-version"]).toBe("2099-01-01");
+    expect(entry?.diagnostics?.bodySnippet).toContain("tools/call");
+  });
+
+  it("omits diagnostics on 2xx /mcp logs", async () => {
+    await supertest(app)
+      .post("/mcp")
+      .set(jsonRpcHeaders())
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "memory_list", arguments: {} },
+      })
+      .expect(200);
+
+    expect(requestLogs.at(-1)?.diagnostics).toBeUndefined();
+  });
 });
 
 describe("request log attribution", () => {


### PR DESCRIPTION
## Summary
- Capture redacted headers + body snippet in the request log whenever an HTTP MCP request returns 4xx, so we can post a concrete reproduction to upstream when client-side quirks (like #32) recur.
- Sensitive headers (`authorization`, `cookie`, `proxy-authorization`, `cf-access-client-secret`, `x-api-key`) are replaced with `[REDACTED]`. Body capped at 500 chars.
- Zero overhead on 2xx; diagnostics field is optional and absent from happy-path entries.

## Why not just fix #32?
Tried to reproduce the described symptom — bare `tools/call` with no `initialize` and no `mcp-session-id` header returns 200 against current code. The stateless HTTP transport (landed in `f3000fe`, a month before #32 was filed) already handles this case. The real 4xx error Desktop is hitting is most likely one of:
- Accept header missing `text/event-stream` → 406
- Content-Type not `application/json` → 415
- `mcp-protocol-version` header with an unsupported version → 400

Rather than patching blindly, this PR lands the minimum instrumentation to confirm which one on a live capture.

## Changes
- `src/index.ts`: extend `RequestLogEntry` with `diagnostics`; `attachRequestLogger` fills it in on `res.finish` when `status >= 400 && path === "/mcp"`.
- `tests/http-transport.test.ts`: 2 new tests — diagnostics present (with redaction) on 400, absent on 200.
- `CHANGELOG.md`: Unreleased entry.

## Test plan
- [x] `npm test` — 1049 tests pass, 3 skipped (benchmark)
- [x] `npm run build` clean
- [ ] Deploy to Pi, trigger a Desktop chat-mode failure, inspect the log entry to confirm which 4xx and which headers are at fault

Refs #32

---
Generated with [Claude Code](https://claude.com/claude-code)