### PR TITLE
Accent-insensitive FTS5 tokenizer (v15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Changed
+
+- **Accent-insensitive lexical search** — migration v15 recreates the
+  `entries_fts` virtual table with `tokenize='unicode61 remove_diacritics 2'`
+  and rebuilds the index. Queries for `Mimir` now match content containing
+  `Mímir` (and vice versa), removing one of the two token-mismatch failure
+  modes observed in the 2026-04-20 retrieval pilot v3c T10 case. Porter
+  stemming stays deferred pending a separate evaluation against the Swedish
+  portion of the corpus (#40).
+
 ### Added
 
 - **4xx diagnostic logging on `/mcp`** — when an HTTP MCP request returns a

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -626,6 +626,47 @@ export const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 15,
+    description: "Recreate entries_fts with unicode61 remove_diacritics=2 for accent-insensitive lexical search",
+    up: (db) => {
+      db.exec(`
+        DROP TRIGGER IF EXISTS entries_ai;
+        DROP TRIGGER IF EXISTS entries_ad;
+        DROP TRIGGER IF EXISTS entries_au;
+        DROP TABLE IF EXISTS entries_fts;
+
+        CREATE VIRTUAL TABLE entries_fts USING fts5(
+          content,
+          namespace,
+          key,
+          tags,
+          content='entries',
+          content_rowid='rowid',
+          tokenize='unicode61 remove_diacritics 2'
+        );
+
+        CREATE TRIGGER entries_ai AFTER INSERT ON entries BEGIN
+          INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+          VALUES (new.rowid, new.content, new.namespace, new.key, new.tags);
+        END;
+
+        CREATE TRIGGER entries_ad AFTER DELETE ON entries BEGIN
+          INSERT INTO entries_fts(entries_fts, rowid, content, namespace, key, tags)
+          VALUES('delete', old.rowid, old.content, old.namespace, old.key, old.tags);
+        END;
+
+        CREATE TRIGGER entries_au AFTER UPDATE ON entries BEGIN
+          INSERT INTO entries_fts(entries_fts, rowid, content, namespace, key, tags)
+          VALUES('delete', old.rowid, old.content, old.namespace, old.key, old.tags);
+          INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+          VALUES (new.rowid, new.content, new.namespace, new.key, new.tags);
+        END;
+
+        INSERT INTO entries_fts(entries_fts) VALUES('rebuild');
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -305,6 +305,21 @@ describe("queryEntries (FTS5)", () => {
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].content).toContain("full-text search");
   });
+
+  it("matches accented tokens against unaccented queries and vice versa (#40)", () => {
+    writeState(db, "decisions/jarvis-architecture", "overview", "Mímir is the wise councillor in Norse mythology.", ["decision"]);
+    writeState(db, "decisions/jarvis-architecture", "plain", "Mimir appears in many sagas.", ["decision"]);
+
+    const accentedHits = queryEntries(db, { query: "Mimir" });
+    const accentedContents = accentedHits.map((r) => r.content);
+    expect(accentedContents.some((c) => c.includes("Mímir"))).toBe(true);
+    expect(accentedContents.some((c) => c.includes("Mimir"))).toBe(true);
+
+    const plainHits = queryEntries(db, { query: "Mímir" });
+    const plainContents = plainHits.map((r) => r.content);
+    expect(plainContents.some((c) => c.includes("Mímir"))).toBe(true);
+    expect(plainContents.some((c) => c.includes("Mimir"))).toBe(true);
+  });
 });
 
 describe("listNamespaces", () => {


### PR DESCRIPTION
## Summary

Migration v15 recreates `entries_fts` with `tokenize='unicode61 remove_diacritics 2'` and rebuilds the index. Queries for `Mimir` now match content containing `Mímir` (and vice versa), closing one of the two token-mismatch failure modes identified in the 2026-04-20 retrieval pilot v3c T10 case.

Porter stemming stays deferred pending a separate evaluation against the Swedish portion of the corpus — English-specific stemming would risk mangling Swedish words.

## Changes

- New migration v15: drops the three FTS triggers + `entries_fts`, recreates with the diacritic-folding tokenizer, recreates triggers, rebuilds the index.
- `tests/db.test.ts`: new test asserting `Mimir` ↔ `Mímir` bidirectional equivalence through `queryEntries`.
- CHANGELOG entry.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1050 passed, 3 skipped (all pre-existing)
- [ ] Pre-deploy on Pi: new migration runs cleanly against current production DB
- [ ] Post-deploy verify: run the T10 query against live Munin, confirm target `1b4c8471-f70d-4758-8453-1b0731ae4729` appears in top-20

Refs #40