### PR TITLE
feat: munin-admin bearer token rotation (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ changelog is the canonical record of what moved.
 
 ### Added
 
+- **`munin-admin bearer rotate/revoke/list`** — DB-managed bearer token rotation with configurable grace window. DB tokens are checked alongside env-var tokens in `verifyAccessToken`, allowing zero-downtime rotation. Migration v16 adds the `bearer_tokens` table. (#35)
+
 - **4xx diagnostic logging on `/mcp`** — when an HTTP MCP request returns a
   4xx status, the request log entry now carries a `diagnostics` field with
   redacted request headers and a 500-char body snippet. Sensitive headers

--- a/src/admin-cli.ts
+++ b/src/admin-cli.ts
@@ -591,14 +591,17 @@ export function rotateBearerToken(
   const now = nowUTC();
   const expiresAt = new Date(Date.now() + graceHours * 3600 * 1000).toISOString();
 
-  // Find current active DB token for this scope
+  // Find truly active DB token for this scope (expires_at IS NULL).
+  // Tokens that are already retiring (expires_at set but in the future)
+  // must NOT be re-extended — that would resurrect a previously retired
+  // credential after rotate -> revoke(active) -> rotate.
   const existing = db
     .prepare(
       `SELECT id FROM bearer_tokens
-       WHERE scope = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)
+       WHERE scope = ? AND revoked_at IS NULL AND expires_at IS NULL
        ORDER BY created_at DESC LIMIT 1`,
     )
-    .get(scope, now) as { id: string } | undefined;
+    .get(scope) as { id: string } | undefined;
 
   const token = randomBytes(32).toString("hex");
   const newId = randomUUID();
@@ -896,8 +899,8 @@ Usage:
   munin-admin oauth-clients list [--principal <principal-id>]
   munin-admin oauth-clients remove <oauth-client-id>
   munin-admin oauth-clients clear <principal-id>
-  munin-admin bearer list [--scope=owner|dpa|consumer]
-  munin-admin bearer rotate [--scope=owner|dpa|consumer] [--grace-hours=<n>]
+  munin-admin bearer list [--scope <owner|dpa|consumer>]
+  munin-admin bearer rotate [--scope <owner|dpa|consumer>] [--grace-hours <n>]
   munin-admin bearer revoke <key-id>
 
 Global flags:

--- a/src/admin-cli.ts
+++ b/src/admin-cli.ts
@@ -122,6 +122,25 @@ export interface RotateTokenResult {
   token: string;
 }
 
+export type BearerScope = "owner" | "dpa" | "consumer";
+
+export interface BearerTokenSummary {
+  id: string;
+  scope: BearerScope;
+  status: "active" | "retiring" | "expired" | "revoked";
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface RotateBearerResult {
+  id: string;
+  token: string;
+  scope: BearerScope;
+  retiringKeyId: string | null;
+  retiringExpiresAt: string | null;
+}
+
 export interface ClassificationFloorSummary {
   namespacePattern: string;
   minClassification: ClassificationLevel;
@@ -564,6 +583,113 @@ export function auditClassification(
   }));
 }
 
+export function rotateBearerToken(
+  db: Database.Database,
+  scope: BearerScope,
+  graceHours: number,
+): RotateBearerResult {
+  const now = nowUTC();
+  const expiresAt = new Date(Date.now() + graceHours * 3600 * 1000).toISOString();
+
+  // Find current active DB token for this scope
+  const existing = db
+    .prepare(
+      `SELECT id FROM bearer_tokens
+       WHERE scope = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)
+       ORDER BY created_at DESC LIMIT 1`,
+    )
+    .get(scope, now) as { id: string } | undefined;
+
+  const token = randomBytes(32).toString("hex");
+  const newId = randomUUID();
+
+  const run = db.transaction(() => {
+    if (existing) {
+      db.prepare("UPDATE bearer_tokens SET expires_at = ? WHERE id = ?").run(
+        expiresAt,
+        existing.id,
+      );
+    }
+    db.prepare(
+      "INSERT INTO bearer_tokens (id, token_hash, scope, created_at) VALUES (?, ?, ?, ?)",
+    ).run(newId, hashToken(token), scope, now);
+    auditLog(
+      db,
+      "bearer_rotate",
+      scope,
+      JSON.stringify({ newKeyId: newId, retiringKeyId: existing?.id ?? null, graceHours }),
+    );
+  });
+  run();
+
+  return {
+    id: newId,
+    token,
+    scope,
+    retiringKeyId: existing?.id ?? null,
+    retiringExpiresAt: existing ? expiresAt : null,
+  };
+}
+
+export function revokeBearerToken(
+  db: Database.Database,
+  keyId: string,
+): boolean {
+  const row = db
+    .prepare("SELECT id, scope FROM bearer_tokens WHERE id = ? AND revoked_at IS NULL")
+    .get(keyId) as { id: string; scope: string } | undefined;
+  if (!row) return false;
+
+  const run = db.transaction(() => {
+    db.prepare("UPDATE bearer_tokens SET revoked_at = ? WHERE id = ?").run(nowUTC(), keyId);
+    auditLog(db, "bearer_revoke", row.scope, JSON.stringify({ keyId }));
+  });
+  run();
+  return true;
+}
+
+export function listBearerTokens(
+  db: Database.Database,
+  scope?: BearerScope,
+): BearerTokenSummary[] {
+  const now = nowUTC();
+  const rows = (
+    scope
+      ? db
+          .prepare(
+            "SELECT id, scope, created_at, expires_at, revoked_at FROM bearer_tokens WHERE scope = ? ORDER BY created_at DESC",
+          )
+          .all(scope)
+      : db
+          .prepare(
+            "SELECT id, scope, created_at, expires_at, revoked_at FROM bearer_tokens ORDER BY created_at DESC",
+          )
+          .all()
+  ) as Array<{
+    id: string;
+    scope: string;
+    created_at: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+  }>;
+
+  return rows.map((r) => ({
+    id: r.id,
+    scope: r.scope as BearerScope,
+    status:
+      r.revoked_at !== null
+        ? "revoked"
+        : r.expires_at !== null && r.expires_at <= now
+          ? "expired"
+          : r.expires_at !== null
+            ? "retiring"
+            : "active",
+    createdAt: r.created_at,
+    expiresAt: r.expires_at,
+    revokedAt: r.revoked_at,
+  }));
+}
+
 // ---------------------------------------------------------------------------
 // CLI output formatting
 // ---------------------------------------------------------------------------
@@ -704,6 +830,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     "--email",
     "--expires-at",
     "--principal",
+    "--scope",
+    "--grace-hours",
   ]);
 
   for (let i = 0; i < args.length; i++) {
@@ -768,6 +896,9 @@ Usage:
   munin-admin oauth-clients list [--principal <principal-id>]
   munin-admin oauth-clients remove <oauth-client-id>
   munin-admin oauth-clients clear <principal-id>
+  munin-admin bearer list [--scope=owner|dpa|consumer]
+  munin-admin bearer rotate [--scope=owner|dpa|consumer] [--grace-hours=<n>]
+  munin-admin bearer revoke <key-id>
 
 Global flags:
   --db <path>     Database path (default: ~/.munin-memory/memory.db)
@@ -1191,6 +1322,87 @@ function handleClassificationAudit(
   console.log(formatClassificationAudit(items));
 }
 
+function handleBearerList(
+  db: Database.Database,
+  flags: Map<string, string>,
+  json: boolean,
+): void {
+  const scope = flags.get("--scope") as BearerScope | undefined;
+  const tokens = listBearerTokens(db, scope);
+  if (json) {
+    console.log(JSON.stringify(tokens, null, 2));
+    return;
+  }
+  if (tokens.length === 0) {
+    console.log("No DB-managed bearer tokens found.");
+    return;
+  }
+  for (const t of tokens) {
+    const expiry = t.expiresAt ? ` expires=${t.expiresAt}` : "";
+    const revoked = t.revokedAt ? ` revoked=${t.revokedAt}` : "";
+    console.log(`${t.id}  scope=${t.scope}  status=${t.status}  created=${t.createdAt}${expiry}${revoked}`);
+  }
+}
+
+function handleBearerRotate(
+  db: Database.Database,
+  flags: Map<string, string>,
+  json: boolean,
+): void {
+  const scope = (flags.get("--scope") ?? "owner") as BearerScope;
+  if (!["owner", "dpa", "consumer"].includes(scope)) {
+    throw new Error(`Invalid scope "${scope}". Must be: owner, dpa, consumer`);
+  }
+  const graceHoursStr = flags.get("--grace-hours");
+  const graceHours = graceHoursStr !== undefined ? parseInt(graceHoursStr, 10) : 24;
+  if (isNaN(graceHours) || graceHours < 0) {
+    throw new Error("--grace-hours must be a non-negative integer");
+  }
+
+  const result = rotateBearerToken(db, scope, graceHours);
+
+  if (json) {
+    console.log(
+      JSON.stringify({
+        id: result.id,
+        token: result.token,
+        scope: result.scope,
+        retiringKeyId: result.retiringKeyId,
+        retiringExpiresAt: result.retiringExpiresAt,
+      }),
+    );
+    return;
+  }
+
+  console.log(`New bearer token (scope=${result.scope}):`);
+  console.log(`  ID:    ${result.id}`);
+  console.log(`  Token: ${result.token}`);
+  console.log("");
+  console.log("Store this token in your credentials file or MCP client config.");
+  console.log("It will NOT be shown again.");
+  if (result.retiringKeyId) {
+    console.log("");
+    console.log(`Previous token (${result.retiringKeyId}) is now retiring.`);
+    console.log(`It will stop working after: ${result.retiringExpiresAt}`);
+  }
+}
+
+function handleBearerRevoke(
+  db: Database.Database,
+  keyId: string,
+  json: boolean,
+): void {
+  const ok = revokeBearerToken(db, keyId);
+  if (json) {
+    console.log(JSON.stringify({ revoked: ok, keyId }));
+    return;
+  }
+  if (!ok) {
+    throw new Error(`Bearer token not found or already revoked: ${keyId}`);
+  }
+  console.log(`Revoked: ${keyId}`);
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1214,11 +1426,12 @@ function main(): void {
     parsed.resource !== "principals"
     && parsed.resource !== "oauth-clients"
     && parsed.resource !== "classification"
+    && parsed.resource !== "bearer"
   ) {
     if (!parsed.resource) {
-      console.error("Missing resource. Expected: munin-admin principals|classification|oauth-clients <command>");
+      console.error("Missing resource. Expected: munin-admin principals|classification|oauth-clients|bearer <command>");
     } else {
-      console.error(`Unknown resource: ${parsed.resource}. Expected: principals, classification, or oauth-clients`);
+      console.error(`Unknown resource: ${parsed.resource}. Expected: principals, classification, oauth-clients, or bearer`);
     }
     console.error("\nRun 'munin-admin --help' for usage.");
     process.exit(1);
@@ -1229,7 +1442,9 @@ function main(): void {
       ? "list, remove, clear"
       : parsed.resource === "classification"
         ? "list-floors, set-floor, audit"
-        : "list, show, add, revoke, update, rotate-token, test";
+        : parsed.resource === "bearer"
+          ? "list, rotate, revoke"
+          : "list, show, add, revoke, update, rotate-token, test";
     console.error(`Missing command. Expected: ${cmds}`);
     console.error("\nRun 'munin-admin --help' for usage.");
     process.exit(1);
@@ -1262,6 +1477,28 @@ function main(): void {
           break;
         default:
           console.error(`Unknown oauth-clients command: ${parsed.command}`);
+          console.error("\nRun 'munin-admin --help' for usage.");
+          process.exit(1);
+      }
+      return;
+    }
+
+    if (parsed.resource === "bearer") {
+      switch (parsed.command) {
+        case "list":
+          handleBearerList(db, parsed.flags, parsed.json);
+          break;
+        case "rotate":
+          handleBearerRotate(db, parsed.flags, parsed.json);
+          break;
+        case "revoke": {
+          const keyId = parsed.positionals[0];
+          if (!keyId) throw new Error("Missing <key-id> argument.");
+          handleBearerRevoke(db, keyId, parsed.json);
+          break;
+        }
+        default:
+          console.error(`Unknown bearer command: ${parsed.command}`);
           console.error("\nRun 'munin-admin --help' for usage.");
           process.exit(1);
       }

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -667,6 +667,23 @@ export const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 16,
+    description: "bearer_tokens table for DB-managed bearer token rotation",
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE bearer_tokens (
+          id TEXT PRIMARY KEY,
+          token_hash TEXT NOT NULL UNIQUE,
+          scope TEXT NOT NULL CHECK(scope IN ('owner', 'dpa', 'consumer')),
+          created_at TEXT NOT NULL,
+          expires_at TEXT,
+          revoked_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS bearer_tokens_scope ON bearer_tokens(scope);
+      `);
+    },
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -539,6 +539,34 @@ export class MuninOAuthProvider implements OAuthServerProvider {
       } as ExtendedAuthInfo;
     }
 
+    // Check DB-managed bearer tokens
+    const bearerHash = createHash("sha256").update(token).digest("hex");
+    const dbBearerRow = this.db
+      .prepare(
+        `SELECT id, scope FROM bearer_tokens
+         WHERE token_hash = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)`,
+      )
+      .get(bearerHash, new Date().toISOString()) as { id: string; scope: string } | undefined;
+
+    if (dbBearerRow) {
+      const scopeClientId =
+        dbBearerRow.scope === "owner" ? "legacy-bearer"
+        : dbBearerRow.scope === "dpa" ? "bearer-dpa"
+        : "bearer-consumer";
+      const transportHint: TransportType | undefined =
+        dbBearerRow.scope === "dpa" ? "dpa_covered"
+        : dbBearerRow.scope === "consumer" ? "consumer"
+        : undefined;
+      return {
+        token,
+        clientId: scopeClientId,
+        scopes: [],
+        expiresAt: farFuture,
+        authMethod: "bearer",
+        ...(transportHint ? { transportTypeHint: transportHint } : {}),
+      } as ExtendedAuthInfo;
+    }
+
     // Check agent service tokens (principals.token_hash)
     const serviceTokenHash = createHash("sha256").update(token).digest("hex");
     const principalRow = this.db

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -557,12 +557,17 @@ export class MuninOAuthProvider implements OAuthServerProvider {
         dbBearerRow.scope === "dpa" ? "dpa_covered"
         : dbBearerRow.scope === "consumer" ? "consumer"
         : undefined;
+      // Owner-scope DB tokens use authMethod="legacy_bearer" so
+      // normalizeTransportType() picks up the configured legacy bearer
+      // transport (e.g. dpa_covered), matching the env-var owner path.
+      const authMethodForScope: AuthMethod =
+        dbBearerRow.scope === "owner" ? "legacy_bearer" : "bearer";
       return {
         token,
         clientId: scopeClientId,
         scopes: [],
         expiresAt: farFuture,
-        authMethod: "bearer",
+        authMethod: authMethodForScope,
         ...(transportHint ? { transportTypeHint: transportHint } : {}),
       } as ExtendedAuthInfo;
     }

--- a/tests/admin-cli.test.ts
+++ b/tests/admin-cli.test.ts
@@ -773,6 +773,28 @@ describe("bearer token rotation", () => {
     expect(dpaTokens[0].status).toBe("active");
     expect(dpaTokens[0].id).toBe(dpaFirst.id);
   });
+
+  it("rotate after revoking the active token does not extend retiring tokens", () => {
+    // Codex regression: rotate -> rotate -> revoke(active) -> rotate
+    // must NOT pick up the still-retiring first token and re-extend its expiry.
+    const first = rotateBearerToken(db, "owner", 24);
+    const second = rotateBearerToken(db, "owner", 24);
+
+    // first is now retiring; second is active
+    revokeBearerToken(db, second.id);
+    // Now there is no active token. The next rotate should retire NOTHING
+    // (since `first` is already retiring) and just mint a new active token.
+    const third = rotateBearerToken(db, "owner", 24);
+
+    expect(third.retiringKeyId).toBeNull();
+    expect(third.retiringExpiresAt).toBeNull();
+
+    // Verify first token's expiry was NOT changed by the third rotation.
+    const tokens = listBearerTokens(db, "owner");
+    const firstAfter = tokens.find((t) => t.id === first.id)!;
+    // Its expires_at should still equal the value set by `second`'s rotation.
+    expect(firstAfter.expiresAt).toBe(second.retiringExpiresAt);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/admin-cli.test.ts
+++ b/tests/admin-cli.test.ts
@@ -16,11 +16,16 @@ import {
   listClassificationFloors,
   setClassificationFloor,
   auditClassification,
+  rotateBearerToken,
+  revokeBearerToken,
+  listBearerTokens,
   parseRules,
   parseClassification,
   parseExpiresAt,
   parseArgs,
   type AddPrincipalOpts,
+  type BearerScope,
+  type BearerTokenSummary,
 } from "../src/admin-cli.js";
 import { writeState } from "../src/db.js";
 
@@ -665,6 +670,108 @@ describe("parseArgs", () => {
     expect(parsed.resource).toBe("classification");
     expect(parsed.command).toBe("set-floor");
     expect(parsed.positionals).toEqual(["contracts/*", "client-restricted"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bearer token rotation
+// ---------------------------------------------------------------------------
+
+describe("bearer token rotation", () => {
+  let db: Database.Database;
+  beforeEach(() => { db = makeDb(); });
+
+  it("rotate creates an active token with no retiring token on first rotation", () => {
+    const result = rotateBearerToken(db, "owner", 24);
+    expect(result.token).toHaveLength(64);
+    expect(result.scope).toBe("owner");
+    expect(result.retiringKeyId).toBeNull();
+    expect(result.retiringExpiresAt).toBeNull();
+
+    const tokens = listBearerTokens(db);
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].status).toBe("active");
+    expect(tokens[0].id).toBe(result.id);
+  });
+
+  it("rotate puts previous DB token into retiring status", () => {
+    const first = rotateBearerToken(db, "owner", 24);
+    const second = rotateBearerToken(db, "owner", 24);
+
+    expect(second.retiringKeyId).toBe(first.id);
+    expect(second.retiringExpiresAt).not.toBeNull();
+
+    const tokens = listBearerTokens(db, "owner");
+    const firstToken = tokens.find((t) => t.id === first.id)!;
+    const secondToken = tokens.find((t) => t.id === second.id)!;
+    expect(firstToken.status).toBe("retiring");
+    expect(secondToken.status).toBe("active");
+  });
+
+  it("retiring token expires after grace window", () => {
+    const first = rotateBearerToken(db, "owner", 24); // create initial token
+    // Rotate again with 0 hours grace — first token retires immediately
+    rotateBearerToken(db, "owner", 0);
+    // The first token should now have expires_at set to (approx) now
+    const tokens = listBearerTokens(db, "owner");
+    const firstToken = tokens.find((t) => t.id === first.id);
+    // With 0 hours grace, expires_at = now, which may be <= now
+    // It's either retiring (expires_at just set to now) or expired
+    expect(firstToken?.status === "retiring" || firstToken?.status === "expired").toBe(true);
+  });
+
+  it("revoke sets revoked_at immediately", () => {
+    const result = rotateBearerToken(db, "owner", 24);
+    const ok = revokeBearerToken(db, result.id);
+    expect(ok).toBe(true);
+
+    const tokens = listBearerTokens(db, "owner");
+    expect(tokens[0].status).toBe("revoked");
+    expect(tokens[0].revokedAt).not.toBeNull();
+  });
+
+  it("revoke returns false for nonexistent key", () => {
+    expect(revokeBearerToken(db, "nonexistent-id")).toBe(false);
+  });
+
+  it("list filters by scope", () => {
+    rotateBearerToken(db, "owner", 24);
+    rotateBearerToken(db, "dpa", 24);
+    rotateBearerToken(db, "consumer", 24);
+
+    expect(listBearerTokens(db, "owner")).toHaveLength(1);
+    expect(listBearerTokens(db, "dpa")).toHaveLength(1);
+    expect(listBearerTokens(db)).toHaveLength(3);
+  });
+
+  it("rotate writes audit log entry", () => {
+    rotateBearerToken(db, "owner", 24);
+    const rows = db
+      .prepare("SELECT action, key FROM audit_log WHERE action = 'bearer_rotate'")
+      .all() as { action: string; key: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe("owner");
+  });
+
+  it("revoke writes audit log entry", () => {
+    const result = rotateBearerToken(db, "owner", 24);
+    revokeBearerToken(db, result.id);
+    const rows = db
+      .prepare("SELECT action FROM audit_log WHERE action = 'bearer_revoke'")
+      .all() as { action: string }[];
+    expect(rows).toHaveLength(1);
+  });
+
+  it("different scopes are independent", () => {
+    const ownerFirst = rotateBearerToken(db, "owner", 24);
+    const dpaFirst = rotateBearerToken(db, "dpa", 24);
+    const ownerSecond = rotateBearerToken(db, "owner", 24);
+
+    // owner second rotation should not touch dpa token
+    expect(ownerSecond.retiringKeyId).toBe(ownerFirst.id);
+    const dpaTokens = listBearerTokens(db, "dpa");
+    expect(dpaTokens[0].status).toBe("active");
+    expect(dpaTokens[0].id).toBe(dpaFirst.id);
   });
 });
 

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -397,6 +397,48 @@ describe("Token verification", () => {
     await expect(provider.verifyAccessToken(wrongKey)).rejects.toThrow();
   });
 
+  it("DB-managed owner bearer uses authMethod=legacy_bearer", async () => {
+    // Codex regression: DB-managed owner-scope tokens must use authMethod="legacy_bearer"
+    // so normalizeTransportType() picks up the configured legacy bearer transport
+    // (e.g. dpa_covered). Otherwise rotated owner tokens silently degrade to consumer.
+    const { createHash, randomBytes, randomUUID } = await import("node:crypto");
+    const ownerToken = randomBytes(32).toString("hex");
+    const ownerHash = createHash("sha256").update(ownerToken).digest("hex");
+    db.prepare(
+      "INSERT INTO bearer_tokens (id, token_hash, scope, created_at) VALUES (?, ?, ?, ?)",
+    ).run(randomUUID(), ownerHash, "owner", new Date().toISOString());
+
+    const info = (await provider.verifyAccessToken(ownerToken)) as ExtendedAuthInfo;
+    expect(info.clientId).toBe("legacy-bearer");
+    expect(info.authMethod).toBe("legacy_bearer");
+  });
+
+  it("DB-managed dpa/consumer bearers use authMethod=bearer with transport hint", async () => {
+    const { createHash, randomBytes, randomUUID } = await import("node:crypto");
+    const dpaToken = randomBytes(32).toString("hex");
+    const dpaHash = createHash("sha256").update(dpaToken).digest("hex");
+    db.prepare(
+      "INSERT INTO bearer_tokens (id, token_hash, scope, created_at) VALUES (?, ?, ?, ?)",
+    ).run(randomUUID(), dpaHash, "dpa", new Date().toISOString());
+
+    const info = (await provider.verifyAccessToken(dpaToken)) as ExtendedAuthInfo;
+    expect(info.clientId).toBe("bearer-dpa");
+    expect(info.authMethod).toBe("bearer");
+    expect(info.transportTypeHint).toBe("dpa_covered");
+  });
+
+  it("DB-managed bearer with expires_at in the past is rejected", async () => {
+    const { createHash, randomBytes, randomUUID } = await import("node:crypto");
+    const expiredToken = randomBytes(32).toString("hex");
+    const expiredHash = createHash("sha256").update(expiredToken).digest("hex");
+    const past = new Date(Date.now() - 1000).toISOString();
+    db.prepare(
+      "INSERT INTO bearer_tokens (id, token_hash, scope, created_at, expires_at) VALUES (?, ?, ?, ?, ?)",
+    ).run(randomUUID(), expiredHash, "owner", new Date().toISOString(), past);
+
+    await expect(provider.verifyAccessToken(expiredToken)).rejects.toThrow();
+  });
+
   it("verifies OAuth access token", async () => {
     const res = createMockResponse();
     provider.completeAuthorization(


### PR DESCRIPTION
## Summary

- Adds a `bearer_tokens` DB table (migration v16) so owner can rotate `MUNIN_API_KEY` without restarting the service or manually editing four places
- New `munin-admin bearer rotate/revoke/list` subcommand family — mints a new token, puts the previous DB token into a configurable grace window, and logs everything to `audit_log`
- `verifyAccessToken` checks DB-managed tokens alongside env-var tokens; env vars remain a permanent bootstrap fallback so existing deployments need no changes

## Changes

- **Migration v16** — `bearer_tokens(id, token_hash, scope, created_at, expires_at, revoked_at)` with scope index
- **`src/oauth.ts`** — DB bearer token lookup inserted after env-var checks; maps `scope → clientId + transportTypeHint` using existing conventions
- **`src/admin-cli.ts`** — `rotateBearerToken`, `revokeBearerToken`, `listBearerTokens` (exported), `bearer` dispatch block, `--scope` / `--grace-hours` flags in `parseArgs`, updated USAGE
- **`tests/admin-cli.test.ts`** — 9 new test cases: first rotation, second rotation (retiring), grace expiry, revoke, double-revoke, scope filtering, audit log, scope independence

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1059 passed, 3 skipped
- [ ] Deploy to Pi and run `npx munin-admin bearer rotate` — confirm new token authenticates and old env-var token still works
- [ ] Confirm `bearer list` shows retiring token with correct expiry

Closes #35

---
Generated with [Claude Code](https://claude.com/claude-code)