### PR TITLE
fix: preserve non-canonical status sections (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memory_update_status` no longer drops non-canonical sections.** Previously
+  the parse → merge → format cycle only recognized the five canonical sections
+  (`Phase`, `Current Work`, `Blockers`, `Next Steps`, `Notes`); anything else
+  (`Vision`, `Roadmap`, `Milestones`, custom sections) was silently discarded
+  on the next call — even a no-op `lifecycle` flip would wipe them. Now
+  `parseStructuredStatus` collects unknown `## Heading` sections into an
+  `extras` array, `buildStructuredStatus` carries them across patches, and
+  `formatStructuredStatus` re-emits them after the canonical block. Heimdall
+  and other downstream readers that depend on `## Vision` / `## Milestones`
+  no longer need the `memory_write patch` workaround. (#44)
+
 ### Changed
 
 - **Accent-insensitive lexical search** — migration v15 recreates the

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -617,12 +617,21 @@ function preflightWriteClassification(
   return null;
 }
 
+interface StatusExtraSection {
+  title: string;
+  body: string;
+}
+
 interface StructuredStatus {
   phase?: string;
   current_work?: string;
   blockers?: string;
   next_steps?: string[];
   notes?: string;
+  // Non-canonical sections (e.g. "Vision", "Roadmap", "Milestones") preserved
+  // verbatim through parse → merge → format so memory_update_status doesn't
+  // drop them when callers patch only canonical fields.
+  extras?: StatusExtraSection[];
 }
 
 const STATUS_SECTION_ORDER = [
@@ -708,18 +717,23 @@ function assignStructuredStatusValue(
 function parseStructuredStatus(content: string): StructuredStatus {
   const structured: StructuredStatus = {};
   const lines = content.split("\n");
+  const extras: StatusExtraSection[] = [];
 
   const headingMatches = [...content.matchAll(/^##\s+(.+)$/gm)];
   if (headingMatches.length > 0) {
     for (let i = 0; i < headingMatches.length; i++) {
       const match = headingMatches[i];
-      const label = normalizeStatusLabel(match[1]);
-      if (!label) continue;
+      const rawTitle = match[1].trim();
+      const label = normalizeStatusLabel(rawTitle);
       const sectionStart = match.index! + match[0].length;
       const sectionEnd = i + 1 < headingMatches.length ? headingMatches[i + 1].index! : content.length;
       const raw = content.slice(sectionStart, sectionEnd).trim();
-      const extracted = extractStatusSectionValue(label, raw);
-      if (extracted !== undefined) assignStructuredStatusValue(structured, label, extracted);
+      if (label) {
+        const extracted = extractStatusSectionValue(label, raw);
+        if (extracted !== undefined) assignStructuredStatusValue(structured, label, extracted);
+      } else if (raw.length > 0) {
+        extras.push({ title: rawTitle, body: raw });
+      }
     }
   }
 
@@ -732,6 +746,7 @@ function parseStructuredStatus(content: string): StructuredStatus {
     if (extracted !== undefined) assignStructuredStatusValue(structured, label, extracted);
   }
 
+  if (extras.length > 0) structured.extras = extras;
   return structured;
 }
 
@@ -747,18 +762,23 @@ function normalizeStatusList(value?: string[]): string[] | undefined {
   return items;
 }
 
-function buildStructuredStatus(update: StructuredStatus, existing?: StructuredStatus): Required<StructuredStatus> {
-  const merged: Required<StructuredStatus> = {
+type BuiltStructuredStatus = Required<Omit<StructuredStatus, "extras">> & {
+  extras: StatusExtraSection[];
+};
+
+function buildStructuredStatus(update: StructuredStatus, existing?: StructuredStatus): BuiltStructuredStatus {
+  const merged: BuiltStructuredStatus = {
     phase: normalizeStatusText(update.phase) ?? normalizeStatusText(existing?.phase) ?? "Unspecified.",
     current_work: normalizeStatusText(update.current_work) ?? normalizeStatusText(existing?.current_work) ?? "Unspecified.",
     blockers: normalizeStatusText(update.blockers) ?? normalizeStatusText(existing?.blockers) ?? "None.",
     next_steps: normalizeStatusList(update.next_steps) ?? normalizeStatusList(existing?.next_steps) ?? ["None."],
     notes: normalizeStatusText(update.notes) ?? normalizeStatusText(existing?.notes) ?? "",
+    extras: update.extras ?? existing?.extras ?? [],
   };
   return merged;
 }
 
-function formatStructuredStatus(status: Required<StructuredStatus>): string {
+function formatStructuredStatus(status: BuiltStructuredStatus): string {
   const sections: string[] = [];
   for (const key of STATUS_SECTION_ORDER) {
     const title = STATUS_SECTION_TITLES[key];
@@ -770,6 +790,11 @@ function formatStructuredStatus(status: Required<StructuredStatus>): string {
     } else {
       sections.push(value as string);
     }
+    sections.push("");
+  }
+  for (const extra of status.extras) {
+    sections.push(`## ${extra.title}`);
+    sections.push(extra.body);
     sections.push("");
   }
   return sections.join("\n").trim();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -464,6 +464,67 @@ describe("memory_update_status", () => {
     expect(entry.classification).toBe("client-confidential");
     expect(entry.tags).toContain("classification:client-confidential");
   });
+
+  it("preserves non-canonical sections (Vision, Roadmap, Milestones) across patches (#44)", async () => {
+    // Seed a status with a mix of canonical and non-canonical sections, written
+    // via memory_write so update_status sees them in the existing content.
+    await callTool("memory_write", {
+      namespace: "projects/heimdall",
+      key: "status",
+      content: [
+        "## Phase",
+        "Active",
+        "",
+        "## Vision",
+        "Render a personal dashboard from Munin tracked statuses.",
+        "",
+        "## Current Work",
+        "Wiring up retrieval health card.",
+        "",
+        "## Roadmap",
+        "- v1: dashboard",
+        "- v2: alerts",
+        "",
+        "## Milestones",
+        "Q3 demo to Magnus.",
+      ].join("\n"),
+      tags: ["active"],
+    });
+
+    // Patch only lifecycle — every non-canonical section must survive.
+    await callTool("memory_update_status", {
+      namespace: "projects/heimdall",
+      lifecycle: "archived",
+    });
+
+    const readRaw = await callTool("memory_read", {
+      namespace: "projects/heimdall",
+      key: "status",
+    });
+    const entry = parseToolResponse(readRaw) as { content: string };
+
+    expect(entry.content).toContain("## Vision");
+    expect(entry.content).toContain("Render a personal dashboard from Munin tracked statuses.");
+    expect(entry.content).toContain("## Roadmap");
+    expect(entry.content).toContain("- v1: dashboard");
+    expect(entry.content).toContain("## Milestones");
+    expect(entry.content).toContain("Q3 demo to Magnus.");
+
+    // Patch a canonical section — extras must still survive a second time.
+    await callTool("memory_update_status", {
+      namespace: "projects/heimdall",
+      blockers: "Waiting on PR review.",
+    });
+    const readRaw2 = await callTool("memory_read", {
+      namespace: "projects/heimdall",
+      key: "status",
+    });
+    const entry2 = parseToolResponse(readRaw2) as { content: string };
+    expect(entry2.content).toContain("## Vision");
+    expect(entry2.content).toContain("## Roadmap");
+    expect(entry2.content).toContain("## Milestones");
+    expect(entry2.content).toContain("Waiting on PR review.");
+  });
 });
 
 describe("memory_read", () => {


### PR DESCRIPTION
## Summary

- `memory_update_status` was silently discarding any `## Heading` section it didn't recognize as one of the five canonical keys (`Phase`, `Current Work`, `Blockers`, `Next Steps`, `Notes`). A single call to flip `lifecycle: "archived"` would wipe `## Vision`, `## Roadmap`, `## Milestones`, and any custom section.
- Heimdall depends on `## Vision` and `## Milestones` to render its dashboard, and had to bypass `update_status` entirely (raw `memory_write patch`) — documented as a "landmine" in `heimdall/docs/projects-authoring.md`.
- Approach A from the issue: pass-through preservation. `parseStructuredStatus` collects unknown sections into an `extras` array; `buildStructuredStatus` carries them across patches; `formatStructuredStatus` re-emits them after the canonical block.

## Changes

- **`src/tools.ts`**:
  - New `StatusExtraSection { title, body }` and optional `extras` field on `StructuredStatus`
  - `parseStructuredStatus`: any `##` heading whose label isn't recognized goes into `extras` verbatim with title and body preserved
  - `buildStructuredStatus`: returns a `BuiltStructuredStatus` (canonical fields required + `extras: StatusExtraSection[]`); update extras win over existing, fallback to existing
  - `formatStructuredStatus`: appends each extra as `## <title>\n<body>` after the canonical block
- **`tests/tools.test.ts`**: regression test seeds Vision / Roadmap / Milestones, patches lifecycle, then patches blockers, asserts every non-canonical section survives both patches
- **`CHANGELOG.md`**: Fixed entry under `[Unreleased]`

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1064 passed, 3 skipped (1 new test)

## Downstream cleanup (not in this PR)

Per the issue, once this lands:
- Drop the "PR-3 revive endpoint" item from Heimdall's roadmap
- Update `heimdall/docs/projects-authoring.md` to remove the landmine warning

Closes #44

---
Generated with [Claude Code](https://claude.com/claude-code)