### PR TITLE
fix: FTS5 matches camelCase/PascalCase identifiers (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ changelog is the canonical record of what moved.
   content with a case-split copy via the `munin_split_tokens` SQL UDF, and
   rebuilds the existing index. `WebFetch` is now findable via `web fetch`,
   `XMLParser` via `XML parser`, `parseXMLResponse` via `parse XML response`,
-  and so on. Original phrases still match unchanged (the augmented copy is
-  appended, not substituted). Known limitation: quoted phrases that span
-  identifier-internal punctuation like `"90/10"` are still tokenizer-split
-  by `unicode61` — query as separate tokens or rely on FTS5's near-match
-  ranking. (#42)
+  `OAuthToken` via `oauth token`, and `IPv6Address` via `IPv6 address`.
+  Original phrases still match unchanged (the augmented copy is appended,
+  not substituted). The maintenance helper `rebuildFTS()` was rewritten to
+  use `delete-all` + augmented re-population, since FTS5's built-in
+  `'rebuild'` command would silently strip the split-token augmentation by
+  reading from `entries` directly. Known limitation: quoted phrases that
+  span identifier-internal punctuation like `"90/10"` are still
+  tokenizer-split by `unicode61` — query as separate tokens or rely on
+  FTS5's near-match ranking. (#42)
 
 - **`memory_update_status` no longer drops non-canonical sections.** Previously
   the parse → merge → format cycle only recognized the five canonical sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **FTS5 now matches camelCase / PascalCase identifiers against separated-word
+  queries.** Migration v17 recreates the FTS triggers to augment indexed
+  content with a case-split copy via the `munin_split_tokens` SQL UDF, and
+  rebuilds the existing index. `WebFetch` is now findable via `web fetch`,
+  `XMLParser` via `XML parser`, `parseXMLResponse` via `parse XML response`,
+  and so on. Original phrases still match unchanged (the augmented copy is
+  appended, not substituted). Known limitation: quoted phrases that span
+  identifier-internal punctuation like `"90/10"` are still tokenizer-split
+  by `unicode61` — query as separate tokens or rely on FTS5's near-match
+  ranking. (#42)
+
 - **`memory_update_status` no longer drops non-canonical sections.** Previously
   the parse → merge → format cycle only recognized the five canonical sections
   (`Phase`, `Current Work`, `Blockers`, `Next Steps`, `Notes`); anything else

--- a/src/db.ts
+++ b/src/db.ts
@@ -124,9 +124,26 @@ function ensureVecSchema(db: Database.Database): void {
   }
 }
 
-// Rebuild FTS index — for maintenance (debate resolution #7)
+// Rebuild FTS index — for maintenance (debate resolution #7).
+// NB: a plain FTS5 'rebuild' on this external-content table reads from
+// `entries` directly and bypasses the entries_ai/au triggers, which means
+// the v17 split-token augmentation (munin_split_tokens) would be silently
+// dropped. We instead wipe the index with delete-all and repopulate via
+// the same augmented form the live triggers use.
 export function rebuildFTS(db: Database.Database): void {
-  db.exec("INSERT INTO entries_fts(entries_fts) VALUES('rebuild')");
+  db.transaction(() => {
+    db.prepare("INSERT INTO entries_fts(entries_fts) VALUES('delete-all')").run();
+    db.prepare(
+      `INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+         SELECT
+           rowid,
+           content || ' ' || munin_split_tokens(content),
+           namespace,
+           key,
+           tags
+         FROM entries`,
+    ).run();
+  })();
 }
 
 // --- Tracked status queries ---

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -684,9 +684,123 @@ export const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 17,
+    description:
+      "Augment FTS index with camelCase/PascalCase splits via munin_split_tokens UDF",
+    up: (db) => {
+      db.exec(`
+        DROP TRIGGER IF EXISTS entries_ai;
+        DROP TRIGGER IF EXISTS entries_ad;
+        DROP TRIGGER IF EXISTS entries_au;
+
+        CREATE TRIGGER entries_ai AFTER INSERT ON entries BEGIN
+          INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+          VALUES (
+            new.rowid,
+            new.content || ' ' || munin_split_tokens(new.content),
+            new.namespace,
+            new.key,
+            new.tags
+          );
+        END;
+
+        CREATE TRIGGER entries_ad AFTER DELETE ON entries BEGIN
+          INSERT INTO entries_fts(entries_fts, rowid, content, namespace, key, tags)
+          VALUES(
+            'delete',
+            old.rowid,
+            old.content || ' ' || munin_split_tokens(old.content),
+            old.namespace,
+            old.key,
+            old.tags
+          );
+        END;
+
+        CREATE TRIGGER entries_au AFTER UPDATE ON entries BEGIN
+          INSERT INTO entries_fts(entries_fts, rowid, content, namespace, key, tags)
+          VALUES(
+            'delete',
+            old.rowid,
+            old.content || ' ' || munin_split_tokens(old.content),
+            old.namespace,
+            old.key,
+            old.tags
+          );
+          INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+          VALUES (
+            new.rowid,
+            new.content || ' ' || munin_split_tokens(new.content),
+            new.namespace,
+            new.key,
+            new.tags
+          );
+        END;
+      `);
+
+      // Manual rebuild — the 'rebuild' command on a contentless-ish
+      // external-content FTS5 table re-reads from the entries table directly
+      // and does NOT invoke our triggers, so the augmented form would not be
+      // picked up. Instead we wipe the index and re-emit each row through
+      // the new trigger logic by deleting + re-inserting via the FTS
+      // contentless interface.
+      db.exec("INSERT INTO entries_fts(entries_fts) VALUES('delete-all');");
+
+      const rows = db
+        .prepare(
+          "SELECT rowid, content, namespace, key, tags FROM entries",
+        )
+        .all() as Array<{
+          rowid: number;
+          content: string;
+          namespace: string;
+          key: string | null;
+          tags: string;
+        }>;
+
+      const insert = db.prepare(
+        `INSERT INTO entries_fts(rowid, content, namespace, key, tags)
+         VALUES (?, ? || ' ' || munin_split_tokens(?), ?, ?, ?)`,
+      );
+      for (const row of rows) {
+        insert.run(row.rowid, row.content, row.content, row.namespace, row.key, row.tags);
+      }
+    },
+  },
 ];
 
+/**
+ * Split identifiers like `webFetch`, `WebFetch`, `XMLParser` on case
+ * transitions so FTS5 (which treats them as single tokens via unicode61)
+ * can also match the underlying word forms.
+ *
+ * Used by migration v17's FTS triggers as a SQL UDF to augment indexed
+ * content. Idempotent and deterministic. Returns the empty string for
+ * non-string inputs so the SQL trigger never throws on NULL/numeric content.
+ */
+export function splitCamelCaseTokens(text: unknown): string {
+  if (typeof text !== "string" || text.length === 0) return "";
+  // Use zero-width lookbehind/lookahead to avoid catastrophic backtracking
+  // on long runs of a single case (e.g. "AAAA…").
+  return text
+    .replace(/(?<=[\p{Ll}\p{Nd}])(?=\p{Lu})/gu, " ")
+    .replace(/(?<=\p{Lu})(?=\p{Lu}\p{Ll})/gu, " ");
+}
+
+export function registerMuninUDFs(db: Database.Database): void {
+  db.function(
+    "munin_split_tokens",
+    { deterministic: true, varargs: false },
+    (text: unknown) => splitCamelCaseTokens(text),
+  );
+}
+
 export function runMigrations(db: Database.Database): void {
+  // Register UDFs needed by triggers BEFORE running any migrations.
+  // Migration v17 wires the FTS triggers to call munin_split_tokens(),
+  // and any future writes via the existing triggers also need it.
+  registerMuninUDFs(db);
+
   // Create the schema_version table (the migration framework's own table)
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -781,10 +781,14 @@ export const migrations: Migration[] = [
 export function splitCamelCaseTokens(text: unknown): string {
   if (typeof text !== "string" || text.length === 0) return "";
   // Use zero-width lookbehind/lookahead to avoid catastrophic backtracking
-  // on long runs of a single case (e.g. "AAAA…").
+  // on long runs of a single case (e.g. "AAAA…"). The acronym-boundary rule
+  // requires 2+ uppercase letters in the lookbehind so identifiers like
+  // `OAuthToken` and `IPv6Address` keep their leading single-capital prefix
+  // attached (→ `OAuth Token`, `IPv6 Address`) instead of being split off
+  // (→ `O Auth Token`, `I Pv6 Address`) and missing FTS hits.
   return text
     .replace(/(?<=[\p{Ll}\p{Nd}])(?=\p{Lu})/gu, " ")
-    .replace(/(?<=\p{Lu})(?=\p{Lu}\p{Ll})/gu, " ");
+    .replace(/(?<=\p{Lu}\p{Lu})(?=\p{Lu}\p{Ll})/gu, " ");
 }
 
 export function registerMuninUDFs(db: Database.Database): void {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -617,6 +617,29 @@ describe("rebuildFTS", () => {
     const results = queryEntries(db, { query: "searchable" });
     expect(results.length).toBe(1);
   });
+
+  it("preserves split-token (camelCase) matches across rebuild (#42)", () => {
+    writeState(
+      db,
+      "projects/test",
+      "tools",
+      "Used the WebFetch tool to scrape",
+      ["tools"],
+    );
+    expect(
+      queryEntries(db, { query: "web fetch" }).some((r) =>
+        r.content.includes("WebFetch"),
+      ),
+    ).toBe(true);
+
+    rebuildFTS(db);
+
+    expect(
+      queryEntries(db, { query: "web fetch" }).some((r) =>
+        r.content.includes("WebFetch"),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("embedding_status on entries", () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -320,6 +320,53 @@ describe("queryEntries (FTS5)", () => {
     expect(plainContents.some((c) => c.includes("Mímir"))).toBe(true);
     expect(plainContents.some((c) => c.includes("Mimir"))).toBe(true);
   });
+
+  it("matches camelCase tokens against separated-word queries (#42)", () => {
+    writeState(
+      db,
+      "projects/test",
+      "tools",
+      "Used the WebFetch tool to scrape the page",
+      ["tools"],
+    );
+
+    const camelHits = queryEntries(db, { query: "WebFetch" });
+    expect(camelHits.some((r) => r.content.includes("WebFetch"))).toBe(true);
+
+    const separatedHits = queryEntries(db, { query: "web fetch" });
+    expect(separatedHits.some((r) => r.content.includes("WebFetch"))).toBe(true);
+
+    const lowerHits = queryEntries(db, { query: "fetch" });
+    expect(lowerHits.some((r) => r.content.includes("WebFetch"))).toBe(true);
+  });
+
+  it("matches PascalCase identifiers and acronym boundaries (#42)", () => {
+    writeState(
+      db,
+      "projects/test",
+      "patterns",
+      "XMLParser handles parseXML and IOError events",
+      ["code"],
+    );
+
+    expect(
+      queryEntries(db, { query: "XML parser" }).some((r) =>
+        r.content.includes("XMLParser"),
+      ),
+    ).toBe(true);
+
+    expect(
+      queryEntries(db, { query: "parse XML" }).some((r) =>
+        r.content.includes("parseXML"),
+      ),
+    ).toBe(true);
+
+    expect(
+      queryEntries(db, { query: "io error" }).some((r) =>
+        r.content.includes("IOError"),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("listNamespaces", () => {

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -720,6 +720,14 @@ describe("splitCamelCaseTokens (#42)", () => {
     expect(splitCamelCaseTokens("parseXMLResponse")).toBe("parse XML Response");
   });
 
+  it("preserves single-capital prefix on Pascal identifiers", () => {
+    // Acronym rule needs 2+ uppers in lookbehind, so a single leading capital
+    // followed by a Pascal-cased word is treated as one PascalCase token.
+    expect(splitCamelCaseTokens("OAuthToken")).toBe("OAuth Token");
+    expect(splitCamelCaseTokens("IPv6Address")).toBe("IPv6 Address");
+    expect(splitCamelCaseTokens("UFooBar")).toBe("UFoo Bar");
+  });
+
   it("splits digit→uppercase boundary", () => {
     expect(splitCamelCaseTokens("foo2Bar")).toBe("foo2 Bar");
   });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { unlinkSync, existsSync } from "node:fs";
-import { runMigrations, getSchemaVersion, migrations } from "../src/migrations.js";
+import {
+  runMigrations,
+  getSchemaVersion,
+  migrations,
+  splitCamelCaseTokens,
+} from "../src/migrations.js";
 import { initDatabase, writeState, readState, queryEntries } from "../src/db.js";
 
 const TEST_DB_PATH = "/tmp/munin-memory-migrations-test.db";
@@ -694,6 +699,96 @@ describe("migration v5 — principals table", () => {
       .prepare("SELECT namespace_rules FROM principals WHERE id = 'p1'")
       .get() as { namespace_rules: string };
     expect(row.namespace_rules).toBe("[]");
+    db.close();
+  });
+});
+
+describe("splitCamelCaseTokens (#42)", () => {
+  it("splits camelCase on lowercase→uppercase boundary", () => {
+    expect(splitCamelCaseTokens("webFetch")).toBe("web Fetch");
+    expect(splitCamelCaseTokens("userIdField")).toBe("user Id Field");
+  });
+
+  it("splits PascalCase identifiers", () => {
+    expect(splitCamelCaseTokens("WebFetch")).toBe("Web Fetch");
+    expect(splitCamelCaseTokens("HelloWorld")).toBe("Hello World");
+  });
+
+  it("splits acronym→Pascal boundary", () => {
+    expect(splitCamelCaseTokens("XMLParser")).toBe("XML Parser");
+    expect(splitCamelCaseTokens("IOError")).toBe("IO Error");
+    expect(splitCamelCaseTokens("parseXMLResponse")).toBe("parse XML Response");
+  });
+
+  it("splits digit→uppercase boundary", () => {
+    expect(splitCamelCaseTokens("foo2Bar")).toBe("foo2 Bar");
+  });
+
+  it("leaves snake_case and kebab-case unchanged", () => {
+    expect(splitCamelCaseTokens("snake_case")).toBe("snake_case");
+    expect(splitCamelCaseTokens("kebab-case")).toBe("kebab-case");
+  });
+
+  it("leaves all-lower and all-upper runs unchanged", () => {
+    expect(splitCamelCaseTokens("hello")).toBe("hello");
+    expect(splitCamelCaseTokens("XML")).toBe("XML");
+  });
+
+  it("handles non-strings and empty values", () => {
+    expect(splitCamelCaseTokens(null)).toBe("");
+    expect(splitCamelCaseTokens(undefined)).toBe("");
+    expect(splitCamelCaseTokens(42)).toBe("");
+    expect(splitCamelCaseTokens("")).toBe("");
+  });
+
+  it("does not catastrophically backtrack on long single-case runs", () => {
+    const longUpper = "A".repeat(50000);
+    const start = Date.now();
+    const result = splitCamelCaseTokens(longUpper);
+    const elapsed = Date.now() - start;
+    expect(result).toBe(longUpper);
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+describe("migration v17 — augmented FTS index", () => {
+  it("rebuilds FTS index so existing rows match split-token queries", () => {
+    // Simulate a pre-v17 DB: stop migrations at v16, insert a row, then upgrade.
+    const db = openRawDb();
+    const v16only = migrations.filter((m) => m.version <= 16);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      );
+    `);
+    // Manually run migrations up to v16 (mirror runMigrations logic)
+    for (const m of v16only) {
+      m.up(db);
+      db.prepare(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+      ).run(m.version, new Date().toISOString());
+    }
+
+    db.prepare(
+      `INSERT INTO entries (id, namespace, key, entry_type, content, tags, created_at, updated_at)
+       VALUES ('e1', 'projects/test', 'note', 'state', 'Used the WebFetch tool', '[]', ?, ?)`,
+    ).run(new Date().toISOString(), new Date().toISOString());
+
+    // Pre-v17: 'web fetch' should not match the camelCased content
+    const preHits = db
+      .prepare("SELECT rowid FROM entries_fts WHERE entries_fts MATCH ?")
+      .all("web fetch") as Array<{ rowid: number }>;
+    expect(preHits).toHaveLength(0);
+
+    // Now run the full migration set (v17 included). runMigrations registers the UDF.
+    runMigrations(db);
+
+    const postHits = db
+      .prepare("SELECT rowid FROM entries_fts WHERE entries_fts MATCH ?")
+      .all("web fetch") as Array<{ rowid: number }>;
+    expect(postHits.length).toBeGreaterThanOrEqual(1);
+
     db.close();
   });
 });


### PR DESCRIPTION
## Summary

- Migration v17 augments the FTS5 index with case-split tokens via a new `munin_split_tokens` SQL UDF, so `WebFetch` / `XMLParser` / `parseXMLResponse` are now findable via `web fetch` / `XML parser` / `parse XML response`.
- The UDF is registered on every DB connection at the start of `runMigrations` (so tests and production share one path) and uses zero-width lookbehind/lookahead to avoid catastrophic regex backtracking on long single-case runs.
- 11 new tests: 8 unit tests for `splitCamelCaseTokens`, a v17 upgrade test that proves a pre-v17 row becomes findable after the migration runs, and 2 end-to-end FTS5 tests in `tests/db.test.ts`.

## Why this approach

Considered three options from the issue:
1. **trigram tokenizer** — would regress the diacritic-folding from #41.
2. **Write-time content augmentation (this PR)** — symmetric, transparent to the query layer, and confined to the FTS triggers.
3. **Query-side expansion alone** — asymmetric: would not help when content is camelCased and the query is separated words (the actual T10 failure mode).

Approach 2 keeps the storage and the query side aligned and avoids any change to the existing `unicode61 remove_diacritics 2` tokenizer.

## Known limitation

Quoted phrases that span identifier-internal punctuation like `"90/10"` are still tokenizer-split by `unicode61` (slash is a separator). Query as separate tokens (`90 10`) and rely on FTS5's near-match ranking. Documented in CHANGELOG.

## Test plan

- [x] `npm run build` clean
- [x] Full vitest suite green: 1075 passed, 3 skipped (was 1064)
- [x] New regression tests prove `WebFetch` ↔ `web fetch` symmetry, `XMLParser` ↔ `XML parser`, `IOError` ↔ `io error`, `parseXMLResponse` ↔ `parse XML response`
- [x] Backtracking guard test: 50,000-char single-case input completes in <500ms
- [ ] Deploy to Pi and re-run T10 corpus query manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)