### PR TITLE
chore: daily backup with GFS retention, move target to HDD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Changed
+
+- **Backup schedule reduced from hourly to daily** with GFS retention (14 most
+  recent daily snapshots + 4 most recent Sunday snapshots, ~18 files total).
+  Previous policy kept 168 hourly snapshots which grew to ~50 GB and filled
+  the NAS Pi's SD card. New target is ~7 GB. Backup destination moved from
+  `/home/magnus/backups/munin-memory` (SD card) to
+  `/mnt/timemachine/backups/munin-memory` (1.8 TB external HDD).
+  `munin-backup.{service,timer}` are now version-controlled in the repo root
+  alongside `munin-memory.service`.
+
 ### Fixed
 
 - **`memory_update_status` no longer drops non-canonical sections.** Previously

--- a/munin-backup.service
+++ b/munin-backup.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Munin Memory backup to NAS
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=magnus
+ExecStart=/home/magnus/repos/munin-memory/scripts/backup-to-nas.sh
+StandardOutput=journal
+StandardError=journal
+
+# Timeouts
+TimeoutStartSec=120
+
+# Hardening (lighter than the main service — just needs network + sqlite3)
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes

--- a/munin-backup.timer
+++ b/munin-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Munin Memory backup to NAS
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/backup-to-nas.sh
+++ b/scripts/backup-to-nas.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 DB="/home/magnus/.munin-memory/memory.db"
 NAS_HOST="100.99.119.52"
-NAS_DIR="/home/magnus/backups/munin-memory"
+NAS_DIR="/mnt/timemachine/backups/munin-memory"
 TIMESTAMP=$(date -u +%Y-%m-%d-%H%M)
 FILENAME="memory-${TIMESTAMP}.db"
 LOCAL_TMP="/tmp/${FILENAME}"
@@ -25,13 +25,30 @@ if [ "$INTEGRITY" != "ok" ]; then
     exit 1
 fi
 
-# 3. rsync to NAS
+# 3. Ensure target dir exists, then rsync to NAS
+ssh "magnus@${NAS_HOST}" "mkdir -p '${NAS_DIR}'"
 rsync -az "$LOCAL_TMP" "magnus@${NAS_HOST}:${NAS_DIR}/${FILENAME}"
 
 # 4. Cleanup local temp
 rm -f "$LOCAL_TMP"
 
-# 5. Prune old backups on NAS (keep last 168 = 7 days of hourly backups)
-ssh "magnus@${NAS_HOST}" "cd ${NAS_DIR} && ls -1t memory-*.db 2>/dev/null | tail -n +169 | xargs -r rm --"
+# 5. Prune old backups on NAS — GFS retention:
+#    - keep the 14 most recent daily snapshots
+#    - plus the 4 most recent Sunday snapshots (rolling monthly coverage)
+ssh "magnus@${NAS_HOST}" "bash -s '${NAS_DIR}'" <<'REMOTE'
+set -euo pipefail
+cd "$1" || exit 0
+keep=$(mktemp)
+trap 'rm -f "$keep"' EXIT
+ls -1t memory-*.db 2>/dev/null | head -n 14 > "$keep"
+for f in $(ls -1t memory-*.db 2>/dev/null); do
+    d=$(echo "$f" | sed -nE 's/^memory-([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p')
+    [ -z "$d" ] && continue
+    if [ "$(date -d "$d" +%u 2>/dev/null)" = "7" ]; then
+        echo "$f"
+    fi
+done | head -n 4 >> "$keep"
+ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" | xargs -r rm --
+REMOTE
 
 echo "$(date -Iseconds) Backup complete: ${FILENAME}"


### PR DESCRIPTION
## Summary

The munin-memory backup policy was hourly with 168-snapshot retention, accumulating ~50 GB on the NAS Pi's SD card root partition (which only has 58 GB total). The SD card filled up on 2026-04-25, and every backup since has failed with `ENOSPC`.

This PR changes the policy to daily backups with GFS retention, and redirects the target from the SD card to the 1.8 TB external HDD that the NAS Pi already has mounted.

## Changes

- **`scripts/backup-to-nas.sh`**:
  - Target dir: `/home/magnus/backups/munin-memory` (SD card) → `/mnt/timemachine/backups/munin-memory` (external HDD with 788 GB free)
  - Retention rewritten as a here-doc: keep the 14 most recent daily snapshots **plus** the 4 most recent Sunday snapshots (rolling monthly coverage). ~18 files steady-state ≈ 7 GB at current DB size (~400 MB).
  - Adds `mkdir -p` on the target dir before rsync.
- **`munin-backup.timer`** (new, version-controlled): `OnCalendar=*-*-* 03:00:00` instead of `OnCalendar=hourly`.
- **`munin-backup.service`** (new, version-controlled): byte-identical to the file currently on the Pi at `/etc/systemd/system/munin-backup.service`.
- **`CHANGELOG.md`**: entry under `[Unreleased] / Changed`.

Retention math:
- Old: 168 hourly × ~300 MB ≈ 50 GB
- New: ~18 (14 daily + up to 4 Sunday) × ~400 MB ≈ 7 GB

## Test plan

- [x] `bash -n scripts/backup-to-nas.sh` — syntax OK
- [ ] After merge: copy unit files to `/etc/systemd/system/` on huginmunin, `daemon-reload`, restart timer, verify next-elapse with `systemctl list-timers munin-backup.timer`
- [ ] Manually trigger first backup: `sudo systemctl start munin-backup.service`, verify file lands in `/mnt/timemachine/backups/munin-memory/` on nas
- [ ] Delete the obsolete `/home/magnus/backups/munin-memory` on nas (50 GB of stale hourly snapshots)
- [ ] `df -h /` on nas should drop from 100% to ~10%

## Why GFS over straight last-N daily

14 days of daily coverage is fine for routine recovery. The 4 Sunday snapshots add ~4 weeks of coarse-grained coverage at almost no extra cost (4 files × ~400 MB = 1.6 GB) — useful if a corruption isn't noticed for a week or two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)