### PR TITLE
fix: tolerate empty grep result in backup retention

### DIFF
--- a/scripts/backup-to-nas.sh
+++ b/scripts/backup-to-nas.sh
@@ -48,7 +48,7 @@ for f in $(ls -1t memory-*.db 2>/dev/null); do
         echo "$f"
     fi
 done | head -n 4 >> "$keep"
-ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" | xargs -r rm --
+{ ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" || true; } | xargs -r rm --
 REMOTE
 
 echo "$(date -Iseconds) Backup complete: ${FILENAME}"


### PR DESCRIPTION
## Summary
- Retention block in `backup-to-nas.sh` failed when the keep-list covered every backup file: `grep -vxFf` exits 1 with no matches and `set -o pipefail` propagated that to the service.
- Wrapped the pipeline in `{ ... || true; }` so empty deletes become no-ops.

## Test plan
- [x] Verified on Pi: service now exits 0 with single backup file present (`systemctl status munin-backup.service`).
- [x] Two backups landed on `/mnt/timemachine/backups/munin-memory/` after fix deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)