### PR TITLE
fix: bound consolidation log window so backlog can't stall worker (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Added
+
+- `MUNIN_CONSOLIDATION_MAX_LOGS_PER_RUN` (default `15`) — caps how many
+  unincorporated logs a single consolidation run incorporates, so a large
+  backlog drains incrementally over successive worker ticks instead of
+  producing one oversized synthesis request.
+
 ### Changed
 
 - **Backup schedule reduced from hourly to daily** with GFS retention (14 most
@@ -21,6 +28,14 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **Consolidation worker no longer stalls indefinitely on a large backlog
+  (#51).** A namespace with many unincorporated logs produced a synthesis
+  that overflowed the OpenRouter `max_tokens` cap, returning truncated JSON
+  that failed to parse. Repeated parse failures tripped the circuit breaker,
+  which silently disabled *all* consolidation until the next process restart;
+  the growing backlog meant the namespace could never self-recover. Fixed by
+  raising `max_tokens` (2048 → 4096) and bounding the per-run log window
+  (`MUNIN_CONSOLIDATION_MAX_LOGS_PER_RUN`) so backlogs drain incrementally.
 - **FTS5 now matches camelCase / PascalCase identifiers against separated-word
   queries.** Migration v17 recreates the FTS triggers to augment indexed
   content with a case-split copy via the `munin_split_tokens` SQL UDF, and

--- a/check-openrouter-credits.sh
+++ b/check-openrouter-credits.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+echo "=== script start ==="
+echo "local: about to ssh to Pi..."
+
+ssh magnus@huginmunin.local 'F=/home/magnus/munin-memory/.env; echo "remote: env file:"; ls -l "$F"; K=$(grep "^OPENROUTER_API_KEY" "$F" | cut -d= -f2- | tr -d "\"'\''" ); echo "remote: key length ${#K}"; echo "remote: /credits response:"; curl -sS -w "\nHTTP=%{http_code}\n" https://openrouter.ai/api/v1/credits -H "Authorization: Bearer $K"; echo "remote: /auth/key response:"; curl -sS -w "\nHTTP=%{http_code}\n" https://openrouter.ai/api/v1/auth/key -H "Authorization: Bearer $K"'
+
+echo "local: ssh exited with code $?"
+echo "=== script end ==="

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -21,6 +21,10 @@ const config = {
   batchSize: parseInt(process.env.MUNIN_CONSOLIDATION_BATCH_SIZE ?? "5", 10) || 5,
   minLogs: parseInt(process.env.MUNIN_CONSOLIDATION_MIN_LOGS ?? "3", 10) || 3,
   maxFailures: parseInt(process.env.MUNIN_CONSOLIDATION_MAX_FAILURES ?? "3", 10) || 3,
+  // Cap logs incorporated per run so a large backlog drains over multiple
+  // ticks instead of producing one synthesis that overflows max_tokens,
+  // truncates, fails to parse, and eventually trips the circuit breaker (#51).
+  maxLogsPerRun: parseInt(process.env.MUNIN_CONSOLIDATION_MAX_LOGS_PER_RUN ?? "15", 10) || 15,
 };
 
 // --- OpenRouter API types ---
@@ -53,7 +57,7 @@ async function callOpenRouter(prompt: string): Promise<ChatCompletionResponse> {
     },
     body: JSON.stringify({
       model: config.model,
-      max_tokens: 2048,
+      max_tokens: 4096,
       messages: [{ role: "user", content: prompt }],
       provider: { zdr: true },
     }),
@@ -168,7 +172,7 @@ export async function consolidateNamespace(
   // Step 1: Read current state
   const metadata = getConsolidationMetadata(db, namespace);
   const sinceTimestamp = metadata?.last_log_created_at ?? null;
-  const logs = getLogsForConsolidation(db, namespace, sinceTimestamp);
+  const logs = getLogsForConsolidation(db, namespace, sinceTimestamp, config.maxLogsPerRun);
 
   if (logs.length === 0) {
     return {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2637,23 +2637,29 @@ export function getLogsForConsolidation(
   db: Database.Database,
   namespace: string,
   sinceTimestamp?: string | null,
+  maxLogs?: number | null,
 ): Entry[] {
+  // Oldest-first, optionally capped so a large backlog drains incrementally
+  // over successive worker ticks instead of producing one oversized synthesis
+  // request that truncates and fails to parse (issue #51).
+  const hasLimit = typeof maxLogs === "number" && maxLogs > 0;
+  const limitClause = hasLimit ? " LIMIT ?" : "";
   if (sinceTimestamp) {
-    return db
-      .prepare(
-        `SELECT * FROM entries
-         WHERE namespace = ? AND entry_type = 'log' AND created_at > ?
-         ORDER BY created_at ASC`,
-      )
-      .all(namespace, sinceTimestamp) as Entry[];
-  }
-  return db
-    .prepare(
+    const stmt = db.prepare(
       `SELECT * FROM entries
+         WHERE namespace = ? AND entry_type = 'log' AND created_at > ?
+         ORDER BY created_at ASC${limitClause}`,
+    );
+    return (hasLimit
+      ? stmt.all(namespace, sinceTimestamp, maxLogs)
+      : stmt.all(namespace, sinceTimestamp)) as Entry[];
+  }
+  const stmt = db.prepare(
+    `SELECT * FROM entries
        WHERE namespace = ? AND entry_type = 'log'
-       ORDER BY created_at ASC`,
-    )
-    .all(namespace) as Entry[];
+       ORDER BY created_at ASC${limitClause}`,
+  );
+  return (hasLimit ? stmt.all(namespace, maxLogs) : stmt.all(namespace)) as Entry[];
 }
 
 /**

--- a/tests/consolidation-db.test.ts
+++ b/tests/consolidation-db.test.ts
@@ -213,6 +213,36 @@ describe("getLogsForConsolidation", () => {
     expect(logs).toHaveLength(1);
     expect(logs[0].entry_type).toBe("log");
   });
+
+  it("caps the result to maxLogs, oldest-first, so a backlog drains incrementally (#51)", () => {
+    for (let i = 0; i < 10; i++) {
+      const ts = `2026-03-01T1${i}:00:00.000Z`;
+      appendLogAndSetTime(db, "projects/theta", `Entry ${i}`, ts);
+    }
+
+    // First run: bounded to the oldest 4 entries
+    const firstRun = getLogsForConsolidation(db, "projects/theta", null, 4);
+    expect(firstRun).toHaveLength(4);
+    expect(firstRun[0].content).toBe("Entry 0");
+    expect(firstRun[3].content).toBe("Entry 3");
+
+    // Next run starts after the last log of the previous (bounded) run —
+    // the cursor advances, draining the backlog over successive ticks.
+    const cursor = firstRun[firstRun.length - 1].created_at;
+    const secondRun = getLogsForConsolidation(db, "projects/theta", cursor, 4);
+    expect(secondRun).toHaveLength(4);
+    expect(secondRun[0].content).toBe("Entry 4");
+    expect(secondRun[3].content).toBe("Entry 7");
+  });
+
+  it("returns all logs when maxLogs is undefined, null, or non-positive", () => {
+    for (let i = 0; i < 6; i++) {
+      appendLogAndSetTime(db, "projects/iota", `E${i}`, `2026-04-01T1${i}:00:00.000Z`);
+    }
+    expect(getLogsForConsolidation(db, "projects/iota")).toHaveLength(6);
+    expect(getLogsForConsolidation(db, "projects/iota", null, null)).toHaveLength(6);
+    expect(getLogsForConsolidation(db, "projects/iota", null, 0)).toHaveLength(6);
+  });
 });
 
 describe("getConsolidationMetadata / upsertConsolidationMetadata", () => {


### PR DESCRIPTION
Fixes #51.

## Problem

The consolidation worker silently stopped for ~12 days. Root cause: large-backlog namespaces produced a synthesis exceeding the OpenRouter `max_tokens: 2048` cap → truncated JSON → `parseSynthesisResponse()` throws. Three consecutive parse failures trip the circuit breaker, which disables **all** consolidation until a process restart. The failing namespace's backlog keeps growing, so it can never self-recover.

Confirmed live: after a 17 May restart, `projects/drone-lab` (29 undigested logs) and `projects/skald` both failed with `Failed to parse JSON ... at position ~3100–3200` — exactly where a 2048-token completion runs out — while smaller namespaces consolidated fine.

## Fix

- `max_tokens` 2048 → 4096 so normal syntheses aren't truncated.
- New `MUNIN_CONSOLIDATION_MAX_LOGS_PER_RUN` (default 15). `getLogsForConsolidation` caps the per-run window oldest-first; the metadata cursor advances by the last log of the bounded set, so a large backlog drains incrementally over successive worker ticks instead of producing one un-parseable mega-response that perpetually fails.

## Tests

- Bounded window returns oldest N; cursor advance over successive runs drains the backlog in order.
- No-cap fallback (undefined / null / 0) returns all logs unchanged.
- Full suite: 1079 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)