### PR TITLE
feat(benchmark): retrieval-v1 lineage manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ changelog is the canonical record of what moved.
   unincorporated logs a single consolidation run incorporates, so a large
   backlog drains incrementally over successive worker ticks instead of
   producing one oversized synthesis request.
+- Retrieval benchmark lineage manifest at
+  `benchmark/queries/retrieval-v1.manifest.{json,md}`. Curated source index
+  that reconciles munin-native query sets (`baseline.jsonl`,
+  `baseline-claude.jsonl`, `example.jsonl` — 34 records) with munin-zero
+  pilot evidence (v2/v3/v3b/v3c, pinned at commit `ad4baff`) into eight
+  first-class source entries (176 records total) plus an explicit
+  `omitted_artifacts[]` inventory. Records `munin-zero#6` as closed by
+  pilot v3c with sha256-pinned evidence (report + intents + queries +
+  results + targets) and the six target UUIDs. Strong validator test in
+  `tests/retrieval-manifest.test.ts` parses native JSONLs against the
+  `BenchmarkQuery` shape, asserts sha256 pins, verifies the v1 source
+  freeze, and includes negative tests for `source_class`, target metadata,
+  closure evidence, and derived totals. The manifest is a citation /
+  provenance index, not a runner input or label store. No existing JSONL
+  is modified.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ changelog is the canonical record of what moved.
   first-class source entries (176 records total) plus an explicit
   `omitted_artifacts[]` inventory. Records `munin-zero#6` as closed by
   pilot v3c with sha256-pinned evidence (report + intents + queries +
-  results + targets) and the six target UUIDs. Strong validator test in
-  `tests/retrieval-manifest.test.ts` parses native JSONLs against the
-  `BenchmarkQuery` shape, asserts sha256 pins, verifies the v1 source
-  freeze, and includes negative tests for `source_class`, target metadata,
-  closure evidence, and derived totals. The manifest is a citation /
+  results + targets, plus the v3b lexical baseline that substantiates
+  the "vs 0/6" comparison) and the six target UUIDs. Validator test in
+  `tests/retrieval-manifest.test.ts` parses every native JSONL against
+  the `BenchmarkQuery` shape, verifies sha256 pins for in-repo native
+  sources, asserts the exact v1 source freeze, and includes negative
+  tests for `source_class`, target metadata, closure evidence, and
+  derived totals. (External munin-zero artifacts are pinned by path +
+  sha256 in the manifest but are not checked out by CI.) The manifest is a citation /
   provenance index, not a runner input or label store. No existing JSONL
   is modified.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -63,3 +63,14 @@ npx tsx benchmark/adapters/longmemeval/run.ts --split s
 - Commit manifests, docs, and adapter code.
 - Do not commit heavyweight raw datasets or generated caches.
 - Keep any CI fixture intentionally small and explicitly documented.
+
+## Retrieval Benchmark Lineage Manifest
+
+`queries/retrieval-v1.manifest.{json,md}` is a curated source index that
+reconciles the munin-native query JSONLs with the sibling munin-zero
+retrieval pilot artifacts (v2/v3/v3b/v3c, pinned at commit `ad4baff`).
+It is a **citation/provenance index, not a runner input** — the runner
+still consumes the native JSONLs directly. Start with the markdown
+companion (`retrieval-v1.manifest.md`) for orientation; the JSON file
+holds the machine-checkable schema. See `tests/retrieval-manifest.test.ts`
+for the invariants the manifest is expected to hold.

--- a/benchmark/queries/retrieval-v1.manifest.json
+++ b/benchmark/queries/retrieval-v1.manifest.json
@@ -121,7 +121,8 @@
       "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v2.jsonl",
       "sha256": "24123389efca7ec1b771089c376aaf71bfd36a3540c27bbfe5fba9b144443f71",
       "record_count": 30,
-      "source_class": "manual",
+      "source_class": "derived",
+      "source_origin": "model:claude-sonnet-4-6 (intent-writer, blind chain — see pilot-report-v2.md)",
       "tier": "evidence",
       "shape": "munin-zero-intent",
       "ground_truth_kind": "targets_external",
@@ -169,7 +170,8 @@
       "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3.jsonl",
       "sha256": "04c56a114b1cfd10a597efcac81c1feee24fc4affa09555eed91193a02ad5cc9",
       "record_count": 50,
-      "source_class": "manual",
+      "source_class": "derived",
+      "source_origin": "model:claude-sonnet-4-6 (intent-writer, blind chain — see pilot-report-v3.md)",
       "tier": "evidence",
       "shape": "munin-zero-intent",
       "ground_truth_kind": "targets_external",
@@ -266,6 +268,7 @@
       "sha256": "a32e78fa057de7354a8903b2c3b9b7bfc672f43f3104b26715c5d1f010e56e8b",
       "record_count": 6,
       "source_class": "manual",
+      "source_origin": "human-rewrite (no model attribution in pilot-report-v3c.md; intents were explicitly rewritten as topical user questions rather than reusing the v3 Sonnet intent-writer output)",
       "tier": "primary",
       "shape": "munin-zero-intent",
       "ground_truth_kind": "targets_external",
@@ -444,14 +447,18 @@
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3c.jsonl",
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3c-sonnet.jsonl",
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl",
-        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl"
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3b.md",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3b-lexical.jsonl"
       ],
       "evidence_sha256": {
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3c.md": "c35c1440e900c1dd94b22c338af632d954b7d63a9526cc9c10ffa773805cd8c4",
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3c.jsonl": "a32e78fa057de7354a8903b2c3b9b7bfc672f43f3104b26715c5d1f010e56e8b",
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3c-sonnet.jsonl": "88d667883459ff50787321ac8323c7dfb9e2dc96b339f457705fc5ad2f273684",
         "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl": "0e8f50101e21eef00f7d843a4d379a0a81f225a6448335326199768a0061d891",
-        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8"
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3b.md": "50e1cdc56417cc8e42a3cf548ca6407a6270f820a1166d26bfe64ed5834f2cb6",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3b-lexical.jsonl": "24415285776e72542800f9706610a84afa60d98eab081f849ac86ac7bb6d97b7"
       },
       "target_uuid_subset": [
         "fb352c89-bc21-4c44-88e9-204f546a6209",

--- a/benchmark/queries/retrieval-v1.manifest.json
+++ b/benchmark/queries/retrieval-v1.manifest.json
@@ -1,0 +1,520 @@
+{
+  "manifest_version": "1.0.0",
+  "manifest_id": "retrieval-v1",
+  "manifest_kind": "source_index",
+  "created_at": "2026-05-20T00:00:00Z",
+  "created_by": "Magnus Gille",
+  "purpose": "Curated source index that reconciles the munin-native retrieval query JSONLs in this repo with the munin-zero retrieval pilot artifacts (v2/v3/v3b/v3c). Records munin-zero#6 as closed by pilot v3c. This is a citation / provenance index, not a runnable benchmark label set.",
+  "citation_format": "<source_id>:<record_key>",
+  "record_key_fields": {
+    "munin-native-baseline": "id",
+    "munin-native-baseline-claude": "id",
+    "munin-native-example": "id",
+    "munin-zero-v2-intents": "target_num",
+    "munin-zero-v3-intents": "target_num",
+    "munin-zero-v3b-queries-sonnet": "target_id",
+    "munin-zero-v3c-intents": "target_num",
+    "munin-zero-v3c-queries-sonnet": "target_id"
+  },
+  "source_repos": [
+    {
+      "name": "munin-memory",
+      "role": "primary",
+      "commit_sha": "52b3f9936d887f8f32e33d367240e11488a84fbb",
+      "remote": "https://github.com/Magnus-Gille/munin-memory",
+      "notes": "Manifest creation commit reference. Native JSONLs live under benchmark/queries/."
+    },
+    {
+      "name": "munin-zero",
+      "role": "evidence",
+      "commit_sha": "ad4baff8b906065679144185af3e02ee632d9d28",
+      "commit_sha_short": "ad4baff",
+      "commit_date": "2026-04-20T22:17:54+02:00",
+      "remote": "local-only",
+      "notes": "Pilot artifact directory pinned at the v3c closure commit. CI does not check this repo out; integrity rests on sha256 pins below."
+    }
+  ],
+  "sources": [
+    {
+      "id": "munin-native-baseline",
+      "repo": "munin-memory",
+      "path": "benchmark/queries/baseline.jsonl",
+      "sha256": "bc3036f1b52a14968538c7c11193b7b9a65548fe5d2e292f6064984e871276f7",
+      "record_count": 15,
+      "source_class": "manual",
+      "tier": "primary",
+      "shape": "BenchmarkQuery",
+      "ground_truth_kind": "expected_ids",
+      "search_modes": ["hybrid"],
+      "strata_breakdown": {
+        "category": {
+          "project-status": 2,
+          "decision-lookup": 2,
+          "person-context": 2,
+          "temporal": 2,
+          "cross-project": 2,
+          "tag-search": 2,
+          "broad-orientation": 3
+        }
+      },
+      "notes": "Hand-curated munin-native baseline. All records use the BenchmarkQuery shape and source=\"manual\"."
+    },
+    {
+      "id": "munin-native-baseline-claude",
+      "repo": "munin-memory",
+      "path": "benchmark/queries/baseline-claude.jsonl",
+      "sha256": "85b09995a28e35132bef2ffafcc84533105aa71a0f4165d2ac1e687e8d54e4bc",
+      "record_count": 16,
+      "source_class": "manual",
+      "tier": "primary",
+      "shape": "BenchmarkQuery",
+      "ground_truth_kind": "both",
+      "ground_truth_breakdown": {
+        "expected_ids_only": 12,
+        "expected_namespaces_only": 4
+      },
+      "search_modes": ["hybrid"],
+      "strata_breakdown": {
+        "category": {
+          "project-status": 2,
+          "decision-lookup": 3,
+          "person-context": 2,
+          "temporal": 2,
+          "cross-project": 2,
+          "tag-search": 2,
+          "broad-orientation": 2,
+          "anecdote": 1
+        }
+      },
+      "anomalies": [
+        {
+          "record_id": "u-001",
+          "kind": "appended_user_anecdote",
+          "gap_ref": "gap-006"
+        }
+      ],
+      "notes": "Claude-authored extension to baseline. u-001 is an out-of-distribution user anecdote, flagged as gap-006 so consumers can filter it out."
+    },
+    {
+      "id": "munin-native-example",
+      "repo": "munin-memory",
+      "path": "benchmark/queries/example.jsonl",
+      "sha256": "bd99ad9843bb770264b1038f03f99c727f1bd0140a1cc0b85f74fee311940cf2",
+      "record_count": 3,
+      "source_class": "synthetic",
+      "tier": "evidence",
+      "shape": "BenchmarkQuery",
+      "ground_truth_kind": "expected_namespaces",
+      "search_modes": ["hybrid"],
+      "strata_breakdown": {
+        "category": {
+          "project-status": 1,
+          "decision-lookup": 1,
+          "person-context": 1
+        }
+      },
+      "notes": "Tiny synthetic example set kept for shape verification, not measurement."
+    },
+    {
+      "id": "munin-zero-v2-intents",
+      "repo": "munin-zero",
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v2.jsonl",
+      "sha256": "24123389efca7ec1b771089c376aaf71bfd36a3540c27bbfe5fba9b144443f71",
+      "record_count": 30,
+      "source_class": "manual",
+      "tier": "evidence",
+      "shape": "munin-zero-intent",
+      "ground_truth_kind": "targets_external",
+      "target_set_id": "munin-zero-pilot-targets-v2",
+      "target_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v2.jsonl",
+      "target_sha256": "75cd0520dc0aaa28b15cb0c5600e4cb9c1b72dee30979e0b043a193fd76926e2",
+      "target_id_field": "target_num",
+      "target_count": 30,
+      "result_paths": [
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v2.jsonl",
+          "sha256": "f17aff0ef61d231c6bcd8dfd04164c778f8674374d79c5c8856a3cc5270d336b",
+          "search_mode": "lexical",
+          "limit": null,
+          "metric": "rank-scored",
+          "record_count": 90,
+          "notes": "90 = 30 intents × 3 models (haiku/opus/sonnet)."
+        },
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v2-hybrid.jsonl",
+          "sha256": "4fd27b33118b67d45fb3a12c525b3093f85bba60e0ad4713f9fb94179a79924d",
+          "search_mode": "hybrid",
+          "limit": null,
+          "metric": "rank-scored",
+          "record_count": 90
+        }
+      ],
+      "evaluation_method": {
+        "method": "rank-scored",
+        "hit_definition": "target UUID appears in top-K (K varies by run)",
+        "notes": "v2 was pre-relaxed-FTS; baselines are stale (see gap-004)."
+      },
+      "strata_breakdown": {
+        "entry_type": {"state": 24, "log": 6},
+        "stratum": {"projects": 12, "people": 2, "decisions": 4, "logs": 6, "other": 6},
+        "language": {"en": 26, "sv": 4},
+        "cross_language": {"false": 26, "true": 4}
+      },
+      "search_modes": ["lexical", "hybrid"],
+      "notes": "v2 intent set. Ground truth lives in the target file by target_num."
+    },
+    {
+      "id": "munin-zero-v3-intents",
+      "repo": "munin-zero",
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3.jsonl",
+      "sha256": "04c56a114b1cfd10a597efcac81c1feee24fc4affa09555eed91193a02ad5cc9",
+      "record_count": 50,
+      "source_class": "manual",
+      "tier": "evidence",
+      "shape": "munin-zero-intent",
+      "ground_truth_kind": "targets_external",
+      "target_set_id": "munin-zero-pilot-targets-v3",
+      "target_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl",
+      "target_sha256": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8",
+      "target_id_field": "target_num",
+      "target_count": 50,
+      "result_paths": [
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3-lexical.jsonl",
+          "sha256": "4c6f562441fac01dab0925414c251dbc210d9a206830c709e103e0494bc3d9a3",
+          "search_mode": "lexical",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 50
+        },
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3-hybrid.jsonl",
+          "sha256": "9cd526f0eedf77da3a39a17330227b5366d9b8d522e934666f564d874df94d3c",
+          "search_mode": "hybrid",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 50
+        }
+      ],
+      "evaluation_method": {
+        "method": "binary-hit",
+        "hit_definition": "target UUID appears in top-20",
+        "limit": 20
+      },
+      "strata_breakdown": {
+        "entry_type": {"log": 32, "state": 18},
+        "stratum": {"prose-log": 27, "prose-state": 5, "mixed-lang": 3, "decision": 6, "research": 8, "other": 1},
+        "difficulty": {"hard": 32, "medium": 15, "easy": 3},
+        "language": {"en": 46, "en-mixed": 1, "sv": 3},
+        "cross_language": {"false": 46, "true": 4}
+      },
+      "search_modes": ["lexical", "hybrid"],
+      "notes": "v3 expanded intent set. Strata are populated directly from pilot-targets-v3.jsonl."
+    },
+    {
+      "id": "munin-zero-v3b-queries-sonnet",
+      "repo": "munin-zero",
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3b-sonnet.jsonl",
+      "sha256": "350b50119eca0fe889ef84b4d5185824d1afe68f2be358823385fd260f9dc4c1",
+      "record_count": 50,
+      "source_class": "derived",
+      "tier": "evidence",
+      "shape": "munin-zero-formulated-query",
+      "ground_truth_kind": "targets_external",
+      "target_set_id": "munin-zero-pilot-targets-v3",
+      "target_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl",
+      "target_sha256": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8",
+      "target_id_field": "target_id",
+      "target_count": 50,
+      "result_paths": [
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3b-lexical.jsonl",
+          "sha256": "24415285776e72542800f9706610a84afa60d98eab081f849ac86ac7bb6d97b7",
+          "search_mode": "lexical",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 50
+        },
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3b-hybrid.jsonl",
+          "sha256": "ad8f9eff5d4e266b80159e7de76486daba7f73d3129f8d1b1c262209f5bd6905",
+          "search_mode": "hybrid",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 50
+        }
+      ],
+      "evaluation_method": {
+        "method": "binary-hit",
+        "hit_definition": "target UUID appears in top-20",
+        "limit": 20
+      },
+      "strata_breakdown": {
+        "inherits_from": "munin-zero-v3-intents",
+        "entry_type": {"log": 32, "state": 18},
+        "stratum": {"prose-log": 27, "prose-state": 5, "mixed-lang": 3, "decision": 6, "research": 8, "other": 1},
+        "difficulty": {"hard": 32, "medium": 15, "easy": 3},
+        "language": {"en": 46, "en-mixed": 1, "sv": 3}
+      },
+      "search_modes": ["lexical", "hybrid"],
+      "notes": "v3b is Sonnet-formulated queries built from the v3 intents; targets are the same as v3."
+    },
+    {
+      "id": "munin-zero-v3c-intents",
+      "repo": "munin-zero",
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3c.jsonl",
+      "sha256": "a32e78fa057de7354a8903b2c3b9b7bfc672f43f3104b26715c5d1f010e56e8b",
+      "record_count": 6,
+      "source_class": "manual",
+      "tier": "primary",
+      "shape": "munin-zero-intent",
+      "ground_truth_kind": "targets_external",
+      "target_set_id": "munin-zero-pilot-targets-v3",
+      "target_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl",
+      "target_sha256": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8",
+      "target_id_field": "target_num",
+      "target_count": 6,
+      "target_subset": [9, 10, 29, 35, 47, 49],
+      "target_uuid_subset": [
+        "fb352c89-bc21-4c44-88e9-204f546a6209",
+        "1b4c8471-f70d-4758-8453-1b0731ae4729",
+        "2ad0276d-21e3-4dc1-b342-e85aa896fd14",
+        "725e495a-4db3-4deb-8987-5cc341d53aac",
+        "30edced3-9552-42df-8ba4-334709ddd9a3",
+        "e6e24975-5942-4db1-b962-e2ef315eb059"
+      ],
+      "result_paths": [
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl",
+          "sha256": "0e8f50101e21eef00f7d843a4d379a0a81f225a6448335326199768a0061d891",
+          "search_mode": "lexical",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 6
+        }
+      ],
+      "evaluation_method": {
+        "method": "binary-hit",
+        "hit_definition": "target UUID appears in top-20",
+        "limit": 20,
+        "search_mode": "lexical",
+        "memory_query_mode": "lexical",
+        "snapshot_parity": "same snapshot as v3b"
+      },
+      "strata_breakdown": {
+        "inherits_from": "munin-zero-v3-intents",
+        "target_subset_uuids": [
+          "fb352c89-bc21-4c44-88e9-204f546a6209",
+          "1b4c8471-f70d-4758-8453-1b0731ae4729",
+          "2ad0276d-21e3-4dc1-b342-e85aa896fd14",
+          "725e495a-4db3-4deb-8987-5cc341d53aac",
+          "30edced3-9552-42df-8ba4-334709ddd9a3",
+          "e6e24975-5942-4db1-b962-e2ef315eb059"
+        ]
+      },
+      "search_modes": ["lexical"],
+      "notes": "Six closure intents that re-tested v3b lexical 0/6 failures after the FTS5 camelCase fix."
+    },
+    {
+      "id": "munin-zero-v3c-queries-sonnet",
+      "repo": "munin-zero",
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3c-sonnet.jsonl",
+      "sha256": "88d667883459ff50787321ac8323c7dfb9e2dc96b339f457705fc5ad2f273684",
+      "record_count": 6,
+      "source_class": "derived",
+      "tier": "primary",
+      "shape": "munin-zero-formulated-query",
+      "ground_truth_kind": "targets_external",
+      "target_set_id": "munin-zero-pilot-targets-v3",
+      "target_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl",
+      "target_sha256": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8",
+      "target_id_field": "target_id",
+      "target_count": 6,
+      "target_subset": ["T9", "T10", "T29", "T35", "T47", "T49"],
+      "result_paths": [
+        {
+          "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl",
+          "sha256": "0e8f50101e21eef00f7d843a4d379a0a81f225a6448335326199768a0061d891",
+          "search_mode": "lexical",
+          "limit": 20,
+          "metric": "hit@20",
+          "record_count": 6
+        }
+      ],
+      "evaluation_method": {
+        "method": "binary-hit",
+        "hit_definition": "target UUID appears in top-20",
+        "limit": 20,
+        "search_mode": "lexical"
+      },
+      "search_modes": ["lexical"],
+      "notes": "Sonnet-formulated queries for the six v3c closure intents."
+    }
+  ],
+  "strata_definitions": {
+    "source_class": {
+      "values": ["manual", "derived", "synthetic"],
+      "definition": "Matches benchmark/types.ts BenchmarkQuery.source. manual = hand-authored; derived = produced by a model or retrieval run; synthetic = generated for shape verification."
+    },
+    "tier": {
+      "values": ["primary", "evidence", "deprecated"],
+      "definition": "Editorial role inside the manifest. primary = load-bearing for the v1 freeze; evidence = cited support; deprecated = retained for lineage but superseded."
+    },
+    "entry_type": {
+      "values": ["state", "log"],
+      "definition": "Munin entry type of the underlying target."
+    },
+    "stratum": {
+      "definition": "Coarse content cluster. Values differ between v2 and v3 — see per-source strata_breakdown."
+    },
+    "difficulty": {
+      "values": ["easy", "medium", "hard"],
+      "definition": "Difficulty grade assigned during v3 target construction. Not populated for v2 (gap-001, gap-004)."
+    },
+    "language": {
+      "values": ["en", "sv", "en-mixed"],
+      "definition": "Primary language of the target content."
+    },
+    "category": {
+      "definition": "Munin-native query category. See benchmark/types.ts BenchmarkQuery.category."
+    },
+    "search_mode": {
+      "values": ["lexical", "semantic", "hybrid"],
+      "definition": "Retrieval mode under test. Mirrors src/types.ts SearchMode."
+    }
+  },
+  "dedupe_policy": {
+    "principle": "No record-level dedupe is performed inside the manifest. Each source's records remain addressable by (source_id, record_key). Cross-source duplicates are possible (e.g. v3c intents are a subset of v3 by target_num) and are documented via target_subset fields.",
+    "rules": [
+      "Treat (source_id, record_key) as the unique citation handle.",
+      "Where a source reuses a parent target set (v3b, v3c → v3 targets), the parent target_set_id is recorded so consumers can deduplicate by target UUID if needed.",
+      "u-001 in baseline-claude.jsonl is excluded from any future deduped retrieval-v1 label set; see gap-006."
+    ]
+  },
+  "known_gaps": [
+    {
+      "id": "gap-001",
+      "summary": "No difficulty stratum on munin-native or v2 sources.",
+      "status": "open",
+      "scope": "munin-native-baseline, munin-native-baseline-claude, munin-native-example, munin-zero-v2-intents"
+    },
+    {
+      "id": "gap-002",
+      "summary": "T10 tokenization issues on '90/10', 'Mímir', 'WebFetch'.",
+      "status": "documented",
+      "scope": "munin-zero-v3c-intents",
+      "evidence_path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3c.md"
+    },
+    {
+      "id": "gap-003",
+      "summary": "retrieval_events data is not yet trustworthy as source_class=derived input. Blocked on #31/#32.",
+      "status": "blocked",
+      "scope": "future-derived-sources"
+    },
+    {
+      "id": "gap-004",
+      "summary": "LoCoMo and v2 baselines pre-date the relaxed-FTS path and the camelCase tokenizer fix; numbers are stale.",
+      "status": "documented",
+      "scope": "munin-zero-v2-intents",
+      "evidence_path": "benchmark/experiment-matrix.md"
+    },
+    {
+      "id": "gap-005",
+      "summary": "entry_type stratum is unpopulated on munin-native sources.",
+      "status": "deferred",
+      "scope": "munin-native-baseline, munin-native-baseline-claude, munin-native-example",
+      "deferred_to": "Artifact 3"
+    },
+    {
+      "id": "gap-006",
+      "summary": "u-001 in baseline-claude.jsonl is an appended user anecdote, not a retrieval target.",
+      "status": "documented",
+      "scope": "munin-native-baseline-claude"
+    }
+  ],
+  "closed_issues": {
+    "munin-zero#6": {
+      "title": "Pilot v3c: lexical closure of v3b 0/6 failures",
+      "closing_commit": "ad4baff8b906065679144185af3e02ee632d9d28",
+      "closing_commit_short": "ad4baff",
+      "closed_at": "2026-04-20T22:17:54+02:00",
+      "summary": "v3c lexical re-test of the six v3b failures returned 5/6 hits at top-20 after the FTS5 camelCase tokenizer fix. T10 remained a miss (gap-002).",
+      "evidence_paths": [
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3c.md",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3c.jsonl",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3c-sonnet.jsonl",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl"
+      ],
+      "evidence_sha256": {
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-report-v3c.md": "c35c1440e900c1dd94b22c338af632d954b7d63a9526cc9c10ffa773805cd8c4",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents-v3c.jsonl": "a32e78fa057de7354a8903b2c3b9b7bfc672f43f3104b26715c5d1f010e56e8b",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3c-sonnet.jsonl": "88d667883459ff50787321ac8323c7dfb9e2dc96b339f457705fc5ad2f273684",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-results-v3c-lexical.jsonl": "0e8f50101e21eef00f7d843a4d379a0a81f225a6448335326199768a0061d891",
+        "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets-v3.jsonl": "7c4942f0724de74fc4ff8483ccd79c7ec30c06a09089fb50c7c8aa28dceafcf8"
+      },
+      "target_uuid_subset": [
+        "fb352c89-bc21-4c44-88e9-204f546a6209",
+        "1b4c8471-f70d-4758-8453-1b0731ae4729",
+        "2ad0276d-21e3-4dc1-b342-e85aa896fd14",
+        "725e495a-4db3-4deb-8987-5cc341d53aac",
+        "30edced3-9552-42df-8ba4-334709ddd9a3",
+        "e6e24975-5942-4db1-b962-e2ef315eb059"
+      ],
+      "outcome": "5/6 hit@20 (lexical) vs 0/6 v3b lexical"
+    }
+  },
+  "omitted_artifacts": [
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v2-haiku.jsonl",
+      "reason": "v2 per-model query files are cited but not first-class entries in the v1 freeze."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v2-opus.jsonl",
+      "reason": "Same as haiku above."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v2-sonnet.jsonl",
+      "reason": "Same as haiku above."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries-v3-sonnet.jsonl",
+      "reason": "v3 formulated-query file. Only v3b and v3c sonnet queries are first-class in v1."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-summaries-v2.jsonl",
+      "reason": "Run summaries, not retrieval queries or labels."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-summaries-v3.jsonl",
+      "reason": "Run summaries, not retrieval queries or labels."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-intents.jsonl",
+      "reason": "Legacy un-versioned intent file superseded by v2/v3."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-queries.jsonl",
+      "reason": "Legacy un-versioned query file."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-results.jsonl",
+      "reason": "Legacy un-versioned results file."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-targets.jsonl",
+      "reason": "Legacy un-versioned targets file."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/pilot-report.md",
+      "reason": "Legacy un-versioned report; superseded by v2/v3/v3b/v3c reports."
+    },
+    {
+      "path": "docs/experiments/retrieval-pilot-2026-04-19/mixed-corpus-weighted-scoring.md",
+      "reason": "Scoring methodology note, not a query or label artifact."
+    }
+  ],
+  "derived_total_record_count": 176,
+  "derived_munin_native_record_count": 34,
+  "derived_munin_zero_record_count": 142
+}

--- a/benchmark/queries/retrieval-v1.manifest.md
+++ b/benchmark/queries/retrieval-v1.manifest.md
@@ -103,8 +103,8 @@ references) live in `sources[]` in the JSON. Quick map:
 | `munin-native-baseline` | munin-memory | primary | manual | 15 | expected_ids | Hand-curated. |
 | `munin-native-baseline-claude` | munin-memory | primary | manual | 16 | both | 12 expected_ids + 4 expected_namespaces. `u-001` is an out-of-distribution anecdote (gap-006). |
 | `munin-native-example` | munin-memory | evidence | synthetic | 3 | expected_namespaces | Shape verification only. |
-| `munin-zero-v2-intents` | munin-zero | evidence | manual | 30 | targets_external | v2 pre-relaxed-FTS; stale (gap-004). |
-| `munin-zero-v3-intents` | munin-zero | evidence | manual | 50 | targets_external | v3 expanded set; full strata populated. |
+| `munin-zero-v2-intents` | munin-zero | evidence | derived | 30 | targets_external | Sonnet intent-writer; v2 pre-relaxed-FTS, stale (gap-004). |
+| `munin-zero-v3-intents` | munin-zero | evidence | derived | 50 | targets_external | Sonnet intent-writer; v3 expanded set, full strata populated. |
 | `munin-zero-v3b-queries-sonnet` | munin-zero | evidence | derived | 50 | targets_external | Sonnet-formulated queries over v3 targets. |
 | `munin-zero-v3c-intents` | munin-zero | primary | manual | 6 | targets_external | Closure intents for `munin-zero#6`. |
 | `munin-zero-v3c-queries-sonnet` | munin-zero | primary | derived | 6 | targets_external | Closure queries for `munin-zero#6`. |

--- a/benchmark/queries/retrieval-v1.manifest.md
+++ b/benchmark/queries/retrieval-v1.manifest.md
@@ -1,0 +1,207 @@
+# Retrieval benchmark lineage manifest (v1)
+
+Companion to `retrieval-v1.manifest.json`. Use this document to understand
+**what the manifest is, what it is not, and how to consume it.** The JSON
+file is the source of truth; this markdown explains it.
+
+## 1. Purpose
+
+This manifest reconciles two threads of retrieval benchmark work into a
+single, source-controlled index:
+
+- the **munin-native** query JSONLs in this repo
+  (`benchmark/queries/{baseline,baseline-claude,example}.jsonl`), and
+- the **munin-zero** retrieval pilot artifacts under
+  `docs/experiments/retrieval-pilot-2026-04-19/` (pinned at commit
+  `ad4baff8b906065679144185af3e02ee632d9d28`).
+
+It is the v1 *source index* — a citation/provenance layer that records
+which artifacts exist, what they contain, what they refer to, and how
+their evidence chains close issues like `munin-zero#6`.
+
+## 2. What this manifest is NOT
+
+This file is **not**:
+
+- a **runnable benchmark input.** The runner consumes
+  `BenchmarkQuery`-shaped JSONLs directly; it does not read this manifest.
+- a **deduped retrieval-v1 label set.** Records across sources may overlap
+  (e.g. v3b and v3c reuse v3 targets); we deliberately do not collapse
+  them here. That work belongs to Artifact 3.
+- an **authoritative relevance-grade store.** No human-audited relevance
+  grades are introduced by this manifest. Relevance lives in either
+  `expected_ids` / `expected_namespaces` on the native JSONLs or in the
+  munin-zero target files referenced by `target_path`.
+- a **complete catalog of every retrieval-related artifact.** Eight
+  sources are indexed; everything else cited but not indexed is listed
+  under `omitted_artifacts[]` with an explicit reason.
+
+If you need a runnable label set or relevance grades, do **not** consume
+this file — wait for Artifact 3.
+
+## 3. How to consume
+
+### 3.1 Citation format
+
+Every record in this corpus can be referenced as:
+
+```
+<source_id>:<record_key>
+```
+
+- `source_id` is one of the eight entries in `sources[]`.
+- `record_key` is the field named by `record_key_fields[source_id]` on
+  the manifest. Examples:
+  - `munin-native-baseline:b-001` (key field = `id`)
+  - `munin-zero-v3c-intents:9` (key field = `target_num`)
+  - `munin-zero-v3c-queries-sonnet:T9` (key field = `target_id`)
+
+### 3.2 Dereferencing target sets
+
+For sources with `ground_truth_kind: "targets_external"`, the relevance
+truth lives in a separate file. The manifest records:
+
+- `target_set_id` — stable handle for the target set
+- `target_path` — repo-relative path inside `munin-zero`
+- `target_sha256` — content pin
+- `target_id_field` — which field on the source row points into the
+  target file (`target_num` for intents, `target_id` for formulated
+  queries that prefix with `T`)
+- `target_count` — number of targets for that source
+- `target_subset` / `target_uuid_subset` (when the source is a strict
+  subset, e.g. v3c uses six of the fifty v3 targets)
+
+### 3.3 Dereferencing result sets
+
+For sources with retrieval runs already on disk, `result_paths[]` lists
+each run with:
+
+- `path`, `sha256`, `record_count`
+- `search_mode` (`lexical` | `semantic` | `hybrid`)
+- `limit` (top-K cutoff used at retrieval time)
+- `metric` (`hit@20`, `rank-scored`, …)
+
+The accompanying `evaluation_method` block declares the hit definition
+that was used to score the run (binary hit-in-top-K, rank-scored,
+snapshot parity, etc.).
+
+## 4. Source repositories
+
+| Name | Role | Pinned commit | Notes |
+|---|---|---|---|
+| `munin-memory` | primary | `52b3f99…` (manifest commit) | Holds native JSONLs. |
+| `munin-zero` | evidence | `ad4baff8b906065679144185af3e02ee632d9d28` | Pilot artifacts at the v3c closure commit. CI does not check out this repo; integrity rests on `sha256` pins. |
+
+## 5. Sources
+
+The v1 freeze contains eight first-class source entries. Full
+machine-readable details (sha256, paths, target metadata, strata, gap
+references) live in `sources[]` in the JSON. Quick map:
+
+| Source ID | Repo | Tier | Class | Records | Ground truth | Notes |
+|---|---|---|---|---|---|---|
+| `munin-native-baseline` | munin-memory | primary | manual | 15 | expected_ids | Hand-curated. |
+| `munin-native-baseline-claude` | munin-memory | primary | manual | 16 | both | 12 expected_ids + 4 expected_namespaces. `u-001` is an out-of-distribution anecdote (gap-006). |
+| `munin-native-example` | munin-memory | evidence | synthetic | 3 | expected_namespaces | Shape verification only. |
+| `munin-zero-v2-intents` | munin-zero | evidence | manual | 30 | targets_external | v2 pre-relaxed-FTS; stale (gap-004). |
+| `munin-zero-v3-intents` | munin-zero | evidence | manual | 50 | targets_external | v3 expanded set; full strata populated. |
+| `munin-zero-v3b-queries-sonnet` | munin-zero | evidence | derived | 50 | targets_external | Sonnet-formulated queries over v3 targets. |
+| `munin-zero-v3c-intents` | munin-zero | primary | manual | 6 | targets_external | Closure intents for `munin-zero#6`. |
+| `munin-zero-v3c-queries-sonnet` | munin-zero | primary | derived | 6 | targets_external | Closure queries for `munin-zero#6`. |
+
+Total: 176 records (34 munin-native + 142 munin-zero).
+
+## 6. Strata definitions
+
+See `strata_definitions` in the JSON for the canonical definitions of
+`source_class`, `tier`, `entry_type`, `stratum`, `difficulty`,
+`language`, `category`, and `search_mode`.
+
+Two non-obvious points:
+
+- **`source_class` is intentionally constrained to `manual | derived | synthetic`**
+  to match the existing `BenchmarkQuery.source` enum in
+  `benchmark/types.ts`. Editorial role lives in `tier` instead
+  (`primary | evidence | deprecated`).
+- **`difficulty` and per-stratum breakdowns are only populated where the
+  underlying target artifact carries them.** v3 and v3b inherit from
+  `pilot-targets-v3.jsonl`; v2 has only `entry_type` / `stratum` /
+  `language`; munin-native sources have none today (gap-001, gap-005).
+
+## 7. Dedupe policy
+
+No record-level deduplication is performed inside the manifest. Each
+record is uniquely addressable by `(source_id, record_key)`. Cross-source
+duplicates (e.g. v3c intents are a subset of v3 by `target_num`) are
+documented via `target_subset` fields so consumers can deduplicate by
+target UUID if they need to.
+
+## 8. Known gaps
+
+See `known_gaps[]` in the JSON for the authoritative list. Summary:
+
+| ID | Status | Scope |
+|---|---|---|
+| gap-001 | open | No difficulty stratum on munin-native or v2 sources. |
+| gap-002 | documented | T10 tokenization issues (`90/10`, `Mímir`, `WebFetch`). |
+| gap-003 | blocked | `retrieval_events` not yet trustworthy as a derived source (#31/#32). |
+| gap-004 | documented | v2 baselines pre-date relaxed FTS and the camelCase tokenizer fix. |
+| gap-005 | deferred | `entry_type` stratum unpopulated on munin-native. |
+| gap-006 | documented | `u-001` is an appended user anecdote, not a retrieval target. |
+
+## 9. Closed issues
+
+### `munin-zero#6` — v3c closure of v3b 0/6 lexical failures
+
+Closed by commit
+`ad4baff8b906065679144185af3e02ee632d9d28`
+(2026-04-20 22:17:54 +0200). Outcome: **5/6 hit@20 (lexical)** vs the
+v3b lexical 0/6 baseline, on the same snapshot as v3b, after the FTS5
+camelCase tokenizer fix landed. T10 remained a miss and is tracked as
+gap-002.
+
+The closure record pins all five evidence artifacts by sha256:
+
+- `pilot-report-v3c.md` (report)
+- `pilot-intents-v3c.jsonl` (six closure intents)
+- `pilot-queries-v3c-sonnet.jsonl` (six Sonnet-formulated queries)
+- `pilot-results-v3c-lexical.jsonl` (six retrieval-run results, top-20)
+- `pilot-targets-v3.jsonl` (target file holding the six target UUIDs)
+
+The six target UUIDs are recorded as
+`closed_issues["munin-zero#6"].target_uuid_subset` so a reader can verify
+ranks without re-running the experiment.
+
+## 10. How to add a new source
+
+1. Compute `sha256` of the source file (and any companion target/result
+   files).
+2. Add a new entry to `sources[]` with at minimum `id`, `repo`, `path`,
+   `sha256`, `record_count`, `source_class`, `tier`, `shape`,
+   `ground_truth_kind`, and `notes`. Add `target_path` / `result_paths[]`
+   if the source ships separate target or result files.
+3. If the source inherits strata from a parent target set, set
+   `strata_breakdown.inherits_from` to the parent `source_id`.
+4. Re-run `npm test -- retrieval-manifest` and update
+   `derived_*_record_count` totals.
+5. Add a row to the table in §5 above.
+
+## 11. Versioning policy
+
+- Additive changes (new sources, new strata in existing breakdowns, new
+  gaps, new closed issues) do **not** bump `manifest_version`.
+- Breaking changes (removing a source, changing `source_class` /
+  `ground_truth_kind` semantics, changing `record_key_fields` for an
+  existing source) bump the major version.
+- Bumping the major version requires a migration note in
+  `CHANGELOG.md` and a parallel `retrieval-vN.manifest.json` while
+  consumers move over.
+
+## 12. Relationship to future work
+
+- **Artifact 3** (≥50 human-audited relevance-graded cases) will sit on
+  top of this manifest but will live in its own file. It is **not**
+  introduced here.
+- **PR 2** (extend `benchmark/runner.ts` for production-ranker + #19)
+  consumes the native JSONLs directly; it does not need this manifest at
+  runtime. The manifest is for humans and lineage tooling.

--- a/benchmark/queries/retrieval-v1.manifest.md
+++ b/benchmark/queries/retrieval-v1.manifest.md
@@ -160,13 +160,15 @@ v3b lexical 0/6 baseline, on the same snapshot as v3b, after the FTS5
 camelCase tokenizer fix landed. T10 remained a miss and is tracked as
 gap-002.
 
-The closure record pins all five evidence artifacts by sha256:
+The closure record pins all evidence artifacts by sha256:
 
-- `pilot-report-v3c.md` (report)
+- `pilot-report-v3c.md` (closure report)
 - `pilot-intents-v3c.jsonl` (six closure intents)
 - `pilot-queries-v3c-sonnet.jsonl` (six Sonnet-formulated queries)
 - `pilot-results-v3c-lexical.jsonl` (six retrieval-run results, top-20)
 - `pilot-targets-v3.jsonl` (target file holding the six target UUIDs)
+- `pilot-report-v3b.md` (baseline report — context for the 0/6 claim)
+- `pilot-results-v3b-lexical.jsonl` (baseline lexical results — substantiates the "vs 0/6" comparison)
 
 The six target UUIDs are recorded as
 `closed_issues["munin-zero#6"].target_uuid_subset` so a reader can verify
@@ -188,16 +190,48 @@ ranks without re-running the experiment.
 
 ## 11. Versioning policy
 
-- Additive changes (new sources, new strata in existing breakdowns, new
-  gaps, new closed issues) do **not** bump `manifest_version`.
-- Breaking changes (removing a source, changing `source_class` /
-  `ground_truth_kind` semantics, changing `record_key_fields` for an
-  existing source) bump the major version.
-- Bumping the major version requires a migration note in
-  `CHANGELOG.md` and a parallel `retrieval-vN.manifest.json` while
-  consumers move over.
+The eight `sources[]` entries are the **v1 freeze**. The validator test
+enforces the exact set, so this is mechanically tested, not just
+documented.
 
-## 12. Relationship to future work
+- Patch (`1.0.x`): metadata-only changes that keep the same set of
+  sources, the same record counts, and the same target/result paths
+  (e.g. clarifying notes, gap status updates, evidence_paths
+  corrections that do not add a new source).
+- Minor (`1.x.0`): additive changes that affect the v1 freeze — adding
+  a new source, recording new result_paths for an existing source, or
+  introducing a new known_gap. The validator's `EXPECTED_V1_SOURCE_IDS`
+  list must be updated in the same change.
+- Major (`x.0.0`): breaking changes (removing a source, changing
+  `source_class` / `ground_truth_kind` semantics, changing
+  `record_key_fields` for an existing source, or restructuring the JSON
+  schema). Major bumps require a migration note in `CHANGELOG.md` and a
+  parallel `retrieval-vN.manifest.json` while consumers move over.
+
+In all cases, update `CHANGELOG.md` and the §5 source table in this
+file in the same commit as the JSON change.
+
+## 12. Maintenance
+
+**Owner:** the same person maintaining `benchmark/queries/*.jsonl` and
+the munin-zero retrieval pilots (currently Magnus). Three triggers
+require touching this manifest:
+
+1. A native JSONL changes (records added, removed, or reordered).
+   Re-run `npm test -- retrieval-manifest`; failing sha256 / line-count
+   assertions will name the file. Update `sha256`, `record_count`, and
+   any affected `strata_breakdown` in the JSON, and the §5 table here.
+2. A new munin-zero pilot artifact is produced. Add it to `sources[]`
+   if it joins the v1 freeze (and bump the minor version per §11);
+   otherwise list it under `omitted_artifacts[]` with a reason.
+3. An issue tracked under `closed_issues[]` reopens or its evidence
+   path changes. Update the entry and its `evidence_sha256` map.
+
+The JSON file is the single machine source of truth. The markdown
+mirrors what the JSON says — when they conflict, the JSON wins and the
+markdown gets a follow-up fix.
+
+## 13. Relationship to future work
 
 - **Artifact 3** (≥50 human-audited relevance-graded cases) will sit on
   top of this manifest but will live in its own file. It is **not**

--- a/tests/retrieval-manifest.test.ts
+++ b/tests/retrieval-manifest.test.ts
@@ -9,8 +9,11 @@ const MANIFEST_PATH = join(
   "benchmark/queries/retrieval-v1.manifest.json",
 );
 
-// Single source of truth for the v1 freeze. If you intentionally add or
-// remove a source, update this list AND bump the relevant counts below.
+// Test-side mirror of the v1 freeze. The JSON manifest is the source of
+// truth (see retrieval-v1.manifest.md §11); this list is a duplicated
+// guard so a silent edit to the JSON can't pass review without also
+// touching the test. If you intentionally add or remove a source, update
+// this list AND bump the relevant counts below.
 const EXPECTED_V1_SOURCE_IDS = [
   "munin-native-baseline",
   "munin-native-baseline-claude",

--- a/tests/retrieval-manifest.test.ts
+++ b/tests/retrieval-manifest.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, join } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const MANIFEST_PATH = join(
+  REPO_ROOT,
+  "benchmark/queries/retrieval-v1.manifest.json",
+);
+
+// Single source of truth for the v1 freeze. If you intentionally add or
+// remove a source, update this list AND bump the relevant counts below.
+const EXPECTED_V1_SOURCE_IDS = [
+  "munin-native-baseline",
+  "munin-native-baseline-claude",
+  "munin-native-example",
+  "munin-zero-v2-intents",
+  "munin-zero-v3-intents",
+  "munin-zero-v3b-queries-sonnet",
+  "munin-zero-v3c-intents",
+  "munin-zero-v3c-queries-sonnet",
+] as const;
+
+const VALID_SOURCE_CLASS = new Set(["manual", "derived", "synthetic"]);
+const VALID_TIER = new Set(["primary", "evidence", "deprecated"]);
+const VALID_GROUND_TRUTH_KIND = new Set([
+  "expected_ids",
+  "expected_namespaces",
+  "both",
+  "targets_external",
+]);
+const VALID_GAP_STATUS = new Set([
+  "open",
+  "in_progress",
+  "blocked",
+  "deferred",
+  "closed",
+  "documented",
+]);
+
+const MUNIN_ZERO_COMMIT = "ad4baff8b906065679144185af3e02ee632d9d28";
+
+interface SourceEntry {
+  id: string;
+  repo: string;
+  path: string;
+  sha256?: string;
+  record_count: number;
+  source_class: string;
+  tier: string;
+  shape: string;
+  ground_truth_kind: string;
+  ground_truth_breakdown?: Record<string, number>;
+  target_set_id?: string;
+  target_path?: string;
+  target_sha256?: string;
+  target_id_field?: string;
+  target_count?: number;
+  target_subset?: unknown[];
+  target_uuid_subset?: string[];
+  result_paths?: Array<{
+    path: string;
+    sha256?: string;
+    search_mode: string;
+    limit: number | null;
+    metric: string;
+    record_count: number;
+  }>;
+  evaluation_method?: Record<string, unknown>;
+  strata_breakdown?: Record<string, unknown>;
+  search_modes?: string[];
+  notes?: string;
+  anomalies?: unknown[];
+}
+
+interface Manifest {
+  manifest_version: string;
+  manifest_id: string;
+  manifest_kind: string;
+  created_at: string;
+  created_by: string;
+  purpose: string;
+  citation_format: string;
+  record_key_fields: Record<string, string>;
+  source_repos: Array<{
+    name: string;
+    role: string;
+    commit_sha: string;
+  }>;
+  sources: SourceEntry[];
+  strata_definitions: Record<string, unknown>;
+  dedupe_policy: { principle: string; rules: string[] };
+  known_gaps: Array<{ id: string; summary: string; status: string }>;
+  closed_issues: Record<
+    string,
+    {
+      closing_commit: string;
+      closing_commit_short?: string;
+      closed_at: string;
+      summary: string;
+      evidence_paths: string[];
+      evidence_sha256?: Record<string, string>;
+    }
+  >;
+  omitted_artifacts: Array<{ path: string; reason: string }>;
+  derived_total_record_count: number;
+  derived_munin_native_record_count: number;
+  derived_munin_zero_record_count: number;
+}
+
+interface Rule {
+  id: string;
+  message: string;
+}
+
+/**
+ * Pure validation helper. Returns a list of rule violations. An empty
+ * list means the manifest passes. Used by both the positive test (must
+ * be empty) and the negative tests (clone, mutate, assert specific rule
+ * fires).
+ */
+export function validateManifest(obj: unknown): Rule[] {
+  const failures: Rule[] = [];
+  const fail = (id: string, message: string) =>
+    failures.push({ id, message });
+
+  if (!obj || typeof obj !== "object") {
+    fail("M-STRUCT", "manifest is not an object");
+    return failures;
+  }
+  const m = obj as Manifest;
+
+  // -- top-level required keys --------------------------------------
+  const required: Array<keyof Manifest> = [
+    "manifest_version",
+    "manifest_id",
+    "manifest_kind",
+    "created_at",
+    "purpose",
+    "citation_format",
+    "record_key_fields",
+    "source_repos",
+    "sources",
+    "strata_definitions",
+    "dedupe_policy",
+    "known_gaps",
+    "closed_issues",
+    "omitted_artifacts",
+    "derived_total_record_count",
+    "derived_munin_native_record_count",
+    "derived_munin_zero_record_count",
+  ];
+  for (const key of required) {
+    if (!(key in m)) fail("M-REQ", `missing top-level key: ${String(key)}`);
+  }
+
+  // -- semver -------------------------------------------------------
+  if (typeof m.manifest_version !== "string" || !/^\d+\.\d+\.\d+$/.test(m.manifest_version)) {
+    fail("M-SEMVER", `manifest_version not semver: ${m.manifest_version}`);
+  }
+  if (m.manifest_id !== "retrieval-v1") {
+    fail("M-ID", `manifest_id must be "retrieval-v1", got ${m.manifest_id}`);
+  }
+  if (m.manifest_kind !== "source_index") {
+    fail("M-KIND", `manifest_kind must be "source_index", got ${m.manifest_kind}`);
+  }
+
+  // -- source_repos -------------------------------------------------
+  if (!Array.isArray(m.source_repos)) {
+    fail("R-ARRAY", "source_repos must be an array");
+  } else {
+    const zero = m.source_repos.find((r) => r.name === "munin-zero");
+    if (!zero) fail("R-ZERO", "source_repos missing munin-zero");
+    else if (zero.commit_sha !== MUNIN_ZERO_COMMIT) {
+      fail(
+        "R-ZERO-SHA",
+        `munin-zero commit_sha must be ${MUNIN_ZERO_COMMIT}, got ${zero.commit_sha}`,
+      );
+    } else if (!/^[0-9a-f]{40}$/.test(zero.commit_sha)) {
+      fail("R-ZERO-SHA-SHAPE", "munin-zero commit_sha is not a 40-char hex");
+    }
+    const native = m.source_repos.find((r) => r.name === "munin-memory");
+    if (!native) fail("R-NATIVE", "source_repos missing munin-memory");
+  }
+
+  // -- sources[] ----------------------------------------------------
+  if (!Array.isArray(m.sources) || m.sources.length === 0) {
+    fail("S-EMPTY", "sources[] must be a non-empty array");
+  } else {
+    const ids = m.sources.map((s) => s.id);
+    // exact set match for the v1 freeze
+    const idSet = new Set(ids);
+    for (const expected of EXPECTED_V1_SOURCE_IDS) {
+      if (!idSet.has(expected)) {
+        fail("S-MISSING", `sources[] missing expected v1 id: ${expected}`);
+      }
+    }
+    for (const got of ids) {
+      if (!EXPECTED_V1_SOURCE_IDS.includes(got as never)) {
+        fail("S-EXTRA", `sources[] contains unexpected v1 id: ${got}`);
+      }
+    }
+    // uniqueness
+    if (new Set(ids).size !== ids.length) {
+      fail("S-DUPE", "sources[].id values must be unique");
+    }
+
+    for (const s of m.sources) {
+      const requiredKeys: Array<keyof SourceEntry> = [
+        "id",
+        "repo",
+        "path",
+        "record_count",
+        "source_class",
+        "tier",
+        "shape",
+        "ground_truth_kind",
+        "notes",
+      ];
+      for (const k of requiredKeys) {
+        if (s[k] === undefined || s[k] === null || s[k] === "") {
+          fail("S-FIELD", `${s.id}: missing/empty ${String(k)}`);
+        }
+      }
+      if (!VALID_SOURCE_CLASS.has(s.source_class)) {
+        fail("S-CLASS", `${s.id}: invalid source_class=${s.source_class}`);
+      }
+      if (!VALID_TIER.has(s.tier)) {
+        fail("S-TIER", `${s.id}: invalid tier=${s.tier}`);
+      }
+      if (!VALID_GROUND_TRUTH_KIND.has(s.ground_truth_kind)) {
+        fail("S-GTK", `${s.id}: invalid ground_truth_kind=${s.ground_truth_kind}`);
+      }
+      // every source needs a sha256
+      if (!s.sha256 || !/^[0-9a-f]{64}$/.test(s.sha256)) {
+        fail("S-SHA", `${s.id}: missing or malformed sha256`);
+      }
+      // targets_external => target_path + target_sha256 + target_id_field + target_count
+      if (s.ground_truth_kind === "targets_external") {
+        if (!s.target_path) fail("S-TGT-PATH", `${s.id}: targets_external requires target_path`);
+        if (!s.target_sha256 || !/^[0-9a-f]{64}$/.test(s.target_sha256 ?? "")) {
+          fail("S-TGT-SHA", `${s.id}: targets_external requires target_sha256`);
+        }
+        if (!s.target_id_field) {
+          fail("S-TGT-FIELD", `${s.id}: targets_external requires target_id_field`);
+        }
+        if (typeof s.target_count !== "number" || s.target_count <= 0) {
+          fail("S-TGT-COUNT", `${s.id}: targets_external requires positive target_count`);
+        }
+      }
+      // result_paths[] integrity
+      if (s.result_paths) {
+        for (const rp of s.result_paths) {
+          if (!rp.path || !rp.search_mode || !rp.metric) {
+            fail("S-RP-FIELD", `${s.id}: result_paths entry missing required field`);
+          }
+          if (!rp.sha256 || !/^[0-9a-f]{64}$/.test(rp.sha256)) {
+            fail("S-RP-SHA", `${s.id}: result_paths entry missing sha256`);
+          }
+          if (typeof rp.record_count !== "number" || rp.record_count < 0) {
+            fail("S-RP-COUNT", `${s.id}: result_paths entry needs record_count`);
+          }
+        }
+      }
+    }
+  }
+
+  // -- record_key_fields covers every source ------------------------
+  if (m.sources && m.record_key_fields) {
+    for (const s of m.sources) {
+      if (!m.record_key_fields[s.id]) {
+        fail("M-RKF", `record_key_fields missing entry for ${s.id}`);
+      }
+    }
+  }
+
+  // -- derived totals ----------------------------------------------
+  if (Array.isArray(m.sources)) {
+    const total = m.sources.reduce((acc, s) => acc + (s.record_count || 0), 0);
+    if (total !== m.derived_total_record_count) {
+      fail(
+        "D-TOTAL",
+        `derived_total_record_count=${m.derived_total_record_count}, computed=${total}`,
+      );
+    }
+    const nativeTotal = m.sources
+      .filter((s) => s.repo === "munin-memory")
+      .reduce((acc, s) => acc + (s.record_count || 0), 0);
+    if (nativeTotal !== m.derived_munin_native_record_count) {
+      fail(
+        "D-NATIVE",
+        `derived_munin_native_record_count=${m.derived_munin_native_record_count}, computed=${nativeTotal}`,
+      );
+    }
+    if (nativeTotal !== 34) {
+      fail("D-NATIVE-34", `munin-native total must be 34, got ${nativeTotal}`);
+    }
+    const zeroTotal = m.sources
+      .filter((s) => s.repo === "munin-zero")
+      .reduce((acc, s) => acc + (s.record_count || 0), 0);
+    if (zeroTotal !== m.derived_munin_zero_record_count) {
+      fail(
+        "D-ZERO",
+        `derived_munin_zero_record_count=${m.derived_munin_zero_record_count}, computed=${zeroTotal}`,
+      );
+    }
+  }
+
+  // -- closed_issues ------------------------------------------------
+  const issue = m.closed_issues?.["munin-zero#6"];
+  if (!issue) {
+    fail("C-ISSUE", "closed_issues missing munin-zero#6");
+  } else {
+    if (!/^[0-9a-f]{40}$/.test(issue.closing_commit ?? "")) {
+      fail("C-SHA", `closed_issues[munin-zero#6].closing_commit must be 40-char hex`);
+    }
+    if (issue.closing_commit_short && issue.closing_commit?.slice(0, 7) !== issue.closing_commit_short) {
+      fail("C-SHORT", "closing_commit_short must equal first 7 chars of closing_commit");
+    }
+    if (!Array.isArray(issue.evidence_paths) || issue.evidence_paths.length === 0) {
+      fail("C-EV", "closed_issues evidence_paths must be a non-empty array");
+    } else {
+      const need = [
+        "pilot-report-v3c.md",
+        "pilot-intents-v3c.jsonl",
+        "pilot-queries-v3c-sonnet.jsonl",
+        "pilot-results-v3c-lexical.jsonl",
+        "pilot-targets-v3.jsonl",
+      ];
+      for (const tail of need) {
+        if (!issue.evidence_paths.some((p) => p.endsWith(tail))) {
+          fail("C-EV-MISSING", `closed_issues evidence_paths missing artifact ending in ${tail}`);
+        }
+      }
+      if (issue.evidence_sha256) {
+        for (const p of issue.evidence_paths) {
+          if (!issue.evidence_sha256[p] || !/^[0-9a-f]{64}$/.test(issue.evidence_sha256[p])) {
+            fail("C-EV-SHA", `closed_issues evidence_sha256 missing or malformed for ${p}`);
+          }
+        }
+      } else {
+        fail("C-EV-SHA-MAP", "closed_issues missing evidence_sha256 map");
+      }
+    }
+  }
+
+  // -- known_gaps ---------------------------------------------------
+  if (Array.isArray(m.known_gaps)) {
+    if (m.known_gaps.length === 0) {
+      fail("G-EMPTY", "known_gaps[] must not be empty (v1 has documented gaps)");
+    }
+    for (const g of m.known_gaps) {
+      if (!g.id || !g.summary) fail("G-FIELD", `known_gap ${g.id ?? "?"} missing fields`);
+      if (!VALID_GAP_STATUS.has(g.status)) {
+        fail("G-STATUS", `known_gap ${g.id}: invalid status=${g.status}`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+function sha256OfFile(absPath: string): string {
+  const buf = readFileSync(absPath);
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function countLines(absPath: string): number {
+  const buf = readFileSync(absPath, "utf8");
+  if (buf.length === 0) return 0;
+  // Treat trailing newline as line terminator, not extra line.
+  const trimmed = buf.endsWith("\n") ? buf.slice(0, -1) : buf;
+  if (trimmed.length === 0) return 0;
+  return trimmed.split("\n").length;
+}
+
+describe("retrieval-v1 manifest", () => {
+  const raw = readFileSync(MANIFEST_PATH, "utf8");
+  const manifest = JSON.parse(raw) as Manifest;
+
+  it("parses as JSON", () => {
+    expect(manifest).toBeTruthy();
+    expect(manifest.manifest_id).toBe("retrieval-v1");
+  });
+
+  it("passes all validation rules", () => {
+    const failures = validateManifest(manifest);
+    expect(failures, JSON.stringify(failures, null, 2)).toEqual([]);
+  });
+
+  it("contains exactly the eight v1 sources", () => {
+    const ids = manifest.sources.map((s) => s.id).sort();
+    expect(ids).toEqual([...EXPECTED_V1_SOURCE_IDS].sort());
+  });
+
+  it("derived totals are correct", () => {
+    expect(manifest.derived_total_record_count).toBe(176);
+    expect(manifest.derived_munin_native_record_count).toBe(34);
+    expect(manifest.derived_munin_zero_record_count).toBe(142);
+  });
+
+  it("v3c closure evidence covers report + intents + queries + results + targets", () => {
+    const ev = manifest.closed_issues["munin-zero#6"].evidence_paths;
+    expect(ev.some((p) => p.endsWith("pilot-report-v3c.md"))).toBe(true);
+    expect(ev.some((p) => p.endsWith("pilot-intents-v3c.jsonl"))).toBe(true);
+    expect(ev.some((p) => p.endsWith("pilot-queries-v3c-sonnet.jsonl"))).toBe(true);
+    expect(ev.some((p) => p.endsWith("pilot-results-v3c-lexical.jsonl"))).toBe(true);
+    expect(ev.some((p) => p.endsWith("pilot-targets-v3.jsonl"))).toBe(true);
+  });
+
+  describe("native JSONL on-disk verification", () => {
+    const nativeSources = (m: Manifest) => m.sources.filter((s) => s.repo === "munin-memory");
+
+    it("line count matches record_count for every native source", () => {
+      for (const s of nativeSources(manifest)) {
+        const abs = join(REPO_ROOT, s.path);
+        expect(statSync(abs).isFile(), `${s.path} not a file`).toBe(true);
+        const lines = countLines(abs);
+        expect(lines, `${s.id} line count`).toBe(s.record_count);
+      }
+    });
+
+    it("sha256 matches actual file contents for every native source", () => {
+      for (const s of nativeSources(manifest)) {
+        const abs = join(REPO_ROOT, s.path);
+        expect(sha256OfFile(abs), `${s.id} sha256`).toBe(s.sha256);
+      }
+    });
+
+    it("every native record parses as BenchmarkQuery with matching source field", () => {
+      for (const s of nativeSources(manifest)) {
+        const abs = join(REPO_ROOT, s.path);
+        const text = readFileSync(abs, "utf8").trim();
+        const records = text.split("\n").map((line) => JSON.parse(line));
+        for (const r of records) {
+          // BenchmarkQuery shape (subset of required fields).
+          expect(typeof r.id, `${s.id} id`).toBe("string");
+          expect(typeof r.query, `${s.id} ${r.id} query`).toBe("string");
+          expect(["manual", "derived", "synthetic"]).toContain(r.source);
+          expect(typeof r.category, `${s.id} ${r.id} category`).toBe("string");
+          expect(typeof r.search_mode, `${s.id} ${r.id} search_mode`).toBe("string");
+          // record-level source must match manifest's declared source_class.
+          expect(r.source, `${s.id} ${r.id} source mismatch`).toBe(s.source_class);
+          // ground truth field must match manifest's ground_truth_kind.
+          const hasIds = Array.isArray(r.expected_ids) && r.expected_ids.length > 0;
+          const hasNs = Array.isArray(r.expected_namespaces) && r.expected_namespaces.length > 0;
+          if (s.ground_truth_kind === "expected_ids") {
+            expect(hasIds, `${s.id} ${r.id} expected_ids required`).toBe(true);
+          } else if (s.ground_truth_kind === "expected_namespaces") {
+            expect(hasNs, `${s.id} ${r.id} expected_namespaces required`).toBe(true);
+          } else if (s.ground_truth_kind === "both") {
+            expect(hasIds || hasNs, `${s.id} ${r.id} needs either expected_ids or expected_namespaces`).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
+  // Negative tests: clone the manifest, mutate it, confirm the right
+  // rule fires. Each test must produce at least one failure that names
+  // the corresponding rule prefix.
+  describe("validateManifest catches violations", () => {
+    function clone(): Manifest {
+      return JSON.parse(JSON.stringify(manifest)) as Manifest;
+    }
+
+    it("rejects invalid source_class", () => {
+      const m = clone();
+      (m.sources[0] as SourceEntry).source_class = "evidence";
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "S-CLASS")).toBe(true);
+    });
+
+    it("rejects duplicate source ids", () => {
+      const m = clone();
+      m.sources[1].id = m.sources[0].id;
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "S-DUPE")).toBe(true);
+    });
+
+    it("rejects derived_total_record_count drift", () => {
+      const m = clone();
+      m.derived_total_record_count = m.derived_total_record_count + 1;
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "D-TOTAL")).toBe(true);
+    });
+
+    it("rejects missing v3c result evidence", () => {
+      const m = clone();
+      m.closed_issues["munin-zero#6"].evidence_paths = m.closed_issues[
+        "munin-zero#6"
+      ].evidence_paths.filter((p) => !p.endsWith("pilot-results-v3c-lexical.jsonl"));
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "C-EV-MISSING")).toBe(true);
+    });
+
+    it("rejects missing target_path on a targets_external source", () => {
+      const m = clone();
+      const ext = m.sources.find((s) => s.ground_truth_kind === "targets_external");
+      if (!ext) throw new Error("test fixture: no targets_external source");
+      delete ext.target_path;
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "S-TGT-PATH")).toBe(true);
+    });
+
+    it("rejects wrong munin-zero commit SHA", () => {
+      const m = clone();
+      const z = m.source_repos.find((r) => r.name === "munin-zero")!;
+      z.commit_sha = "0".repeat(40);
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "R-ZERO-SHA")).toBe(true);
+    });
+
+    it("rejects an unknown gap status", () => {
+      const m = clone();
+      m.known_gaps[0].status = "lol";
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "G-STATUS")).toBe(true);
+    });
+
+    it("rejects an extra source id beyond the v1 freeze", () => {
+      const m = clone();
+      m.sources.push({
+        ...m.sources[0],
+        id: "munin-zero-something-else",
+      });
+      // Re-jig derived totals so we isolate S-EXTRA.
+      m.derived_total_record_count += m.sources[0].record_count;
+      m.derived_munin_zero_record_count = m.sources
+        .filter((s) => s.repo === "munin-zero")
+        .reduce((a, s) => a + s.record_count, 0);
+      m.derived_munin_native_record_count = m.sources
+        .filter((s) => s.repo === "munin-memory")
+        .reduce((a, s) => a + s.record_count, 0);
+      const f = validateManifest(m);
+      expect(f.some((r) => r.id === "S-EXTRA")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `benchmark/queries/retrieval-v1.manifest.{json,md}` — a curated v1 source index that reconciles the three munin-native query JSONLs (34 records) with the munin-zero retrieval pilot artifacts (v2/v3/v3b/v3c, 142 records) pinned at commit `ad4baff`. Records `munin-zero#6` as closed by pilot v3c with full sha256-pinned evidence.

This is PR 1 of the quality-metrics workstream (#28-adjacent). It only adds files; no JSONL, runner, scorer, or adapter is modified.

## What this manifest is (and is not)

- **Is:** a citation/provenance index over eight first-class sources, with sha256 pins, target/result metadata, evaluation method, and a closed-issue record for `munin-zero#6`.
- **Is not:** a runner input, a deduped label set, or a relevance-grade store. The runner still consumes the native JSONLs directly.

## Key design choices (after Codex REQUEST_REVISIONS)

- `source_class` is strictly `manual|derived|synthetic` to match the existing `BenchmarkQuery.source` enum in `benchmark/types.ts`. Editorial role lives in `tier` (`primary|evidence|deprecated`) instead.
- `targets_external` sources carry `target_set_id`, `target_path`, `target_sha256`, `target_id_field`, `target_count`, plus `result_paths[]` with `search_mode`, `limit`, `metric`, `record_count`, and an `evaluation_method` block. The v3c closure evidence list pins all five artifacts (report, intents, queries, results, targets) and records the six target UUIDs inline.
- `strata_breakdown` propagates real `entry_type` / `stratum` / `difficulty` / `language` values from the v3 targets file (it does *not* claim those are absent).
- The eight-source list is framed as the **v1 freeze**; everything cited but not indexed (per-model v2 queries, v3 sonnet queries, summaries, legacy un-versioned files, scoring methodology notes) is enumerated under `omitted_artifacts[]` with explicit reasons.
- `citation_format` and `record_key_fields` tell consumers how to dereference records.

## Validator (`tests/retrieval-manifest.test.ts`)

16 tests, including 7 negative tests. Highlights:

- Asserts the **exact** v1 source ID set (rejects unknown additions).
- Parses every native JSONL line against the `BenchmarkQuery` shape, cross-checks the record-level `source` field against the manifest's `source_class`, and validates `ground_truth_kind` against actual `expected_ids` / `expected_namespaces` usage.
- Verifies sha256 pins on disk for every native source.
- Requires sha256 + `target_id_field` + `target_count` on `targets_external` sources; sha256 + `record_count` on every `result_paths` entry; sha256 + `evidence_paths` covering report/intents/queries/results/targets for the v3c closure.
- Negative tests: invalid `source_class`, duplicate IDs, derived total drift, missing v3c result evidence, missing `target_path`, wrong munin-zero SHA, unknown gap status, unexpected v1 source.

CI does not check out the sibling `munin-zero` repo; sha256 pins are the contract.

## Test plan

```
npm test
# 1108 passed, 3 skipped (33 test files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)