### PR TITLE
feat(benchmark): production_ranker runner mode + parity tests (PR 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ changelog is the canonical record of what moved.
 
 ### Added
 
+- **Benchmark `production_ranker` mode (PR 2b).** The benchmark runner
+  now offers a second code path that runs results through the same
+  pipeline `memory_query` uses in production: canonical reference
+  injection, attention/triage injection, completed-task filtering, and
+  `rerankQueryResults` with heuristic + freshness scoring — sliced to
+  the user-facing limit. Opt in with `runnerMode: "production_ranker"`
+  on `runBenchmark`, or `--runner-mode production_ranker` on the
+  LongMemEval / LoCoMo adapter CLIs. Fails loud when the snapshot
+  schema is too old for the rerank pipeline (need v5+); pass
+  `fallbackRunnerMode: "raw"` to opt into a silent downgrade with a
+  `warnings[]` entry. New report fields: `runner_mode_requested`
+  (always present, equal to `runner_mode` for non-degraded runs);
+  `search_recency_weight` (number for `production_ranker`, `null` for
+  `raw` — `0` would falsely imply "rerank ran with zero recency");
+  `principal_id: "owner"` reserved for a future multi-principal
+  benchmarking mode. New tests: `tests/runner-parity.test.ts` asserts
+  the runner's `production_ranker` top-k IDs match what
+  `memory_query` returns for the same DB and query (4 corpus shapes:
+  tracked-status, canonical-injection, decision-lookup, and the
+  relaxed-lexical fallback path) plus 4 prereq-handling cases;
+  `tests/benchmark-import-boundary.test.ts` pins the curated set of
+  names the benchmark surface is allowed to import from `src/tools.ts`
+  so the boundary survives until issue #59 extracts the rerank
+  pipeline into a dedicated module. The runner's per-query
+  `executeQuery` now returns full `Entry[]` (not just IDs) so the
+  caller picks the projection — IDs+namespaces for raw, full entries
+  for the production reranker. PR 2a's `runner_mode` field gains its
+  second value: previously always `"raw"`, now `"production_ranker"`
+  when the new path is selected. Issue #59 tracks the planned
+  follow-up that moves the exported reranker names into
+  `src/internal/reranker.ts`.
 - **Benchmark instrumentation (PR 2a — report schema v2).** Reports
   produced by `benchmark/runner.ts` now carry a `report_schema_version: 2`
   tag and additive fields on top of the existing v1 shape: top-20 scoring

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -77,12 +77,24 @@ revisions; consumers should branch on it before reading new fields.
 - `snapshot_schema_version` — DB migration version of the snapshot used
   for the run. `schema_version` is kept for one release as a deprecated
   alias and mirrors this value.
-- `runner_mode` — which runner code path produced the numbers. `"raw"`
-  calls `src/db.ts` query functions directly (faster, no rerank, no
-  injectors). `"production_ranker"` (added in PR 2b) additionally runs
-  results through `rerankQueryResults` + canonical/attention injectors
-  + completed-task filter, matching `memory_query`. PR 2a always emits
-  `"raw"`.
+- `runner_mode` — which runner code path actually produced the numbers.
+  `"raw"` calls `src/db.ts` query functions directly (faster, no rerank,
+  no injectors). `"production_ranker"` (PR 2b) over-fetches per source
+  by `QUERY_RERANK_OVERFETCH_MULTIPLIER` and runs results through the
+  same canonical/attention injectors + `rerankQueryResults` +
+  completed-task filter that `memory_query` uses, then slices to the
+  requested limit. Select via `runnerMode` on `runBenchmark` or
+  `--runner-mode` on the adapter CLIs.
+- `runner_mode_requested` (PR 2b) — what the caller asked for. Equal to
+  `runner_mode` for non-degraded runs. When they differ, the runner
+  downgraded — `warnings[]` carries the reason.
+- `search_recency_weight` (PR 2b) — recency weight applied during
+  reranking. Number for `production_ranker` (default `0.2`); `null` for
+  `raw` because the reranker is skipped entirely.
+- `principal_id` (PR 2b) — always `"owner"` today. Benchmarks run with
+  full owner access and skip `filterByAccess`. Reserved so a future
+  multi-principal benchmarking mode can change this without a schema
+  bump.
 - `query_set_sources` — per-file lineage: path, filename, record_count,
   raw-bytes SHA-256, byte size, optional `manifest_source_id`, and
   `manifest_match` outcome (`matched` | `filename_match_sha_mismatch` |
@@ -119,6 +131,22 @@ SHA mismatch is recorded as a `warnings[]` entry and reflected in
 `manifest_match: "filename_match_sha_mismatch"`. It is not an error —
 local edits during ablations are expected. The load-bearing guardrail
 is the separate manifest CI test in `tests/retrieval-manifest.test.ts`.
+
+### `production_ranker` prereqs and fallback
+
+`production_ranker` mode reads columns added in schema v5
+(`entries.owner_principal_id`, `classification`, `valid_until`). Running
+against an older snapshot is **fail-loud** by default — `runBenchmark`
+throws with the missing-prereq reason. To opt into a silent downgrade
+that emits a `warnings[]` entry and falls back to `runner_mode: "raw"`,
+pass `fallbackRunnerMode: "raw"`. In both cases `runner_mode_requested`
+preserves the original ask, so post-hoc consumers can detect the
+degraded run by comparing the two fields.
+
+The benchmark-import-boundary test (`tests/benchmark-import-boundary.test.ts`)
+pins the small curated surface the benchmark is allowed to import from
+`src/tools.ts`. Issue #59 tracks the planned extraction of that surface
+into `src/internal/reranker.ts`.
 
 ### Line endings
 

--- a/benchmark/adapters/locomo/run.ts
+++ b/benchmark/adapters/locomo/run.ts
@@ -4,10 +4,12 @@ import { buildLocomoArtifacts, type BuildMetadata, type BuildOptions } from "./b
 import { loadQueriesWithSource, runBenchmark, writeReport } from "../../runner.js";
 import { ensureSafeGeneratedPath, populateCorpusEmbeddings, type CorpusEmbeddingSummary } from "../shared.js";
 import type { SearchMode } from "../../../src/types.js";
+import type { RunnerMode } from "../../types.js";
 
 interface RunOptions extends BuildOptions {
   reportDir: string;
   reuseExisting: boolean;
+  runnerMode: RunnerMode;
 }
 
 function parseArgs(argv: string[]): RunOptions {
@@ -30,6 +32,13 @@ function parseArgs(argv: string[]): RunOptions {
   const granularity = (args.get("granularity") ?? "session") as BuildOptions["granularity"];
   const searchMode = (args.get("search-mode") ?? "lexical") as SearchMode;
   const includeAdversarial = flags.has("include-adversarial");
+  const runnerModeRaw = args.get("runner-mode") ?? "raw";
+  if (runnerModeRaw !== "raw" && runnerModeRaw !== "production_ranker") {
+    throw new Error(
+      `Invalid --runner-mode: ${runnerModeRaw}. Expected "raw" or "production_ranker".`,
+    );
+  }
+  const runnerMode: RunnerMode = runnerModeRaw;
   const suffix = granularity === "session" ? "locomo" : `locomo-${granularity}`;
   const outputBase = searchMode === "lexical"
     ? `benchmark/generated/${suffix}`
@@ -47,6 +56,7 @@ function parseArgs(argv: string[]): RunOptions {
     reportDir: resolve(args.get("report-dir") ?? "benchmark/reports"),
     limit: args.has("limit") ? Number(args.get("limit")) : undefined,
     reuseExisting: (args.get("reuse-existing") ?? "true") !== "false",
+    runnerMode,
   };
 }
 
@@ -102,6 +112,7 @@ async function main(): Promise<void> {
   const { queries, source } = loadQueriesWithSource(options.queryPath);
   const report = await runBenchmark(options.dbPath, queries, {
     querySetSources: [source],
+    runnerMode: options.runnerMode,
   });
   const reportPath = writeReport(report, options.reportDir);
 

--- a/benchmark/adapters/longmemeval/run.ts
+++ b/benchmark/adapters/longmemeval/run.ts
@@ -4,10 +4,12 @@ import { buildLongMemEvalArtifacts, type BuildMetadata, type BuildOptions } from
 import { loadQueriesWithSource, runBenchmark, writeReport } from "../../runner.js";
 import { ensureSafeGeneratedPath, populateCorpusEmbeddings, type CorpusEmbeddingSummary } from "../shared.js";
 import type { SearchMode } from "../../../src/types.js";
+import type { RunnerMode } from "../../types.js";
 
 interface RunOptions extends BuildOptions {
   reportDir: string;
   reuseExisting: boolean;
+  runnerMode: RunnerMode;
 }
 
 function parseArgs(argv: string[]): RunOptions {
@@ -28,6 +30,13 @@ function parseArgs(argv: string[]): RunOptions {
   const split = args.get("split") ?? "s";
   const granularity = (args.get("granularity") ?? "session") as BuildOptions["granularity"];
   const searchMode = (args.get("search-mode") ?? "lexical") as SearchMode;
+  const runnerModeRaw = args.get("runner-mode") ?? "raw";
+  if (runnerModeRaw !== "raw" && runnerModeRaw !== "production_ranker") {
+    throw new Error(
+      `Invalid --runner-mode: ${runnerModeRaw}. Expected "raw" or "production_ranker".`,
+    );
+  }
+  const runnerMode: RunnerMode = runnerModeRaw;
   const queryBase = granularity === "session"
     ? `benchmark/generated/longmemeval-${split}`
     : `benchmark/generated/longmemeval-${split}-${granularity}`;
@@ -48,6 +57,7 @@ function parseArgs(argv: string[]): RunOptions {
     reportDir: resolve(args.get("report-dir") ?? "benchmark/reports"),
     limit: args.has("limit") ? Number(args.get("limit")) : undefined,
     reuseExisting: (args.get("reuse-existing") ?? "true") !== "false",
+    runnerMode,
   };
 }
 
@@ -103,6 +113,7 @@ async function main(): Promise<void> {
   const { queries, source } = loadQueriesWithSource(options.queryPath);
   const report = await runBenchmark(options.dbPath, queries, {
     querySetSources: [source],
+    runnerMode: options.runnerMode,
   });
   const reportPath = writeReport(report, options.reportDir);
 

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -16,10 +16,21 @@ import {
   queryEntriesLexicalScored,
   queryEntriesHybridScored,
   queryEntriesSemanticScored,
+  getCompletedTaskNamespaces,
   setVecLoaded,
 } from "../src/db.js";
 import { generateEmbedding, embeddingToBuffer, initEmbeddings } from "../src/embeddings.js";
-import { buildRelaxedLexicalQuery } from "../src/tools.js";
+import {
+  buildRelaxedLexicalQuery,
+  QUERY_RERANK_OVERFETCH_MULTIPLIER,
+  DEFAULT_SEARCH_RECENCY_WEIGHT,
+  shouldApplyDefaultQuerySuppression,
+  getTrackedStatusAssessments,
+  injectCanonicalQueryEntries,
+  injectAttentionQueryEntries,
+  rerankQueryResults,
+} from "../src/tools.js";
+import type { Entry, QueryParams } from "../src/types.js";
 import {
   scoreQuery,
   aggregateScores,
@@ -284,6 +295,36 @@ export interface RunBenchmarkOptions {
    * populated. Pass `null` to explicitly skip even auto-detection.
    */
   manifestPath?: string | null;
+  /**
+   * Which runner code path to use. Defaults to `"raw"`.
+   *
+   * - `"raw"` — calls `src/db.ts` query functions directly with
+   *   `limit=10`. Faster, no rerank, no injectors. Useful for isolating
+   *   retrieval-recall changes from ranker behavior.
+   * - `"production_ranker"` — over-fetches by `QUERY_RERANK_OVERFETCH_MULTIPLIER`
+   *   and runs results through the same canonical/attention injectors +
+   *   `rerankQueryResults` + completed-task filter that `memory_query`
+   *   uses in production, then slices to the requested limit. End-to-end
+   *   parity with what production users see.
+   */
+  runnerMode?: RunnerMode;
+  /**
+   * Opt-in fallback when the prerequisites for `runnerMode` are not met
+   * (e.g. snapshot too old for `production_ranker`).
+   *
+   * Default behavior is fail-loud — the runner throws. Set
+   * `fallbackRunnerMode: "raw"` to instead downgrade with a
+   * `warnings[]` entry and emit `runner_mode: "raw"` /
+   * `runner_mode_requested: "production_ranker"` so post-hoc consumers
+   * can detect the degraded run.
+   */
+  fallbackRunnerMode?: "raw";
+  /**
+   * Recency weight passed into the production reranker. Defaults to
+   * `DEFAULT_SEARCH_RECENCY_WEIGHT` (0.2). Ignored in raw mode (no
+   * rerank). Range [0, 1].
+   */
+  searchRecencyWeight?: number;
 }
 
 /**
@@ -321,48 +362,43 @@ function scoreByNamespace(
 }
 
 /**
- * Run a single query through a specific search mode and return result IDs.
+ * Run a single query through a specific search mode and return the
+ * matching entries together with whether the relaxed-lexical fallback
+ * fired.
+ *
+ * Returns full `Entry` objects (not just IDs) so the caller can either
+ * project to IDs+namespaces (raw mode) or feed them through the
+ * production reranker pipeline (production_ranker mode). The previous
+ * IDs-only return shape was insufficient because the reranker needs the
+ * full entries.
+ *
+ * `limit` controls the per-source fetch size:
+ * - raw mode: pass the user-facing limit (typically 10)
+ * - production_ranker: pass `requestedLimit * QUERY_RERANK_OVERFETCH_MULTIPLIER`
+ *   (clamped to 50 by `queryEntriesLexicalScored` internally) so the
+ *   reranker has room to reorder.
  */
 async function executeQuery(
   db: Database.Database,
   query: string,
   mode: SearchMode,
   limit: number = 10,
-): Promise<{ ids: string[]; namespaces: string[]; relaxed: boolean }> {
+): Promise<{ entries: Entry[]; relaxed: boolean; effectiveMode: SearchMode }> {
   if (mode === "lexical") {
-    let results = queryEntriesLexicalScored(db, {
-      query,
-      limit,
-      includeExpired: true,
-    });
-    let relaxed = false;
-    // Mirror memory_query's production fallback: if strict AND-of-all-words
-    // returns nothing, retry with the relaxed OR-of-content-terms form.
-    // Without this, benchmark lexical numbers are artificially depressed
-    // for any corpus where documents are shorter than the query.
-    if (results.length === 0) {
-      const relaxedQuery = buildRelaxedLexicalQuery(query);
-      if (relaxedQuery) {
-        results = queryEntriesLexicalScored(db, {
-          query: relaxedQuery,
-          limit,
-          includeExpired: true,
-          rawFts5: true,
-        });
-        relaxed = results.length > 0;
-      }
-    }
-    return {
-      ids: results.map((r) => r.entry.id),
-      namespaces: results.map((r) => r.entry.namespace),
-      relaxed,
-    };
+    return runLexical(db, query, limit);
   }
 
   if (mode === "semantic") {
     const emb = await generateEmbedding(query);
     if (!emb) {
-      return { ids: [], namespaces: [], relaxed: false };
+      // Mirror memory_query's per-query semantic→lexical degradation
+      // (src/tools.ts:5828-5831): when embedding generation fails, fall
+      // back to lexical with the same strict-then-relaxed sequence so
+      // the report's actual_mode and the result IDs both stay parity
+      // with production. Previous behavior (return empty) was a silent
+      // divergence — M3 from the PR 2b internal review.
+      const fallback = await runLexical(db, query, limit);
+      return { ...fallback, effectiveMode: "lexical" };
     }
     const buf = embeddingToBuffer(emb);
     const results = queryEntriesSemanticScored(db, {
@@ -370,28 +406,17 @@ async function executeQuery(
       limit,
       includeExpired: true,
     });
-    return {
-      ids: results.map((r) => r.entry.id),
-      namespaces: results.map((r) => r.entry.namespace),
-      relaxed: false,
-    };
+    return { entries: results.map((r) => r.entry), relaxed: false, effectiveMode: "semantic" };
   }
 
   // hybrid
   const emb = await generateEmbedding(query);
   if (!emb) {
-    // Fall back to lexical (strict; no relaxed fallback here — matches
-    // production hybrid-when-embeddings-unavailable behavior)
-    const results = queryEntriesLexicalScored(db, {
-      query,
-      limit,
-      includeExpired: true,
-    });
-    return {
-      ids: results.map((r) => r.entry.id),
-      namespaces: results.map((r) => r.entry.namespace),
-      relaxed: false,
-    };
+    // memory_query degrades hybrid→lexical on embedding failure (strict
+    // first, then relaxed). Mirror it. Previously we ran strict-only
+    // without the relaxed fallback, which is a subtle parity gap.
+    const fallback = await runLexical(db, query, limit);
+    return { ...fallback, effectiveMode: "lexical" };
   }
   const buf = embeddingToBuffer(emb);
   const relaxedQuery = buildRelaxedLexicalQuery(query);
@@ -403,10 +428,130 @@ async function executeQuery(
       : undefined,
   });
   return {
-    ids: hybridScored.results.map((r) => r.entry.id),
-    namespaces: hybridScored.results.map((r) => r.entry.namespace),
+    entries: hybridScored.results.map((r) => r.entry),
     relaxed: hybridScored.ftsRelaxed,
+    effectiveMode: "hybrid",
   };
+}
+
+/**
+ * Run the lexical pipeline: strict FTS5 first, then the relaxed
+ * OR-of-content-terms fallback if strict returned nothing. Mirrors
+ * memory_query's lexical branch.
+ */
+function runLexical(
+  db: Database.Database,
+  query: string,
+  limit: number,
+): { entries: Entry[]; relaxed: boolean; effectiveMode: "lexical" } {
+  let results = queryEntriesLexicalScored(db, {
+    query,
+    limit,
+    includeExpired: true,
+  });
+  let relaxed = false;
+  if (results.length === 0) {
+    const relaxedQuery = buildRelaxedLexicalQuery(query);
+    if (relaxedQuery) {
+      results = queryEntriesLexicalScored(db, {
+        query: relaxedQuery,
+        limit,
+        includeExpired: true,
+        rawFts5: true,
+      });
+      relaxed = results.length > 0;
+    }
+  }
+  return { entries: results.map((r) => r.entry), relaxed, effectiveMode: "lexical" };
+}
+
+/**
+ * Replicate the production rerank pipeline from `src/tools.ts:5924-5936`,
+ * minus `filterByAccess` (the benchmark always runs as owner). Called
+ * per-query so `shouldApplyDefaultQuerySuppression` is evaluated against
+ * each query's params — caching the tracked-status / completed-task maps
+ * across queries would be incorrect because the predicate gate differs.
+ *
+ * The pipeline order is load-bearing:
+ *   1. Inject canonical entries (reference-index, magnus profile, …)
+ *   2. Inject blocked/attention statuses if the query is a triage query
+ *   3. Filter completed-task namespaces if default suppression applies
+ *   4. Rerank by heuristic + freshness, then slice to requestedLimit
+ *
+ * Any divergence from this order is a parity bug — the parity test in
+ * `tests/runner-parity.test.ts` is the safety net.
+ */
+function applyProductionReranker(
+  db: Database.Database,
+  rawResults: Entry[],
+  queryParams: QueryParams,
+  requestedLimit: number,
+): Entry[] {
+  // Memoize the gate predicate. Production memory_query gates on
+  // `shouldApplyDefaultQuerySuppression(...) || explain`; the benchmark
+  // always sets `explain: false`, so the `|| explain` branch is dead
+  // here. If that changes in the future, lift it back into the gate.
+  const applyDefaults = shouldApplyDefaultQuerySuppression(queryParams);
+
+  const trackedStatuses = applyDefaults ? getTrackedStatusAssessments(db) : undefined;
+
+  let results: Entry[] = injectCanonicalQueryEntries(db, rawResults, queryParams);
+  if (trackedStatuses) {
+    results = injectAttentionQueryEntries(results, queryParams, trackedStatuses);
+  }
+  const completedTasks = applyDefaults
+    ? getCompletedTaskNamespaces(db)
+    : new Set<string>();
+  return rerankQueryResults(results, queryParams, completedTasks, trackedStatuses).slice(
+    0,
+    requestedLimit,
+  );
+}
+
+/**
+ * Fail-loud prerequisite check for production_ranker mode.
+ *
+ * Production_ranker only runs against a snapshot whose schema is new
+ * enough to carry every column the rerank pipeline reads (canonical
+ * entries, tracked-status detection, completed-task namespaces). If
+ * something is missing we either throw (default) or downgrade to raw
+ * mode with a `warnings[]` entry (opt-in via `fallbackRunnerMode: "raw"`).
+ */
+function checkProductionRankerPrereqs(
+  db: Database.Database,
+  snapshotSchemaVersion: number,
+): { ok: true } | { ok: false; reason: string } {
+  // v5 introduces the principals table — the schema the multi-principal
+  // pipeline depends on. Older snapshots predate every column the rerank
+  // pipeline reads (notably `entries.owner_principal_id`), so we refuse
+  // to silently invent missing data.
+  if (snapshotSchemaVersion < 5) {
+    return {
+      ok: false,
+      reason: `Snapshot schema v${snapshotSchemaVersion} is too old for production_ranker (need v5+).`,
+    };
+  }
+  // Sanity: the entries table must exist and carry the v5 columns the
+  // tracked-status query reads.
+  const entriesRow = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='entries'")
+    .get() as { name: string } | undefined;
+  if (!entriesRow) {
+    return { ok: false, reason: "Snapshot is missing required table 'entries'." };
+  }
+  const columns = db
+    .prepare("PRAGMA table_info(entries)")
+    .all() as Array<{ name: string }>;
+  const colNames = new Set(columns.map((c) => c.name));
+  for (const required of ["owner_principal_id", "classification", "valid_until"]) {
+    if (!colNames.has(required)) {
+      return {
+        ok: false,
+        reason: `Snapshot entries table missing required column '${required}' for production_ranker.`,
+      };
+    }
+  }
+  return { ok: true };
 }
 
 /**
@@ -425,8 +570,23 @@ export async function runBenchmark(
   queries: BenchmarkQuery[],
   options: RunBenchmarkOptions = {},
 ): Promise<BenchmarkReport> {
-  // Open snapshot DB read-only
+  // Open snapshot DB read-only. The function wraps the body in try/finally
+  // so any early throw (e.g. failed production_ranker prereq check)
+  // still closes the connection — m5 from the PR 2b internal review.
   const db = new Database(snapshotPath, { readonly: true });
+  try {
+    return await runBenchmarkInner(db, snapshotPath, queries, options);
+  } finally {
+    db.close();
+  }
+}
+
+async function runBenchmarkInner(
+  db: Database.Database,
+  snapshotPath: string,
+  queries: BenchmarkQuery[],
+  options: RunBenchmarkOptions,
+): Promise<BenchmarkReport> {
   sqliteVec.load(db);
   setVecLoaded(true);
 
@@ -468,6 +628,36 @@ export async function runBenchmark(
 
   const querySetChecksum = computeQuerySetChecksum(querySetSources);
 
+  // Resolve runner mode. fail-loud is the default; opt-in fallback to raw
+  // is allowed when the caller explicitly sets `fallbackRunnerMode: "raw"`.
+  const requestedRunnerMode: RunnerMode = options.runnerMode ?? "raw";
+  let effectiveRunnerMode: RunnerMode = requestedRunnerMode;
+  if (requestedRunnerMode === "production_ranker") {
+    const check = checkProductionRankerPrereqs(db, snapshotSchemaVersion);
+    if (!check.ok) {
+      if (options.fallbackRunnerMode === "raw") {
+        warnings.push(
+          `production_ranker prereq failed — downgraded to raw mode. Reason: ${check.reason}`,
+        );
+        effectiveRunnerMode = "raw";
+      } else {
+        // The outer try/finally in `runBenchmark` owns db lifecycle.
+        throw new Error(
+          `production_ranker prerequisites not met: ${check.reason}. Pass fallbackRunnerMode: "raw" to opt into silent downgrade.`,
+        );
+      }
+    }
+  }
+
+  // Recency weight is only meaningful for production_ranker. Reporting it
+  // as `null` for raw mode keeps reports unambiguous: a 0 value would
+  // imply "rerank ran but recency was zeroed out", which is a different
+  // story.
+  const searchRecencyWeight =
+    effectiveRunnerMode === "production_ranker"
+      ? options.searchRecencyWeight ?? DEFAULT_SEARCH_RECENCY_WEIGHT
+      : null;
+
   const requiresEmbeddings = queries.some(
     (query) => query.search_mode === "semantic" || query.search_mode === "hybrid" || query.search_mode === "all",
   );
@@ -501,20 +691,58 @@ export async function runBenchmark(
         : [query.search_mode];
 
     for (const mode of modes) {
-      // Track when embeddings are unavailable and mode is affected
-      let actualMode = mode;
-      if ((mode === "semantic" || mode === "hybrid") && !embeddingsAvailable) {
-        actualMode = "lexical";
-      }
+      // Per-query limit and fetch size. Raw mode uses a tight limit=10
+      // (preserving PR 2a behavior). production_ranker over-fetches by
+      // QUERY_RERANK_OVERFETCH_MULTIPLIER so the rerank pipeline has the
+      // same candidate window as memory_query.
+      const requestedLimit = 10;
+      const internalLimit =
+        effectiveRunnerMode === "production_ranker"
+          ? Math.min(requestedLimit * QUERY_RERANK_OVERFETCH_MULTIPLIER, 50)
+          : requestedLimit;
 
+      // Pre-flight: if embeddings init returned unavailable, every
+      // semantic/hybrid query degrades to lexical. We still pass the
+      // requested mode into `executeQuery`, which performs the actual
+      // per-query embedding attempt and reports the resolved
+      // `effectiveMode` — that way a transient per-query embedding
+      // failure on a snapshot that DOES have a working model is still
+      // reported correctly (M3 from the PR 2b internal review).
       const queryStart = performance.now();
-      const { ids: resultIds, namespaces: resultNamespaces, relaxed } = await executeQuery(
+      const { entries: rawEntries, relaxed, effectiveMode } = await executeQuery(
         db,
         query.query,
         mode,
-        10,
+        internalLimit,
       );
+      const actualMode = effectiveMode;
+
+      let finalEntries: Entry[];
+      if (effectiveRunnerMode === "production_ranker") {
+        // Build the QueryParams memory_query would synthesize from the
+        // request. Mirror src/tools.ts:5788-5800. The benchmark doesn't
+        // carry namespace/entry_type/tags filters per-query today, so
+        // those stay undefined and the suppression heuristics fire as
+        // they would for a bare query string. The runner sets
+        // `explain: false`, which means the `|| explain` clause in
+        // memory_query at src/tools.ts:5924 is dead here — runner
+        // gating reduces to `shouldApplyDefaultQuerySuppression` alone.
+        const queryParams: QueryParams = {
+          query: query.query,
+          limit: requestedLimit,
+          search_mode: actualMode,
+          search_recency_weight: searchRecencyWeight ?? DEFAULT_SEARCH_RECENCY_WEIGHT,
+          include_expired: true,
+          explain: false,
+        };
+        finalEntries = applyProductionReranker(db, rawEntries, queryParams, requestedLimit);
+      } else {
+        finalEntries = rawEntries.slice(0, requestedLimit);
+      }
       const durationMs = performance.now() - queryStart;
+
+      const resultIds = finalEntries.map((e) => e.id);
+      const resultNamespaces = finalEntries.map((e) => e.namespace);
       if (relaxed) {
         relaxedLexicalFallbackCount += 1;
       }
@@ -613,7 +841,7 @@ export async function runBenchmark(
     bySearchModeDuration[mode] = summarizeDurations(modeDurations.get(mode)!);
   }
 
-  db.close();
+  // db lifecycle is owned by the outer try/finally in `runBenchmark`.
 
   return {
     run_at: new Date().toISOString(),
@@ -624,7 +852,10 @@ export async function runBenchmark(
     entry_count: entryCount,
     query_count: queries.length,
     evaluation_count: allResults.length,
-    runner_mode: "raw",
+    runner_mode: effectiveRunnerMode,
+    runner_mode_requested: requestedRunnerMode,
+    search_recency_weight: searchRecencyWeight,
+    principal_id: "owner",
     query_set_sources: querySetSources,
     query_set_checksum: querySetChecksum,
     overall,

--- a/benchmark/types.ts
+++ b/benchmark/types.ts
@@ -159,10 +159,34 @@ export interface BenchmarkReport {
   /** Total evaluations (queries × modes; differs from query_count when search_mode is "all"). */
   evaluation_count: number;
   /**
-   * Which runner code path produced these numbers. In PR 2a always `"raw"`;
-   * PR 2b adds `"production_ranker"`. Present on every report as of v2.
+   * Which runner code path actually produced these numbers. PR 2a emitted
+   * only `"raw"`; PR 2b adds `"production_ranker"`. Compare with
+   * `runner_mode_requested` to detect a degraded run (e.g. caller asked
+   * for `production_ranker` but the runner downgraded to `raw` because a
+   * prerequisite was missing and `fallbackRunnerMode: "raw"` was set).
    */
   runner_mode: RunnerMode;
+  /**
+   * Which runner mode the caller asked for. Always present as of PR 2b.
+   * Equal to `runner_mode` for non-degraded runs. When they differ, the
+   * runner downgraded — `warnings[]` carries the reason.
+   */
+  runner_mode_requested: RunnerMode;
+  /**
+   * Recency weight applied during reranking. Only meaningful for
+   * `production_ranker`; in `raw` mode the reranker is skipped entirely
+   * and this is reported as `null` for traceability.
+   */
+  search_recency_weight: number | null;
+  /**
+   * Principal identifier the runner ran as. Always `"owner"` in PR 2b —
+   * benchmarks run with full owner access and skip `filterByAccess`. The
+   * field is typed `string` so a future multi-principal benchmarking
+   * mode can populate it (e.g. `"family:sara"`, `"agent:skuld"`) without
+   * forcing every TypeScript consumer through a widening bump. Today's
+   * reports always carry the literal `"owner"`.
+   */
+  principal_id: string;
   /** Per-file lineage metadata for the query set(s) loaded into this run. */
   query_set_sources: QuerySetSource[];
   /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -854,9 +854,13 @@ function phaseOneliner(content: string, maxLen = 100): string {
 const STALENESS_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const EVENT_STALENESS_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 const EVENT_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-const QUERY_RERANK_OVERFETCH_MULTIPLIER = 5;
+// Exported (PR 2b) so the benchmark runner's production_ranker mode can
+// over-fetch by the same multiplier and apply the same default recency
+// weight as memory_query. Issue #59 tracks the eventual relocation into
+// src/internal/reranker.ts together with the rest of the rerank pipeline.
+export const QUERY_RERANK_OVERFETCH_MULTIPLIER = 5;
 const DEFAULT_ORIENT_DETAIL: OrientDetail = "compact";
-const DEFAULT_SEARCH_RECENCY_WEIGHT = 0.2;
+export const DEFAULT_SEARCH_RECENCY_WEIGHT = 0.2;
 const SEARCH_RECENCY_HALF_LIFE_DAYS = 30;
 const EXPIRES_SOON_DAYS = 7;
 const ISO_8601_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
@@ -1015,7 +1019,9 @@ const ATTENTION_TRIAGE_QUERY_PHRASES = [
   "what should i look at",
 ];
 
-interface TrackedStatusAssessment {
+// Exported (PR 2b) so the benchmark runner can pass the assessment map
+// through `rerankQueryResults`. Issue #59 tracks the planned relocation.
+export interface TrackedStatusAssessment {
   row: TrackedStatusRow;
   entry: Entry;
   lifecycle: string;
@@ -1152,7 +1158,17 @@ export function buildRelaxedLexicalQuery(query: string): string | null {
   return uniqueTerms.map((term) => `"${term}"`).join(" OR ");
 }
 
-function shouldApplyDefaultQuerySuppression(params: QueryParams): boolean {
+/**
+ * Whether the default attention/suppression heuristics apply.
+ *
+ * Exported (PR 2b) so the benchmark runner's production_ranker mode can
+ * apply the same predicate per-query as `memory_query`. Don't cache the
+ * result across queries — the gating depends on each query's params.
+ *
+ * Issue #59 tracks the planned relocation into src/internal/reranker.ts
+ * along with the rest of the rerank pipeline.
+ */
+export function shouldApplyDefaultQuerySuppression(params: QueryParams): boolean {
   return !params.namespace && !params.entry_type && (!params.tags || params.tags.length === 0);
 }
 
@@ -1315,7 +1331,13 @@ function assessTrackedStatus(row: TrackedStatusRow): TrackedStatusAssessment {
   };
 }
 
-function getTrackedStatusAssessments(db: Database.Database): Map<string, TrackedStatusAssessment> {
+/**
+ * Build the per-entry tracked-status assessment map.
+ *
+ * Exported (PR 2b) for the benchmark runner's production_ranker mode.
+ * Issue #59 tracks relocation into src/internal/reranker.ts.
+ */
+export function getTrackedStatusAssessments(db: Database.Database): Map<string, TrackedStatusAssessment> {
   const assessments = getTrackedStatuses(db).map(assessTrackedStatus);
   return new Map(assessments.map((assessment) => [assessment.entry.id, assessment]));
 }
@@ -1427,7 +1449,14 @@ function getQueryHeuristicScore(
   return score;
 }
 
-function injectCanonicalQueryEntries(
+/**
+ * Inject canonical reference entries (reference-index, magnus profile,
+ * conventions) when the query looks like a broad orientation request.
+ *
+ * Exported (PR 2b) for the benchmark runner. Issue #59 tracks the
+ * relocation into src/internal/reranker.ts.
+ */
+export function injectCanonicalQueryEntries(
   db: Database.Database,
   results: Entry[],
   params: QueryParams,
@@ -1454,7 +1483,14 @@ function injectCanonicalQueryEntries(
   return merged;
 }
 
-function injectAttentionQueryEntries(
+/**
+ * Inject blocked/needs-attention tracked statuses when the query looks
+ * like a triage request.
+ *
+ * Exported (PR 2b) for the benchmark runner. Issue #59 tracks the
+ * relocation into src/internal/reranker.ts.
+ */
+export function injectAttentionQueryEntries(
   results: Entry[],
   params: QueryParams,
   trackedStatuses: Map<string, TrackedStatusAssessment>,
@@ -1479,7 +1515,17 @@ function injectAttentionQueryEntries(
   return merged;
 }
 
-function rerankQueryResults(
+/**
+ * Rerank query results by heuristic score + freshness, applying the
+ * default suppression filter when appropriate.
+ *
+ * Exported (PR 2b) for the benchmark runner's production_ranker mode.
+ * Issue #59 tracks the relocation into src/internal/reranker.ts along
+ * with the supporting helpers (`getQueryHeuristicScore`,
+ * `isBroadOrientationQuery`, `isAttentionTriageQuery`,
+ * `looksLikeTombstone`, …).
+ */
+export function rerankQueryResults(
   results: Entry[],
   params: QueryParams,
   completedTasks: Set<string>,

--- a/tests/benchmark-import-boundary.test.ts
+++ b/tests/benchmark-import-boundary.test.ts
@@ -1,0 +1,195 @@
+/**
+ * PR 2b — load-bearing import boundary test.
+ *
+ * The benchmark runner is allowed to import only a small, curated set of
+ * names from `src/tools.ts` (the reranker pipeline that PR 2b widened to
+ * `export`). If new names creep in here we risk benchmark/ depending on
+ * implementation detail that issue #59 is meant to extract into a
+ * dedicated module. Lock the surface down now so a refactor stays
+ * mechanical.
+ *
+ * Update the allow-list when issue #59 lands or when a new pipeline name
+ * needs benchmark visibility — and update issue #59's acceptance
+ * criteria at the same time.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const BENCHMARK_DIR = resolve(__dirname, "..", "benchmark");
+
+/**
+ * Names the benchmark surface is allowed to import from src/tools.js.
+ * Anything else is a lint failure — either remove the new dependency or
+ * propose a new public name on src/tools.ts and add it here in the
+ * same PR that introduces it.
+ */
+const ALLOWED_TOOLS_IMPORTS = new Set<string>([
+  "buildRelaxedLexicalQuery",
+  "QUERY_RERANK_OVERFETCH_MULTIPLIER",
+  "DEFAULT_SEARCH_RECENCY_WEIGHT",
+  "shouldApplyDefaultQuerySuppression",
+  "getTrackedStatusAssessments",
+  "injectCanonicalQueryEntries",
+  "injectAttentionQueryEntries",
+  "rerankQueryResults",
+]);
+
+function walkTypeScriptFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const st = statSync(path);
+    if (st.isDirectory()) {
+      // Skip generated and downloaded data — they don't host source.
+      if (entry === "node_modules" || entry === "data" || entry === "generated" || entry === "fixtures" || entry === "reports") {
+        continue;
+      }
+      walkTypeScriptFiles(path, out);
+    } else if (entry.endsWith(".ts")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+interface ImportRecord {
+  from: string;
+  /** Named imports — empty for star/default. */
+  names: string[];
+  /** Star (`import * as x`) and default (`import x from`) imports are
+   * sweeping aliases: they implicitly pull every export off the target
+   * module, so even one of them on `src/tools.js` blows the curated
+   * surface wide open. Flag separately so the assertion can reject
+   * them outright instead of relying on the named-import allow-list. */
+  wildcard: boolean;
+}
+
+/**
+ * Parse import statements out of a TypeScript source string.
+ *
+ * Handles named imports, namespace (`import * as ...`) imports, and
+ * default imports. Mixed forms like `import def, { a, b } from "..."`
+ * are reported as both — the named names are collected and `wildcard`
+ * is set (the default binding counts as a sweeping alias).
+ *
+ * Naive but sufficient for this allow-list: we only care about imports
+ * from a specific module, and `prettier` formats benchmark/ enough that
+ * we never have to worry about adversarial whitespace.
+ */
+function extractImports(source: string): ImportRecord[] {
+  const out: ImportRecord[] = [];
+
+  // Named or mixed default+named:  import [Foo,] { a, b as c } from "x";
+  // Captures optional default binding before the braced list.
+  const named = /import\s+(?:type\s+)?(?:([A-Za-z_$][\w$]*)\s*,\s*)?\{\s*([^}]+)\s*\}\s+from\s+["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = named.exec(source)) !== null) {
+    const names = m[2]
+      .split(",")
+      .map((s) => s.trim())
+      .map((s) => s.split(/\s+as\s+/)[0].trim())
+      .map((s) => s.replace(/^type\s+/, "").trim())
+      .filter((s) => s.length > 0);
+    out.push({ from: m[3], names, wildcard: Boolean(m[1]) });
+  }
+
+  // Pure star alias:  import * as tools from "x";
+  const star = /import\s+(?:type\s+)?\*\s+as\s+[A-Za-z_$][\w$]*\s+from\s+["']([^"']+)["']/g;
+  while ((m = star.exec(source)) !== null) {
+    out.push({ from: m[1], names: [], wildcard: true });
+  }
+
+  // Pure default:  import tools from "x";
+  // Use a negative lookahead to avoid double-matching the `default + named`
+  // form already captured above (those start with `import Foo, {`).
+  const def = /import\s+(?:type\s+)?([A-Za-z_$][\w$]*)\s+from\s+["']([^"']+)["']/g;
+  while ((m = def.exec(source)) !== null) {
+    out.push({ from: m[2], names: [], wildcard: true });
+  }
+
+  return out;
+}
+
+describe("extractImports — lint primitive", () => {
+  it("captures named imports including aliases and type modifier", () => {
+    const src = `import { foo, bar as baz, type qux } from "x";`;
+    const records = extractImports(src);
+    expect(records).toHaveLength(1);
+    expect(records[0].from).toBe("x");
+    expect(records[0].names.sort()).toEqual(["bar", "foo", "qux"].sort());
+    expect(records[0].wildcard).toBe(false);
+  });
+
+  it("flags star imports as wildcards (M2 from PR 2b review)", () => {
+    const src = `import * as tools from "../src/tools.js";`;
+    const records = extractImports(src);
+    expect(records).toHaveLength(1);
+    expect(records[0].wildcard).toBe(true);
+    expect(records[0].names).toEqual([]);
+  });
+
+  it("flags default imports as wildcards", () => {
+    const src = `import tools from "../src/tools.js";`;
+    const records = extractImports(src);
+    // The default-import regex may match — but the assertion only cares
+    // that at least one record on `../src/tools.js` is flagged wildcard.
+    const toolsImports = records.filter((r) => r.from === "../src/tools.js");
+    expect(toolsImports.some((r) => r.wildcard)).toBe(true);
+  });
+
+  it("captures mixed default + named as both", () => {
+    const src = `import tools, { foo } from "../src/tools.js";`;
+    const records = extractImports(src);
+    expect(records).toHaveLength(1);
+    expect(records[0].wildcard).toBe(true);
+    expect(records[0].names).toEqual(["foo"]);
+  });
+});
+
+describe("benchmark/ → src/tools.ts import boundary", () => {
+  it("benchmark/ only imports the curated reranker surface from src/tools", () => {
+    const files = walkTypeScriptFiles(BENCHMARK_DIR);
+    const violations: Array<{ file: string; name: string }> = [];
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf-8");
+      const imports = extractImports(src);
+      for (const imp of imports) {
+        // Match the various relative paths benchmark/ uses to reach
+        // src/tools(.js). Direct file imports only — package imports
+        // never resolve into the tools module.
+        const isToolsImport = /(?:^|\/)src\/tools(?:\.js)?$/.test(imp.from)
+          || imp.from === "../src/tools.js"
+          || imp.from === "../../src/tools.js"
+          || imp.from === "../../../src/tools.js";
+        if (!isToolsImport) continue;
+        // Star and default imports are categorically forbidden: they
+        // pull every export off `src/tools.js` and trivially bypass the
+        // allow-list. Surface as a violation with a synthetic name so
+        // the error message points at the right pattern.
+        if (imp.wildcard) {
+          violations.push({ file, name: "<star-or-default import>" });
+        }
+        for (const name of imp.names) {
+          if (!ALLOWED_TOOLS_IMPORTS.has(name)) {
+            violations.push({ file, name });
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const summary = violations
+        .map((v) => `  ${v.file.replace(BENCHMARK_DIR, "benchmark")}: imports ${v.name}`)
+        .join("\n");
+      throw new Error(
+        `Benchmark surface imports unapproved names from src/tools.ts:\n${summary}\n\n` +
+          `If the new dependency is legitimate, add the name to ALLOWED_TOOLS_IMPORTS ` +
+          `in tests/benchmark-import-boundary.test.ts AND update issue #59's acceptance ` +
+          `criteria. If not, refactor the benchmark to not need it.`,
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/runner-parity.test.ts
+++ b/tests/runner-parity.test.ts
@@ -1,0 +1,273 @@
+/**
+ * PR 2b parity test — the benchmark runner's `production_ranker` mode
+ * must produce the same top-k result IDs as `memory_query` for the same
+ * snapshot DB + query.
+ *
+ * If this test ever fails, it means the runner's pipeline composition
+ * has drifted from `src/tools.ts:5924-5936`. Re-sync the runner before
+ * publishing benchmark numbers — a divergent runner reports retrieval
+ * quality that real users will never see.
+ *
+ * The test deliberately uses a small handcrafted corpus (no LongMemEval
+ * data) so failures are debuggable without external downloads.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { initDatabase, writeState, appendLog } from "../src/db.js";
+import { registerTools } from "../src/tools.js";
+import { ownerContext } from "../src/access.js";
+import { runBenchmark } from "../benchmark/runner.js";
+import type { BenchmarkQuery } from "../benchmark/types.js";
+
+interface MemoryQueryResultEntry {
+  id: string;
+  namespace: string;
+  key?: string | null;
+}
+
+interface MemoryQueryResponse {
+  results: MemoryQueryResultEntry[];
+  total: number;
+  search_mode: string;
+  search_mode_actual?: string;
+}
+
+async function callTool(
+  server: Server,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<unknown> {
+  const handler = (server as unknown as {
+    _requestHandlers: Map<string, (req: unknown) => unknown>;
+  })._requestHandlers?.get("tools/call");
+  if (!handler) throw new Error("tools/call handler not registered");
+  return handler({ method: "tools/call", params: { name, arguments: args } });
+}
+
+function parseMemoryQuery(response: unknown): MemoryQueryResponse {
+  const resp = response as { content: Array<{ text: string }> };
+  return JSON.parse(resp.content[0].text) as MemoryQueryResponse;
+}
+
+/**
+ * Seed the DB with a small mixed corpus: tracked-project statuses, a
+ * canonical reference-index entry, some chronological logs, and a few
+ * noise entries. The mix matters — too uniform and the rerank pipeline
+ * has nothing to reorder, so the parity assertion becomes trivial.
+ */
+function seedCorpus(db: Database.Database): void {
+  // Tracked-status entries (drive attention/canonical injection)
+  writeState(db, "projects/alpha", "status", "Active project alpha. Blockers: dependency on bravo.", ["active"]);
+  writeState(db, "projects/bravo", "status", "Blocked on review for bravo retrieval changes.", ["blocked"]);
+  writeState(db, "projects/charlie", "status", "Completed feature charlie.", ["completed"]);
+  writeState(db, "clients/delta", "status", "Delta engagement renewed; quarterly check-in scheduled.", ["active"]);
+
+  // Canonical entries
+  writeState(db, "meta", "reference-index", "Catalog of important Munin namespaces and conventions.", ["canonical"]);
+  writeState(db, "people/magnus", "profile", "Owner of the Munin Memory project. Prefers terse outputs.", ["canonical"]);
+
+  // Plain notes
+  writeState(db, "decisions/ranker", "v1", "Decided to apply heuristic rerank + freshness over raw FTS5 scores.", ["decision"]);
+  writeState(db, "decisions/embedding", "v1", "Decided to ship local Transformers.js embeddings before any remote API option.", ["decision"]);
+
+  // Logs (no key — append_log)
+  appendLog(db, "projects/alpha", "Made progress on alpha retrieval changes today.", ["progress"]);
+  appendLog(db, "projects/bravo", "Discovered new edge case in bravo lexical fallback.", ["bug"]);
+  appendLog(db, "projects/alpha", "Pair-debugged with reviewer; landed reranker fix in alpha branch.", ["progress"]);
+
+  // Noise entries unrelated to typical queries
+  writeState(db, "meta/test", "demo-noise-1", "Zucchini risotto recipe with parmesan and lemon zest.", []);
+  writeState(db, "meta/test", "demo-noise-2", "Notes on the migratory pattern of arctic terns.", []);
+}
+
+describe("benchmark runner — production_ranker parity with memory_query", () => {
+  let tmp: string;
+  let dbPath: string;
+  let db: Database.Database;
+  let server: Server;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "runner-parity-"));
+    dbPath = join(tmp, "snap.db");
+    db = initDatabase(dbPath);
+    seedCorpus(db);
+    server = new Server(
+      { name: "munin-parity-test", version: "0.0.1" },
+      { capabilities: { tools: {} } },
+    );
+    registerTools(server, db, "parity-session", ownerContext());
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the same query through both surfaces and assert top-k ID equality.
+   *
+   * `memory_query` already runs the rerank pipeline; the runner's
+   * production_ranker mode must match it byte-for-byte on the result-ID
+   * sequence. Latency and explain payloads are not part of parity — only
+   * the ordered IDs are.
+   */
+  async function assertParity(query: string, searchMode: "lexical" | "semantic" | "hybrid" = "lexical") {
+    // 1. Production: hit memory_query through the registered MCP handler.
+    const prodRaw = await callTool(server, "memory_query", {
+      query,
+      search_mode: searchMode,
+      limit: 10,
+      include_expired: true,
+    });
+    const prod = parseMemoryQuery(prodRaw);
+    const prodMode = prod.search_mode_actual ?? prod.search_mode;
+    const prodIds = prod.results.map((r) => r.id);
+
+    // 2. Runner: same DB, same query, production_ranker mode.
+    const benchQuery: BenchmarkQuery = {
+      id: "parity-1",
+      query,
+      source: "manual",
+      category: "broad-orientation",
+      search_mode: searchMode,
+      // expected_ids is required by the runner ground-truth gate; we don't
+      // care what scores it computes — only that it returns the entries.
+      expected_ids: prodIds.length > 0 ? [prodIds[0]] : ["__never__"],
+    };
+    const report = await runBenchmark(dbPath, [benchQuery], {
+      runnerMode: "production_ranker",
+      querySetSources: [], // suppress lineage-untracked warning
+      manifestPath: null,
+    });
+    // Only the lineage warning is allowed to slip through here. Anything
+    // else (especially "downgraded to raw mode") would invalidate parity.
+    const realWarnings = (report.warnings ?? []).filter(
+      (w) => !w.includes("query_set_sources not tracked"),
+    );
+    expect(realWarnings).toEqual([]);
+    expect(report.runner_mode).toBe("production_ranker");
+    expect(report.runner_mode_requested).toBe("production_ranker");
+    expect(report.queries).toHaveLength(1);
+    const runnerIds = report.queries[0].result_ids;
+
+    // 3. Parity: both surfaces must agree on the ordered top-k IDs.
+    // We compare the prefix up to min(len) so that limit cutoffs match
+    // exactly — they should already be the same since both apply
+    // requestedLimit=10, but if memory_query returns fewer due to a
+    // post-rerank filter (e.g. ACL), allow the runner to return the
+    // same prefix.
+    expect(runnerIds.slice(0, prodIds.length)).toEqual(prodIds);
+    // Sanity: the runner must record the actual mode the same way.
+    if (prodMode !== searchMode) {
+      expect(report.queries[0].actual_mode).toBe(prodMode);
+    }
+  }
+
+  it("matches memory_query for a tracked-status query (lexical)", async () => {
+    await assertParity("blocked review");
+  });
+
+  it("matches memory_query for a broad-orientation query that triggers canonical injection", async () => {
+    await assertParity("how should I orient on munin reference");
+  });
+
+  it("matches memory_query for a decision-lookup query", async () => {
+    await assertParity("reranker decision");
+  });
+
+  it("matches memory_query for a noisy query that misses everything (relaxed lexical fallback)", async () => {
+    // Multiword query with no exact match → exercises the relaxed-OR
+    // fallback both surfaces share.
+    await assertParity("arctic terns migratory snippet");
+  });
+});
+
+describe("benchmark runner — production_ranker prereq handling", () => {
+  let tmp: string;
+  let dbPath: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "runner-prereq-"));
+    dbPath = join(tmp, "snap.db");
+    db = initDatabase(dbPath);
+    writeState(db, "projects/x", "status", "Active.", ["active"]);
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const benchQuery: BenchmarkQuery = {
+    id: "prereq-1",
+    query: "active",
+    source: "manual",
+    category: "broad-orientation",
+    search_mode: "lexical",
+    expected_ids: ["__never__"],
+  };
+
+  it("emits both runner_mode and runner_mode_requested on a successful production_ranker run", async () => {
+    const report = await runBenchmark(dbPath, [benchQuery], {
+      runnerMode: "production_ranker",
+      manifestPath: null,
+    });
+    expect(report.runner_mode).toBe("production_ranker");
+    expect(report.runner_mode_requested).toBe("production_ranker");
+    expect(report.search_recency_weight).toBe(0.2);
+    expect(report.principal_id).toBe("owner");
+  });
+
+  it("reports search_recency_weight: null for raw mode (no rerank ran)", async () => {
+    const report = await runBenchmark(dbPath, [benchQuery], {
+      runnerMode: "raw",
+      manifestPath: null,
+    });
+    expect(report.runner_mode).toBe("raw");
+    expect(report.runner_mode_requested).toBe("raw");
+    expect(report.search_recency_weight).toBeNull();
+  });
+
+  it("downgrades to raw with a warning when fallbackRunnerMode is opt-in", async () => {
+    // Build a snapshot whose schema_version row reads as 0 — too old for
+    // production_ranker prereq. Easiest way is to manipulate the
+    // schema_version table directly on a fresh DB.
+    const oldDb = new Database(dbPath);
+    oldDb.prepare("DELETE FROM schema_version").run();
+    oldDb.prepare("INSERT INTO schema_version (version, applied_at) VALUES (1, ?)")
+      .run(new Date().toISOString());
+    oldDb.close();
+
+    const report = await runBenchmark(dbPath, [benchQuery], {
+      runnerMode: "production_ranker",
+      fallbackRunnerMode: "raw",
+      manifestPath: null,
+    });
+    expect(report.runner_mode).toBe("raw");
+    expect(report.runner_mode_requested).toBe("production_ranker");
+    expect(report.warnings ?? []).toEqual(
+      expect.arrayContaining([expect.stringContaining("downgraded to raw mode")]),
+    );
+  });
+
+  it("throws when production_ranker prereqs fail and no fallback is opted in", async () => {
+    const oldDb = new Database(dbPath);
+    oldDb.prepare("DELETE FROM schema_version").run();
+    oldDb.prepare("INSERT INTO schema_version (version, applied_at) VALUES (1, ?)")
+      .run(new Date().toISOString());
+    oldDb.close();
+
+    await expect(
+      runBenchmark(dbPath, [benchQuery], {
+        runnerMode: "production_ranker",
+        manifestPath: null,
+      }),
+    ).rejects.toThrow(/production_ranker prerequisites not met/);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2b — adds an opt-in `production_ranker` runner mode that mirrors the `memory_query` rerank pipeline so benchmark numbers reflect end-to-end production behavior. Includes adversarial parity tests against `memory_query` and an import-boundary lint that pins the curated `src/tools.ts` surface.

This is the second of the PR 2 split (after PR 2a `report schema v2` landed in #57). Together they close out the production-rerank visibility gap identified in the Codex/Claude debate.

## Behavior changes

- `runBenchmark` accepts `runnerMode: "raw" | "production_ranker"` (default `"raw"`). The new mode over-fetches per source by `QUERY_RERANK_OVERFETCH_MULTIPLIER` and runs the same canonical / attention injectors + completed-task filter + `rerankQueryResults` pipeline as `memory_query` before slicing to the requested limit.
- **Fail-loud prereq check**: `production_ranker` against a snapshot missing schema v5 columns (`owner_principal_id`, `classification`, `valid_until`) throws by default. Opt into a silent downgrade with `fallbackRunnerMode: "raw"` — a warning is emitted and `runner_mode_requested` preserves the original ask so post-hoc consumers can detect the degraded run.
- **Per-query semantic→lexical degradation**: `executeQuery` now mirrors `memory_query` and falls back to the strict-then-relaxed lexical path when per-query embedding generation fails, instead of returning empty results.

## New report fields (additive)

- `runner_mode_requested` — what the caller asked for; differs from `runner_mode` on degraded runs.
- `search_recency_weight` — recency weight during rerank. `null` in raw mode to disambiguate "rerank skipped" from "rerank ran with zero recency".
- `principal_id` — always `"owner"` today; typed `string` (not the literal) so future multi-principal benchmarking doesn't force a schema bump.

`report_schema_version` stays at `2`.

## New tests

- `tests/runner-parity.test.ts` — 4 adversarial parity cases against `memory_query` (tracked-status, canonical injection, decision lookup, relaxed-lexical fallback) plus 4 prereq tests covering fail-loud / fallback / raw recency-weight reporting.
- `tests/benchmark-import-boundary.test.ts` — pins the curated `src/tools.ts` surface; flags star (`import * as`) and default imports as wildcard violations alongside named-import allow-list enforcement. Issue #59 tracks extracting the curated surface into `src/internal/reranker.ts`.

## CLI

`--runner-mode production_ranker` added to both adapter CLIs (`longmemeval`, `locomo`).

## Testing

- `npm test` — 1152 tests pass, 3 benchmark fixtures skipped (gated on `MUNIN_BENCHMARK=true`).
- `npm run build` — clean.
- Internal review by Opus reviewer subagent (debate/pr-2b-internal-review.md): APPROVE with major findings addressed before merge.

## Follow-ups

Issue #59 — extract curated surface into `src/internal/reranker.ts`. Until then the named exports on `src/tools.ts` are pinned by the boundary lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)