### PR TITLE
fix(security): bump hono + @hono/node-server (#49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2886,9 +2886,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     "sqlite-vec": "^0.1.7-alpha.2",
     "uuid": "^11.1.0"
   },
+  "overrides": {
+    "hono": "^4.12.18",
+    "@hono/node-server": "^1.19.13"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
Closes #49.

## What
Pin patched versions of the transitive `hono` / `@hono/node-server` deps (pulled in by `@modelcontextprotocol/sdk`) via `package.json` `overrides`:

- `hono` 4.12.8 → **4.12.23**
- `@hono/node-server` 1.19.11 → **1.19.14**

Both stay within the MCP SDK's accepted ranges (`hono ^4.11.4`, `@hono/node-server ^1.19.9`), and node-server stays in its 1.x line (no 2.x major bump).

## Advisories cleared
- GHSA-92pp-h63x-v22m — `@hono/node-server` serveStatic repeated-slash middleware bypass
- GHSA-26pp-8wgv-hjvm + GHSA-r5rp-j6wh-rvv4 — `hono` cookie-name validation
- plus the remaining hono advisories npm audit flagged

## Verification
- `npm audit` no longer lists any `hono` advisory.
- `grep` confirms Munin uses **neither** `serveStatic` nor `express.static` — the bypass never applied to our code path (HTTP transport is Express + `mcpAuthRouter`/`requireBearerAuth`). The bump is defense-in-depth, as the issue framed it.
- `npm run build` clean.
- All 99 HTTP-hardening / HTTP-transport / OAuth / OAuth-integration tests pass.

## Scope
`package-lock.json` diff touches only `hono` and `@hono/node-server`. The other open advisories (protobufjs, fast-uri, ip-address, postcss) are intentionally out of scope — #50 covers protobufjs; the rest are not yet filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)