### PR TITLE
docs: sync CLAUDE.md tool table to 22 tools + inventory CI test (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,19 +25,32 @@ Part of the Hugin & Munin personal AI system. See `prd.md` for full product cont
 
 ### MCP tools exposed
 
+All 22 tools registered in `TOOL_DEFINITIONS` (`src/tools.ts`) are listed below, in registration order. This table is the single human-readable inventory; `tests/claude-md-tool-inventory.test.ts` asserts every registered tool name appears here exactly once.
+
 | Tool | Purpose |
 |------|---------|
-| `memory_orient` | **Start here.** Returns compact conventions, computed project dashboard (grouped by lifecycle), curated notes, maintenance suggestions, and namespace overview in one call. Hides completed task namespaces by default. Pass `include_full_conventions: true` for the full guide. |
-| `memory_write` | Store/update a state entry (namespace + key + content). Supports compare-and-swap via `expected_updated_at` for tracked statuses. Auto-canonicalizes lifecycle tags. |
-| `memory_read` | Retrieve a specific state entry by namespace + key |
-| `memory_get` | Retrieve any entry (state or log) by UUID |
-| `memory_query` | Search and filter memories (lexical/semantic/hybrid). Supports `since`/`until` temporal filters. Query string optional — can browse by filters alone (tags, namespace, time range). |
-| `memory_log` | Append a chronological log entry to a namespace |
-| `memory_list` | Browse namespaces and their contents (with recent log previews; demo and completed task namespaces hidden by default) |
-| `memory_delete` | Delete entries (with token-based confirmation) |
-| `memory_insights` | Inspect retrieval usage signals per entry: impressions, open rate, follow-through rate, staleness pressure, learned signals. Now also returns aggregate retrieval health metrics (reformulation rate, positive outcome rate, feedback counts). |
-| `memory_retrieval_feedback` | Submit explicit feedback on retrieval quality. Supports: bad_results, missing_result, wrong_order, stale_results, good_results. Auto-links to most recent retrieval event. Owner-only. Feeds benchmark ground truth pipeline. |
-| `memory_consolidate` | Manually trigger consolidation for a specific namespace or all eligible tracked namespaces. Synthesizes unincorporated logs into an enriched 'synthesis' key via OpenRouter LLM call. Owner-only. |
+| `memory_orient` | **Start here.** Call at the start of every conversation before any other memory tool. Returns conventions, a computed project dashboard (grouped by lifecycle), curated notes, maintenance suggestions, and a namespace overview in one call. Hides completed task namespaces by default; pass `include_full_conventions: true` for the full guide. |
+| `memory_resume` | Build a compact, targeted continuation pack after `memory_orient` from a project hint, namespace, or opener — the most relevant state, logs, and next steps to pick work back up. |
+| `memory_extract` | Suggest reviewable memory operations from explicit conversation signals (messy notes, transcript text). Proposes writes/logs for you to confirm; does not write directly. |
+| `memory_narrative` | Derive a narrative view for one namespace from current status, recent logs, and audit history — project-arc signals like momentum and direction. |
+| `memory_commitments` | Surface explicit commitments derived from tracked next steps and dated, attributable source text. Review open, at-risk, and overdue obligations. |
+| `memory_patterns` | Derive conservative, reviewable patterns from repeated decision logs, tracked-status follow-through, and commitment outcomes. |
+| `memory_handoff` | Assemble a source-backed handoff pack for one namespace: current state, recent decisions, open loops, recent actors, and recommended next actions. |
+| `memory_write` | Store/update a state entry (namespace + key + content); upserts on conflict. Supports compare-and-swap via `expected_updated_at` for tracked statuses. Auto-canonicalizes lifecycle tags. |
+| `memory_update_status` | Update a tracked status entry in `projects/*` or `clients/*` only, using server-enforced canonical sections (Phase, Current Work, Blockers, Next Steps, Notes). Supports lifecycle tag + CAS. |
+| `memory_read` | Retrieve a specific state entry by namespace + key. Returns full content, tags, and timestamps. |
+| `memory_read_batch` | Retrieve multiple state entries in a single call; returns results (found or not found) in input order. Orient across several known keys at once. |
+| `memory_get` | Retrieve the full content of any entry (state or log) by UUID. Use after `memory_query` returns truncated previews. |
+| `memory_query` | Search and filter memories: lexical (keyword), semantic (vector), or hybrid (RRF fusion). Filters by namespace, tags, type, and `since`/`until`. Query string optional — browse by filters alone. |
+| `memory_attention` | Return deterministic triage items for tracked work: blocked statuses, stale active work, expiring/expired statuses, near-term event staleness, and missing status/lifecycle tags. |
+| `memory_log` | Append an immutable, timestamped log entry to a namespace. For decisions, events, and milestones with rationale. |
+| `memory_list` | Browse namespaces and their contents with recent log previews. Demo and completed task-run namespaces hidden by default. |
+| `memory_history` | View the chronological audit trail of changes (writes, updates, deletes, namespace deletes, log appends). Supports an ascending cursor for sync/polling workflows. |
+| `memory_delete` | Delete a state entry by namespace+key, or all entries in a namespace. Call without `delete_token` to preview, then with the returned token to confirm. |
+| `memory_insights` | Per-entry retrieval analytics: impressions, opens, follow-through rate, staleness pressure, learned signals. Also returns aggregate retrieval-health metrics (reformulation rate, positive outcome rate, feedback counts). |
+| `memory_retrieval_feedback` | Submit explicit feedback on retrieval quality: bad_results, missing_result, wrong_order, stale_results, good_results. Owner-only. Auto-links to the most recent retrieval event; feeds the benchmark ground-truth pipeline. |
+| `memory_consolidate` | Manually trigger consolidation for a namespace or all eligible tracked namespaces. Synthesizes unincorporated logs into an enriched `synthesis` key via OpenRouter LLM call. Owner-only. |
+| `memory_status` | Return server capabilities, version, and feature availability — discover which search modes, tools, and features this instance supports. |
 
 ## Project structure
 
@@ -361,7 +374,7 @@ After `MUNIN_EMBEDDINGS_MAX_FAILURES` (default 5) consecutive embedding failures
 
 ### Overview
 
-Server-enforced namespace isolation. Each authenticated principal has scoped namespace rules; owner retains full access with zero overhead. All 12 MCP tools enforce access rules via `AccessContext`.
+Server-enforced namespace isolation. Each authenticated principal has scoped namespace rules; owner retains full access with zero overhead. All registered MCP tools enforce access rules via `AccessContext`.
 
 ### Schema
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3971,6 +3971,15 @@ const TOOL_DEFINITIONS = [
   },
 ];
 
+/**
+ * Names of every MCP tool registered in {@link TOOL_DEFINITIONS}.
+ * Exported as the single source of truth for the CLAUDE.md tool-table
+ * inventory contract (see tests/claude-md-tool-inventory.test.ts, issue #54).
+ */
+export const REGISTERED_TOOL_NAMES: readonly string[] = TOOL_DEFINITIONS.map(
+  (t) => t.name,
+);
+
 function textResult(obj: Record<string, unknown>) {
   return { content: [{ type: "text" as const, text: JSON.stringify(obj) }] };
 }

--- a/tests/claude-md-tool-inventory.test.ts
+++ b/tests/claude-md-tool-inventory.test.ts
@@ -1,0 +1,83 @@
+/**
+ * CLAUDE.md tool-table inventory contract (issue #54).
+ *
+ * The "MCP tools exposed" table in CLAUDE.md is the single human-readable
+ * inventory of the MCP tool surface. This test makes that inventory
+ * machine-checked: every tool registered in `TOOL_DEFINITIONS`
+ * (exported as `REGISTERED_TOOL_NAMES`) must appear in the table exactly
+ * once, and the table must not list any name that isn't registered.
+ *
+ * When you add, rename, or remove a tool, update the CLAUDE.md table row
+ * in the same change — this test will fail until you do.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { REGISTERED_TOOL_NAMES } from "../src/tools.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLAUDE_MD = join(__dirname, "..", "CLAUDE.md");
+
+/**
+ * Extract the tool names from the "MCP tools exposed" table in CLAUDE.md.
+ * Scoped to that section only (from the heading to the next "## " heading)
+ * so unrelated `| \`memory_*\` |`-shaped rows elsewhere can't leak in.
+ */
+function extractTableToolNames(markdown: string): string[] {
+  const lines = markdown.split("\n");
+  const start = lines.findIndex((l) => l.trim() === "### MCP tools exposed");
+  if (start === -1) {
+    throw new Error('Could not find "### MCP tools exposed" heading in CLAUDE.md');
+  }
+  const names: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // Stop at the next section heading.
+    if (/^##\s/.test(line)) break;
+    // Table rows look like:  | `memory_orient` | ... |
+    const match = line.match(/^\|\s*`([a-z_]+)`\s*\|/);
+    if (match) names.push(match[1]);
+  }
+  return names;
+}
+
+describe("CLAUDE.md tool-table inventory contract", () => {
+  const markdown = readFileSync(CLAUDE_MD, "utf8");
+  const tableNames = extractTableToolNames(markdown);
+
+  it("registers a non-trivial number of tools", () => {
+    // Guard against the regex silently matching zero rows.
+    expect(REGISTERED_TOOL_NAMES.length).toBeGreaterThan(10);
+    expect(tableNames.length).toBeGreaterThan(10);
+  });
+
+  it("lists every registered tool exactly once", () => {
+    for (const name of REGISTERED_TOOL_NAMES) {
+      const occurrences = tableNames.filter((n) => n === name).length;
+      expect(
+        occurrences,
+        `Tool \`${name}\` should appear exactly once in the CLAUDE.md table, found ${occurrences}`,
+      ).toBe(1);
+    }
+  });
+
+  it("does not list any name that isn't a registered tool", () => {
+    const registered = new Set(REGISTERED_TOOL_NAMES);
+    const extras = tableNames.filter((n) => !registered.has(n));
+    expect(
+      extras,
+      `CLAUDE.md table lists names not registered in TOOL_DEFINITIONS: ${extras.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("has no duplicate rows in the table", () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const n of tableNames) {
+      if (seen.has(n)) dupes.push(n);
+      seen.add(n);
+    }
+    expect(dupes, `Duplicate rows in CLAUDE.md table: ${dupes.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #54.

## Problem
`CLAUDE.md`'s "MCP tools exposed" table listed **11** tools while `TOOL_DEFINITIONS` in `src/tools.ts` registers **22**, and a stale line claimed *"All 12 MCP tools enforce access rules"*. `README.md` already says 22 and points at `CLAUDE.md` → internally inconsistent docs.

## Fix (deliberately narrow, per the recorded debate)
1. **Table** now lists all 22 registered tools, in registration order, each with a concise one-line purpose derived from the tool's actual `description` field. The 7 orientation/synthesis tools (`memory_resume`, `memory_extract`, `memory_narrative`, `memory_commitments`, `memory_patterns`, `memory_handoff`) and the others (`memory_update_status`, `memory_read_batch`, `memory_attention`, `memory_history`, `memory_status`) that were missing are now documented.
2. **Stale line** fixed: "All 12 MCP tools enforce access rules" → "All registered MCP tools enforce access rules".
3. **CI contract**: exported `REGISTERED_TOOL_NAMES` from `src/tools.ts` (single source of truth) and added `tests/claude-md-tool-inventory.test.ts` asserting every registered tool name appears in the table **exactly once**, with no stale, extra, or duplicate rows.

## Explicitly out of scope (per `debate/tool-surface-summary.md`)
- No prose generator from `TOOL_DEFINITIONS` (Codex-flagged over-engineering trap).
- No tool/API consolidation.
- No `read_batch`→`read` merge.

## Verification
- New test passes (4 cases). Red/green confirmed: removing a row makes it fail with a precise message; restoring passes.
- `npm run build` clean.
- Rest of suite green.

> Note: `tests/onboarding/wizard-routes.test.ts` shows pre-existing intermittent failures under full-suite parallel runs (passes 9/9 in isolation and on clean `main`; unrelated to this change). Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)