### PR TITLE
chore(benchmark): remove deprecated schema_version alias (report schema v3) (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ changelog is the canonical record of what moved.
 
 ### Changed
 
+- **Benchmark report schema v3 — removed the deprecated `schema_version`
+  alias (#58).** `BenchmarkReport.schema_version` (a one-release mirror of
+  `snapshot_schema_version` introduced in report schema v2 / PR 2a) is gone.
+  `report_schema_version` is now `3`. Consumers must read
+  `snapshot_schema_version` for the snapshot DB migration version. This is a
+  breaking change to the report shape; historical report JSON under
+  `benchmark/reports/` is unaffected (frozen records).
 - **Backup schedule reduced from hourly to daily** with GFS retention (14 most
   recent daily snapshots + 4 most recent Sunday snapshots, ~18 files total).
   Previous policy kept 168 hourly snapshots which grew to ~50 GB and filled

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -70,13 +70,19 @@ Reports under `reports/` follow the shape defined in `types.ts` as
 `BenchmarkReport`. The `report_schema_version` field tags additive
 revisions; consumers should branch on it before reading new fields.
 
+### v3 changes (#58)
+
+- `report_schema_version: 3` — pin for the current revision. The
+  deprecated `schema_version` alias (a one-release mirror of
+  `snapshot_schema_version`) has been removed. Read
+  `snapshot_schema_version` for the snapshot DB migration version.
+
 ### v2 additions (PR 2a)
 
 - `report_schema_version: 2` — pin for this revision. Implicit `1` for
   any pre-PR-2a report.
 - `snapshot_schema_version` — DB migration version of the snapshot used
-  for the run. `schema_version` is kept for one release as a deprecated
-  alias and mirrors this value.
+  for the run.
 - `runner_mode` — which runner code path actually produced the numbers.
   `"raw"` calls `src/db.ts` query functions directly (faster, no rerank,
   no injectors). `"production_ranker"` (PR 2b) over-fetches per source

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -847,8 +847,7 @@ async function runBenchmarkInner(
     run_at: new Date().toISOString(),
     snapshot_path: snapshotPath,
     snapshot_schema_version: snapshotSchemaVersion,
-    schema_version: snapshotSchemaVersion, // deprecated alias for one release
-    report_schema_version: 2,
+    report_schema_version: 3,
     entry_count: entryCount,
     query_count: queries.length,
     evaluation_count: allResults.length,

--- a/benchmark/types.ts
+++ b/benchmark/types.ts
@@ -135,12 +135,6 @@ export interface BenchmarkReport {
    */
   snapshot_schema_version: number;
   /**
-   * @deprecated since `report_schema_version: 2`. Mirrors
-   * `snapshot_schema_version` for one release so existing consumers keep
-   * working. Tracked for removal in #58 — read `snapshot_schema_version`.
-   */
-  schema_version: number;
-  /**
    * Version of the BenchmarkReport JSON shape itself. Bumped additively
    * when new fields are introduced. Old consumers should treat unknown
    * fields as optional and branch on this when consuming new ones.
@@ -150,8 +144,10 @@ export interface BenchmarkReport {
    *   overall_duration, by_search_mode_duration, snapshot_schema_version,
    *   runner_mode, CategoryResult.duration, QueryBenchmarkResult.duration_ms,
    *   ScoringResult.recallAt20/ndcgAt20).
+   * - `3` — removed the deprecated `schema_version` alias (#58). Read
+   *   `snapshot_schema_version` for the snapshot DB migration version.
    */
-  report_schema_version: 2;
+  report_schema_version: 3;
   /** Number of entries in the snapshot DB. */
   entry_count: number;
   /** Total queries in the query set. */

--- a/tests/benchmark.test.ts
+++ b/tests/benchmark.test.ts
@@ -54,7 +54,7 @@ describe.skipIf(!shouldRun)("Retrieval Benchmark", () => {
     if (!report) return;
     console.log("\n=== Benchmark Summary ===");
     console.log(`  Snapshot: ${report.snapshot_path}`);
-    console.log(`  Schema: v${report.schema_version}, Entries: ${report.entry_count}`);
+    console.log(`  Schema: v${report.snapshot_schema_version}, Entries: ${report.entry_count}`);
     console.log(`  Queries: ${report.query_count}`);
     console.log(`  Evaluations: ${report.evaluation_count}`);
     if (report.warnings) {

--- a/tests/runner-instrumentation.test.ts
+++ b/tests/runner-instrumentation.test.ts
@@ -377,11 +377,10 @@ describe("runBenchmark (end-to-end report shape)", () => {
       manifestPath: null, // no manifest in this fixture
     });
 
-    // Shape — v2 fields present and consistent.
-    expect(report.report_schema_version).toBe(2);
+    // Shape — v3 fields present and consistent.
+    expect(report.report_schema_version).toBe(3);
     expect(report.runner_mode).toBe("raw");
     expect(report.snapshot_schema_version).toBeGreaterThan(0);
-    expect(report.schema_version).toBe(report.snapshot_schema_version);
     expect(report.query_count).toBe(5);
     expect(report.evaluation_count).toBe(5);
     expect(report.query_set_sources).toHaveLength(1);


### PR DESCRIPTION
Closes #58.

## What
PR #57 renamed `BenchmarkReport.schema_version` → `snapshot_schema_version` and kept `schema_version` as a one-release deprecated alias. Consumers have moved off it, so this removes it:

- Drop the `schema_version` field from `BenchmarkReport` (`benchmark/types.ts`).
- Drop the `schema_version: snapshotSchemaVersion` assignment in `runBenchmark` (`benchmark/runner.ts`).
- Bump `report_schema_version` **2 → 3** (breaking report-shape change).
- Update `benchmark/README.md` (new v3 section) and add a CHANGELOG entry under **Changed**.

## Consumers updated
- `tests/runner-instrumentation.test.ts` — assert `report_schema_version === 3`; remove the `report.schema_version === snapshot_schema_version` alias assertion.
- `tests/benchmark.test.ts` — summary log now reads `snapshot_schema_version`.

## Deliberately left untouched (same name, different concern)
- The SQLite **`schema_version` migration-tracking table** (`benchmark/runner.ts:594`, `scripts/snapshot-benchmark-db.sh`, `tests/migrations.test.ts`, `tests/runner-parity.test.ts`).
- `memory_status`'s `schema_version` field (`tests/tools.test.ts`).
- Frozen historical report JSON under `benchmark/reports/`.

## Verification
- `tsc` clean — TypeScript would flag any remaining read of the now-removed `BenchmarkReport.schema_version`; `grep` confirms none remain.
- Benchmark / parity / instrumentation suites pass (32 tests, `MUNIN_BENCHMARK=true`).
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)