### PR TITLE
refactor(reranker): extract query rerank pipeline into src/internal (#59)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -145,8 +145,8 @@ degraded run by comparing the two fields.
 
 The benchmark-import-boundary test (`tests/benchmark-import-boundary.test.ts`)
 pins the small curated surface the benchmark is allowed to import from
-`src/tools.ts`. Issue #59 tracks the planned extraction of that surface
-into `src/internal/reranker.ts`.
+`src/internal/reranker.ts`. Issue #59 extracted the reranker pipeline out
+of `src/tools.ts` into that dedicated module.
 
 ### Line endings
 

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -29,7 +29,7 @@ import {
   injectCanonicalQueryEntries,
   injectAttentionQueryEntries,
   rerankQueryResults,
-} from "../src/tools.js";
+} from "../src/internal/reranker.js";
 import type { Entry, QueryParams } from "../src/types.js";
 import {
   scoreQuery,

--- a/src/internal/reranker.ts
+++ b/src/internal/reranker.ts
@@ -1,0 +1,510 @@
+/**
+ * Query reranker pipeline — heuristic scoring, canonical/attention entry
+ * injection, and the production-ranker that `memory_query` applies.
+ *
+ * Extracted from src/tools.ts as part of issue #59 (reranker-module refactor).
+ */
+
+import type Database from "better-sqlite3";
+import {
+  readState,
+  getTrackedStatuses,
+  isEntryExpired,
+} from "../db.js";
+import {
+  parseTags,
+  canonicalizeTags,
+  getLifecycleTags,
+  LIFECYCLE_TAGS,
+  isStale,
+  getFreshnessScore,
+  getDaysUntil,
+  isEntryExpiringSoon,
+  findUpcomingEventDate,
+  isTrackedNamespace,
+  RELAXED_QUERY_STOPWORDS,
+} from "./retrieval-shared.js";
+import type {
+  Entry,
+  TrackedStatusRow,
+  QueryParams,
+  QueryResult,
+  MaintenanceItem,
+} from "../types.js";
+
+// --- Constants ---
+
+export const QUERY_RERANK_OVERFETCH_MULTIPLIER = 5;
+export const DEFAULT_SEARCH_RECENCY_WEIGHT = 0.2;
+
+export const ORIENTATION_QUERY_PHRASES = [
+  "orient me",
+  "orientation",
+  "catch me up",
+  "catch-up",
+  "brief me",
+  "what should i know",
+  "what's magnus working on",
+  "what is magnus working on",
+  "what magnus is working on",
+];
+export const ATTENTION_TRIAGE_QUERY_PHRASES = [
+  "what needs attention",
+  "need attention",
+  "needs attention",
+  "blocked projects",
+  "blocked project",
+  "what is blocked",
+  "what's blocked",
+  "at risk",
+  "stale",
+  "urgent",
+  "what should i look at",
+];
+
+// --- Interface ---
+
+/** Exported for the benchmark runner's production_ranker mode. */
+export interface TrackedStatusAssessment {
+  row: TrackedStatusRow;
+  entry: Entry;
+  lifecycle: string;
+  needsAttention: boolean;
+  attentionReason?: "blocked" | MaintenanceItem["issue"];
+  maintenanceItems: MaintenanceItem[];
+}
+
+// --- Functions ---
+
+export function buildRelaxedLexicalQuery(query: string): string | null {
+  if (query.includes("\"")) return null;
+  if (/\b(AND|OR|NOT|NEAR)\b|[:()*]/.test(query)) return null;
+
+  const terms = query
+    .toLowerCase()
+    .split(/[^a-z0-9_-]+/i)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 3 && !RELAXED_QUERY_STOPWORDS.has(term));
+
+  const uniqueTerms = [...new Set(terms)];
+  if (uniqueTerms.length < 2) return null;
+
+  return uniqueTerms.map((term) => `"${term}"`).join(" OR ");
+}
+
+/**
+ * Whether the default attention/suppression heuristics apply.
+ *
+ * Exported so the benchmark runner's production_ranker mode can
+ * apply the same predicate per-query as `memory_query`. Don't cache the
+ * result across queries — the gating depends on each query's params.
+ */
+export function shouldApplyDefaultQuerySuppression(params: QueryParams): boolean {
+  return !params.namespace && !params.entry_type && (!params.tags || params.tags.length === 0);
+}
+
+export function isBroadOrientationQuery(query: string, params: QueryParams): boolean {
+  if (!shouldApplyDefaultQuerySuppression(params)) return false;
+
+  const normalized = query.toLowerCase();
+  if (ORIENTATION_QUERY_PHRASES.some((phrase) => normalized.includes(phrase))) {
+    return true;
+  }
+
+  const hasOrientationVerb = queryMentionsAny(normalized, ["orient", "orientation", "brief"]);
+  const hasSummaryIntent = queryMentionsAny(normalized, [
+    "working on",
+    "current work",
+    "active work",
+    "what should i know",
+    "context",
+    "catch up",
+  ]);
+
+  return hasOrientationVerb && hasSummaryIntent;
+}
+
+export function isAttentionTriageQuery(query: string, params: QueryParams): boolean {
+  if (!shouldApplyDefaultQuerySuppression(params)) return false;
+
+  const normalized = query.toLowerCase();
+  if (ATTENTION_TRIAGE_QUERY_PHRASES.some((phrase) => normalized.includes(phrase))) {
+    return true;
+  }
+
+  const hasBlockedIntent = /\bblocked\b/.test(normalized);
+  const hasAttentionIntent = normalized.includes("attention");
+  const hasRiskIntent = queryMentionsAny(normalized, ["at risk", "stale", "urgent"]);
+  const hasWorkScope = queryMentionsAny(normalized, [
+    "project",
+    "projects",
+    "client",
+    "clients",
+    "work",
+    "right now",
+    "current",
+  ]);
+
+  return hasBlockedIntent || (hasAttentionIntent && hasWorkScope) || hasRiskIntent;
+}
+
+export function looksLikeTombstone(content: string): boolean {
+  return /\bTOMBSTONE\b/i.test(content);
+}
+
+export function queryMentionsAny(query: string, terms: string[]): boolean {
+  return terms.some((term) => query.includes(term));
+}
+
+export function trackedStatusRowToEntry(row: TrackedStatusRow): Entry {
+  return {
+    id: row.id,
+    namespace: row.namespace,
+    key: row.key,
+    entry_type: "state",
+    content: row.content,
+    tags: row.tags,
+    agent_id: row.agent_id,
+    owner_principal_id: row.owner_principal_id,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    valid_until: row.valid_until,
+    classification: row.classification,
+    embedding_status: "pending",
+    embedding_model: null,
+  };
+}
+
+export function assessTrackedStatus(row: TrackedStatusRow): TrackedStatusAssessment {
+  const maintenanceItems: MaintenanceItem[] = [];
+  const tags = parseTags(row.tags);
+  const { canonical } = canonicalizeTags(tags);
+  const lifecycleTags = getLifecycleTags(canonical);
+
+  let lifecycle: string;
+  if (lifecycleTags.length === 0) {
+    lifecycle = "uncategorized";
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "missing_lifecycle",
+      suggestion: `Status has no lifecycle tag. Add one of: ${[...LIFECYCLE_TAGS].join(", ")}.`,
+    });
+  } else if (lifecycleTags.length > 1) {
+    lifecycle = lifecycleTags[0];
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "conflicting_lifecycle",
+      suggestion: `Status has tags [${lifecycleTags.join(", ")}]. Use exactly one.`,
+    });
+  } else {
+    lifecycle = lifecycleTags[0];
+  }
+
+  let needsAttention = false;
+  let attentionReason: TrackedStatusAssessment["attentionReason"];
+
+  if (lifecycle === "blocked") {
+    attentionReason = "blocked";
+  }
+
+  if (row.valid_until && isEntryExpired({ entry_type: "state", valid_until: row.valid_until })) {
+    needsAttention = true;
+    attentionReason = "expired";
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "expired",
+      suggestion: `Status expired at ${row.valid_until}. Refresh it or rewrite without valid_until if it should remain current.`,
+    });
+  } else if (row.valid_until && isEntryExpiringSoon({ entry_type: "state", valid_until: row.valid_until })) {
+    needsAttention = true;
+    attentionReason = "expiring_soon";
+    const daysUntil = Math.max(1, Math.ceil(getDaysUntil(row.valid_until)));
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "expiring_soon",
+      suggestion: `Status expires in ${daysUntil} day${daysUntil === 1 ? "" : "s"} (${row.valid_until}). Refresh it if it should remain current.`,
+    });
+  }
+
+  if (lifecycle === "active" && !needsAttention && isStale(row.updated_at)) {
+    needsAttention = true;
+    attentionReason = "active_but_stale";
+    const daysSince = Math.floor((Date.now() - new Date(row.updated_at).getTime()) / (24 * 60 * 60 * 1000));
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "active_but_stale",
+      suggestion: `Last updated ${daysSince} days ago. Update status or change lifecycle to maintenance/archived.`,
+    });
+  }
+
+  if (lifecycle === "active" && !needsAttention) {
+    const upcomingDate = findUpcomingEventDate(row.content, row.updated_at);
+    if (upcomingDate) {
+      needsAttention = true;
+      attentionReason = "upcoming_event_stale";
+      const daysUntil = Math.ceil((new Date(upcomingDate + "T23:59:59Z").getTime() - Date.now()) / (24 * 60 * 60 * 1000));
+      const daysSinceUpdate = Math.floor((Date.now() - new Date(row.updated_at).getTime()) / (24 * 60 * 60 * 1000));
+      maintenanceItems.push({
+        namespace: row.namespace,
+        issue: "upcoming_event_stale",
+        suggestion: `Event date ${upcomingDate} is ${daysUntil} day${daysUntil === 1 ? "" : "s"} away but status was last updated ${daysSinceUpdate} days ago. Verify status is current.`,
+      });
+    }
+  }
+
+  return {
+    row,
+    entry: trackedStatusRowToEntry(row),
+    lifecycle,
+    needsAttention,
+    attentionReason,
+    maintenanceItems,
+  };
+}
+
+/**
+ * Build the per-entry tracked-status assessment map.
+ *
+ * Exported for the benchmark runner's production_ranker mode.
+ */
+export function getTrackedStatusAssessments(db: Database.Database): Map<string, TrackedStatusAssessment> {
+  const assessments = getTrackedStatuses(db).map(assessTrackedStatus);
+  return new Map(assessments.map((assessment) => [assessment.entry.id, assessment]));
+}
+
+export function getQueryHeuristicScore(
+  entry: Entry,
+  queryLower: string,
+  trackedStatuses?: Map<string, TrackedStatusAssessment>,
+): number {
+  const tags = parseTags(entry.tags);
+  let score = 0;
+  const orientationQuery = isBroadOrientationQuery(queryLower, { query: queryLower });
+  const triageQuery = isAttentionTriageQuery(queryLower, { query: queryLower });
+  const trackedStatus = trackedStatuses?.get(entry.id);
+
+  if (entry.entry_type === "state") score += 6;
+
+  if (isTrackedNamespace(entry.namespace) && entry.key === "status") {
+    score += 20;
+    if (queryMentionsAny(queryLower, ["active", "work", "blocker", "blockers", "next", "steps", "project"])) {
+      score += 4;
+    }
+    if (orientationQuery) {
+      score += 2;
+    }
+    if (triageQuery) {
+      score += 6;
+    }
+  }
+
+  if (entry.namespace.startsWith("people/") && entry.key === "profile") {
+    score += 18;
+    if (queryMentionsAny(queryLower, ["personal", "profile", "collaboration", "style", "preference", "preferences", "context"])) {
+      score += 10;
+    }
+    if (queryMentionsAny(queryLower, ["magnus", "working on", "what should i know"])) {
+      score += 12;
+    }
+  }
+
+  if (entry.namespace === "meta/conventions" && entry.key === "conventions") {
+    score += 16;
+    if (queryMentionsAny(queryLower, ["convention", "handshake", "cas", "lifecycle", "write protocol"])) {
+      score += 8;
+    }
+  }
+
+  if (entry.namespace === "meta" && entry.key === "reference-index") {
+    score += 10;
+    if (orientationQuery) {
+      score += 18;
+    }
+  }
+
+  if (entry.entry_type === "log") {
+    score -= 3;
+    if (triageQuery) score -= 6;
+  }
+
+  if (looksLikeTombstone(entry.content)) {
+    score -= 30;
+  }
+
+  if (entry.key === "status") {
+    if (tags.includes("archived")) score -= 12;
+    if (tags.includes("completed")) score -= 8;
+    if (tags.includes("stopped")) score -= 8;
+  }
+
+  if (entry.namespace.startsWith("tasks/")) {
+    score -= 8;
+    if (triageQuery) score -= 14;
+  }
+
+  if (triageQuery && entry.key === "index") {
+    score -= 10;
+  }
+
+  if (triageQuery && trackedStatus) {
+    if (trackedStatus.lifecycle === "blocked") {
+      score += 36;
+    } else if (trackedStatus.needsAttention) {
+      score += 28;
+      if (trackedStatus.attentionReason === "upcoming_event_stale") score += 4;
+      if (trackedStatus.attentionReason === "active_but_stale") score += 2;
+    } else if (trackedStatus.lifecycle === "active") {
+      score -= 8;
+    }
+  }
+
+  return score;
+}
+
+/**
+ * Inject canonical reference entries (reference-index, magnus profile,
+ * conventions) when the query looks like a broad orientation request.
+ *
+ * Exported for the benchmark runner.
+ */
+export function injectCanonicalQueryEntries(
+  db: Database.Database,
+  results: Entry[],
+  params: QueryParams,
+): Entry[] {
+  const query = params.query;
+  if (!query || !isBroadOrientationQuery(query, params)) return results;
+
+  const injected = [
+    readState(db, "meta", "reference-index"),
+    readState(db, "people/magnus", "profile"),
+    readState(db, "meta/conventions", "conventions"),
+  ].filter((entry): entry is Entry => entry !== null);
+
+  if (injected.length === 0) return results;
+
+  const seen = new Set(results.map((entry) => entry.id));
+  const merged = [...results];
+  for (const entry of injected) {
+    if (!params.include_expired && isEntryExpired(entry)) continue;
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    merged.push(entry);
+  }
+  return merged;
+}
+
+/**
+ * Inject blocked/needs-attention tracked statuses when the query looks
+ * like a triage request.
+ *
+ * Exported for the benchmark runner.
+ */
+export function injectAttentionQueryEntries(
+  results: Entry[],
+  params: QueryParams,
+  trackedStatuses: Map<string, TrackedStatusAssessment>,
+): Entry[] {
+  const query = params.query;
+  if (!query || !isAttentionTriageQuery(query, params)) return results;
+
+  const injected = [...trackedStatuses.values()]
+    .filter((assessment) => assessment.lifecycle === "blocked" || assessment.needsAttention)
+    .map((assessment) => assessment.entry);
+
+  if (injected.length === 0) return results;
+
+  const seen = new Set(results.map((entry) => entry.id));
+  const merged = [...results];
+  for (const entry of injected) {
+    if (!params.include_expired && isEntryExpired(entry)) continue;
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    merged.push(entry);
+  }
+  return merged;
+}
+
+/**
+ * Rerank query results by heuristic score + freshness, applying the
+ * default suppression filter when appropriate.
+ *
+ * Exported for the benchmark runner's production_ranker mode.
+ */
+export function rerankQueryResults(
+  results: Entry[],
+  params: QueryParams,
+  completedTasks: Set<string>,
+  trackedStatuses?: Map<string, TrackedStatusAssessment>,
+): Entry[] {
+  const query = params.query ?? "";
+  const queryLower = query.toLowerCase();
+  const searchRecencyWeight = params.search_recency_weight ?? DEFAULT_SEARCH_RECENCY_WEIGHT;
+  const suppressDefaults = shouldApplyDefaultQuerySuppression(params);
+  const filtered = results.filter((entry) => {
+    if (!suppressDefaults) return true;
+    if (entry.namespace === "demo" || entry.namespace.startsWith("demo/")) return false;
+    if (completedTasks.has(entry.namespace)) return false;
+    return true;
+  });
+
+  return filtered
+    .map((entry, index) => ({
+      entry,
+      index,
+      heuristic: getQueryHeuristicScore(entry, queryLower, trackedStatuses),
+      freshness: getFreshnessScore(entry.updated_at),
+    }))
+    .sort((a, b) => {
+      if (b.heuristic !== a.heuristic) return b.heuristic - a.heuristic;
+      if (searchRecencyWeight > 0 && b.freshness !== a.freshness) return b.freshness - a.freshness;
+      return a.index - b.index;
+    })
+    .map((item) => item.entry);
+}
+
+export function resolveSearchRecencyWeight(params: QueryParams): { ok: true; value: number } | { ok: false; error: string } {
+  if (params.search_recency_weight === undefined) {
+    return { ok: true, value: DEFAULT_SEARCH_RECENCY_WEIGHT };
+  }
+  if (typeof params.search_recency_weight !== "number" || !Number.isFinite(params.search_recency_weight)) {
+    return { ok: false, error: '"search_recency_weight" must be a number between 0 and 1.' };
+  }
+  if (params.search_recency_weight < 0 || params.search_recency_weight > 1) {
+    return { ok: false, error: '"search_recency_weight" must be between 0 and 1.' };
+  }
+  return { ok: true, value: params.search_recency_weight };
+}
+
+export function getQueryExplainReasons(
+  entry: Entry,
+  queryLower: string,
+  trackedStatus: TrackedStatusAssessment | undefined,
+  match: NonNullable<QueryResult["match"]>,
+): string[] {
+  const reasons: string[] = [];
+
+  if (match.lexical_rank !== undefined) reasons.push("matched lexical terms");
+  if (match.semantic_rank !== undefined) reasons.push("matched semantic similarity");
+  if (match.hybrid_score !== undefined && match.lexical_rank !== undefined && match.semantic_rank !== undefined) {
+    reasons.push("combined lexical and semantic signals");
+  }
+  if (isTrackedNamespace(entry.namespace) && entry.key === "status") reasons.push("tracked status");
+  if (trackedStatus?.lifecycle === "blocked") reasons.push("blocked item");
+  else if (trackedStatus?.needsAttention) reasons.push("needs attention");
+  if (entry.namespace.startsWith("people/") && entry.key === "profile") reasons.push("profile entry");
+  if (entry.namespace === "meta/conventions" && entry.key === "conventions") reasons.push("conventions reference");
+  if (entry.namespace === "meta" && entry.key === "reference-index") reasons.push("reference index");
+  if (match.freshness_score !== undefined && match.freshness_score >= 0.5) reasons.push("recently updated");
+  if (isEntryExpired(entry)) reasons.push("expired entry included on request");
+
+  const queryTerms = queryLower
+    .split(/[^a-z0-9_-]+/i)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 4 && !RELAXED_QUERY_STOPWORDS.has(term));
+  const contentLower = entry.content.toLowerCase();
+  const matchedTerm = queryTerms.find((term) => contentLower.includes(term) || entry.namespace.toLowerCase().includes(term) || (entry.key?.toLowerCase().includes(term) ?? false));
+  if (matchedTerm) reasons.push(`matched term: ${matchedTerm}`);
+
+  return [...new Set(reasons)];
+}

--- a/src/internal/retrieval-shared.ts
+++ b/src/internal/retrieval-shared.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared retrieval primitives — staleness/freshness helpers, tag lifecycle
+ * utilities, and the constants that multiple retrieval tools depend on.
+ *
+ * Extracted from src/tools.ts as part of issue #59 (reranker-module refactor).
+ * These are pure-utility declarations with no dependency on tools.ts.
+ */
+
+import { isEntryExpired } from "../db.js";
+import type { Entry } from "../types.js";
+
+// --- Staleness / recency thresholds ---
+
+export const STALENESS_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+export const EVENT_STALENESS_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+export const EVENT_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const SEARCH_RECENCY_HALF_LIFE_DAYS = 30;
+export const EXPIRES_SOON_DAYS = 7;
+
+// Date pattern: YYYY-MM-DD (standalone or in ISO timestamp)
+export const DATE_PATTERN = /\b(20\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))\b/g;
+
+// --- Lifecycle tag management ---
+
+export const LIFECYCLE_TAGS = new Set(["active", "blocked", "completed", "stopped", "maintenance", "archived"]);
+
+export const TAG_ALIASES: Record<string, string> = {
+  "done": "completed",
+  "paused": "stopped",
+  "inactive": "archived",
+};
+
+export const RELAXED_QUERY_STOPWORDS = new Set([
+  "a", "an", "and", "are", "for", "how", "i", "important", "is", "it",
+  "my", "myself", "of", "or", "should", "the", "to", "what",
+]);
+
+// --- Functions ---
+
+export function parseTags(tags: string): string[] {
+  return JSON.parse(tags) as string[];
+}
+
+export function isStale(updatedAt: string): boolean {
+  return Date.now() - new Date(updatedAt).getTime() > STALENESS_THRESHOLD_MS;
+}
+
+export function getFreshnessScore(updatedAt: string): number {
+  const ageMs = Math.max(0, Date.now() - new Date(updatedAt).getTime());
+  const ageDays = ageMs / (24 * 60 * 60 * 1000);
+  return Math.exp((-Math.log(2) * ageDays) / SEARCH_RECENCY_HALF_LIFE_DAYS);
+}
+
+export function getDaysUntil(validUntil: string): number {
+  return (new Date(validUntil).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
+}
+
+export function isEntryExpiringSoon(entry: { entry_type: "state" | "log"; valid_until?: string | null }): boolean {
+  if (entry.entry_type !== "state" || !entry.valid_until) return false;
+  const daysUntil = getDaysUntil(entry.valid_until);
+  return daysUntil > 0 && daysUntil <= EXPIRES_SOON_DAYS;
+}
+
+/**
+ * Detect if content mentions a date within the next 7 days and the entry
+ * hasn't been updated in 3+ days. Returns the soonest upcoming date or null.
+ */
+export function findUpcomingEventDate(content: string, updatedAt: string): string | null {
+  const now = Date.now();
+  const sinceUpdate = now - new Date(updatedAt).getTime();
+  if (sinceUpdate < EVENT_STALENESS_THRESHOLD_MS) return null; // recently updated, no concern
+
+  let soonest: string | null = null;
+  let soonestMs = Infinity;
+  for (const match of content.matchAll(DATE_PATTERN)) {
+    const dateStr = match[1];
+    const dateMs = new Date(dateStr + "T23:59:59Z").getTime();
+    const untilEvent = dateMs - now;
+    if (untilEvent > 0 && untilEvent <= EVENT_LOOKAHEAD_MS && untilEvent < soonestMs) {
+      soonestMs = untilEvent;
+      soonest = dateStr;
+    }
+  }
+  return soonest;
+}
+
+export function isTrackedNamespace(namespace: string): boolean {
+  return namespace.startsWith("projects/") || namespace.startsWith("clients/");
+}
+
+export function canonicalizeTags(tags: string[]): { canonical: string[]; normalized: string[] } {
+  const normalized: string[] = [];
+  const canonical = tags.map(t => {
+    const alias = TAG_ALIASES[t];
+    if (alias) {
+      normalized.push(`"${t}" → "${alias}"`);
+      return alias;
+    }
+    return t;
+  });
+  return { canonical, normalized };
+}
+
+export function getLifecycleTags(tags: string[]): string[] {
+  return tags.filter(t => LIFECYCLE_TAGS.has(t));
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -557,10 +557,6 @@ function formatHistoryEntry(
   };
 }
 
-function parseTags(tags: string): string[] {
-  return JSON.parse(tags) as string[];
-}
-
 function validateClassificationInput(
   classification: unknown,
   classificationOverride: unknown,
@@ -851,24 +847,46 @@ function phaseOneliner(content: string, maxLen = 100): string {
   return content.slice(0, maxLen);
 }
 
-const STALENESS_THRESHOLD_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
-const EVENT_STALENESS_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
-const EVENT_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-// Exported (PR 2b) so the benchmark runner's production_ranker mode can
-// over-fetch by the same multiplier and apply the same default recency
-// weight as memory_query. Issue #59 tracks the eventual relocation into
-// src/internal/reranker.ts together with the rest of the rerank pipeline.
-export const QUERY_RERANK_OVERFETCH_MULTIPLIER = 5;
+import {
+  STALENESS_THRESHOLD_MS,
+  EVENT_STALENESS_THRESHOLD_MS,
+  EVENT_LOOKAHEAD_MS,
+  SEARCH_RECENCY_HALF_LIFE_DAYS,
+  EXPIRES_SOON_DAYS,
+  DATE_PATTERN,
+  LIFECYCLE_TAGS,
+  TAG_ALIASES,
+  RELAXED_QUERY_STOPWORDS,
+  parseTags,
+  isStale,
+  getFreshnessScore,
+  getDaysUntil,
+  isEntryExpiringSoon,
+  findUpcomingEventDate,
+  isTrackedNamespace,
+  canonicalizeTags,
+  getLifecycleTags,
+} from "./internal/retrieval-shared.js";
+// The reranker pipeline lives in ./internal/reranker.js (issue #59).
+// tools.ts imports only the names it uses internally; the dedicated module
+// is the explicit public surface (benchmark/ imports from there directly).
+import {
+  QUERY_RERANK_OVERFETCH_MULTIPLIER,
+  DEFAULT_SEARCH_RECENCY_WEIGHT,
+  buildRelaxedLexicalQuery,
+  shouldApplyDefaultQuerySuppression,
+  getTrackedStatusAssessments,
+  getQueryHeuristicScore,
+  injectCanonicalQueryEntries,
+  injectAttentionQueryEntries,
+  rerankQueryResults,
+  resolveSearchRecencyWeight,
+  getQueryExplainReasons,
+  type TrackedStatusAssessment,
+} from "./internal/reranker.js";
 const DEFAULT_ORIENT_DETAIL: OrientDetail = "compact";
-export const DEFAULT_SEARCH_RECENCY_WEIGHT = 0.2;
-const SEARCH_RECENCY_HALF_LIFE_DAYS = 30;
-const EXPIRES_SOON_DAYS = 7;
 const ISO_8601_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 const TRANSCRIPT_SPEAKER_PREFIX_RE = /^(user|assistant|human|claude|codex|magnus|sara)\s*:\s*/i;
-const RELAXED_QUERY_STOPWORDS = new Set([
-  "a", "an", "and", "are", "for", "how", "i", "important", "is", "it",
-  "my", "myself", "of", "or", "should", "the", "to", "what",
-]);
 const PATTERN_GENERIC_TERMS = new Set([
   "about",
   "added",
@@ -994,46 +1012,6 @@ const NARRATIVE_DECISION_RATIONALE_TERMS =
   /\b(again|avoid|because|choose|chose|concern|concerns|defer|due to|keep|narrow|prefer|reason|revisit|risk|scope|settled|still|tradeoff|uncertainty)\b/i;
 const NARRATIVE_CHURN_MARKERS =
   /\b(again|avoid|changed|defer|deferred|instead|reconsider|revisit|rework|rollback|tradeoff|uncertainty|for now)\b/i;
-const ORIENTATION_QUERY_PHRASES = [
-  "orient me",
-  "orientation",
-  "catch me up",
-  "catch-up",
-  "brief me",
-  "what should i know",
-  "what's magnus working on",
-  "what is magnus working on",
-  "what magnus is working on",
-];
-const ATTENTION_TRIAGE_QUERY_PHRASES = [
-  "what needs attention",
-  "need attention",
-  "needs attention",
-  "blocked projects",
-  "blocked project",
-  "what is blocked",
-  "what's blocked",
-  "at risk",
-  "stale",
-  "urgent",
-  "what should i look at",
-];
-
-// Exported (PR 2b) so the benchmark runner can pass the assessment map
-// through `rerankQueryResults`. Issue #59 tracks the planned relocation.
-export interface TrackedStatusAssessment {
-  row: TrackedStatusRow;
-  entry: Entry;
-  lifecycle: string;
-  needsAttention: boolean;
-  attentionReason?: "blocked" | MaintenanceItem["issue"];
-  maintenanceItems: MaintenanceItem[];
-}
-
-function isStale(updatedAt: string): boolean {
-  return Date.now() - new Date(updatedAt).getTime() > STALENESS_THRESHOLD_MS;
-}
-
 function normalizeIsoTimestamp(value: unknown, fieldName: string): { ok: true; value: string } | { ok: false; error: string } {
   if (typeof value !== "string" || !ISO_8601_TIMESTAMP_RE.test(value)) {
     return {
@@ -1051,35 +1029,6 @@ function normalizeIsoTimestamp(value: unknown, fieldName: string): { ok: true; v
   }
 
   return { ok: true, value: date.toISOString() };
-}
-
-function resolveSearchRecencyWeight(params: QueryParams): { ok: true; value: number } | { ok: false; error: string } {
-  if (params.search_recency_weight === undefined) {
-    return { ok: true, value: DEFAULT_SEARCH_RECENCY_WEIGHT };
-  }
-  if (typeof params.search_recency_weight !== "number" || !Number.isFinite(params.search_recency_weight)) {
-    return { ok: false, error: '"search_recency_weight" must be a number between 0 and 1.' };
-  }
-  if (params.search_recency_weight < 0 || params.search_recency_weight > 1) {
-    return { ok: false, error: '"search_recency_weight" must be between 0 and 1.' };
-  }
-  return { ok: true, value: params.search_recency_weight };
-}
-
-function getFreshnessScore(updatedAt: string): number {
-  const ageMs = Math.max(0, Date.now() - new Date(updatedAt).getTime());
-  const ageDays = ageMs / (24 * 60 * 60 * 1000);
-  return Math.exp((-Math.log(2) * ageDays) / SEARCH_RECENCY_HALF_LIFE_DAYS);
-}
-
-function getDaysUntil(validUntil: string): number {
-  return (new Date(validUntil).getTime() - Date.now()) / (24 * 60 * 60 * 1000);
-}
-
-function isEntryExpiringSoon(entry: { entry_type: "state" | "log"; valid_until?: string | null }): boolean {
-  if (entry.entry_type !== "state" || !entry.valid_until) return false;
-  const daysUntil = getDaysUntil(entry.valid_until);
-  return daysUntil > 0 && daysUntil <= EXPIRES_SOON_DAYS;
 }
 
 function filterExpiredEntries<T extends Entry | { entry: Entry }>(
@@ -1102,246 +1051,6 @@ function filterExpiredEntries<T extends Entry | { entry: Entry }>(
   return { items: filtered, expiredFilteredCount };
 }
 
-// Date pattern: YYYY-MM-DD (standalone or in ISO timestamp)
-const DATE_PATTERN = /\b(20\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))\b/g;
-
-/**
- * Detect if content mentions a date within the next 7 days and the entry
- * hasn't been updated in 3+ days. Returns the soonest upcoming date or null.
- */
-function findUpcomingEventDate(content: string, updatedAt: string): string | null {
-  const now = Date.now();
-  const sinceUpdate = now - new Date(updatedAt).getTime();
-  if (sinceUpdate < EVENT_STALENESS_THRESHOLD_MS) return null; // recently updated, no concern
-
-  let soonest: string | null = null;
-  let soonestMs = Infinity;
-  for (const match of content.matchAll(DATE_PATTERN)) {
-    const dateStr = match[1];
-    const dateMs = new Date(dateStr + "T23:59:59Z").getTime();
-    const untilEvent = dateMs - now;
-    if (untilEvent > 0 && untilEvent <= EVENT_LOOKAHEAD_MS && untilEvent < soonestMs) {
-      soonestMs = untilEvent;
-      soonest = dateStr;
-    }
-  }
-  return soonest;
-}
-
-// --- Lifecycle tag management ---
-
-const LIFECYCLE_TAGS = new Set(["active", "blocked", "completed", "stopped", "maintenance", "archived"]);
-
-const TAG_ALIASES: Record<string, string> = {
-  "done": "completed",
-  "paused": "stopped",
-  "inactive": "archived",
-};
-
-function isTrackedNamespace(namespace: string): boolean {
-  return namespace.startsWith("projects/") || namespace.startsWith("clients/");
-}
-
-export function buildRelaxedLexicalQuery(query: string): string | null {
-  if (query.includes("\"")) return null;
-  if (/\b(AND|OR|NOT|NEAR)\b|[:()*]/.test(query)) return null;
-
-  const terms = query
-    .toLowerCase()
-    .split(/[^a-z0-9_-]+/i)
-    .map((term) => term.trim())
-    .filter((term) => term.length >= 3 && !RELAXED_QUERY_STOPWORDS.has(term));
-
-  const uniqueTerms = [...new Set(terms)];
-  if (uniqueTerms.length < 2) return null;
-
-  return uniqueTerms.map((term) => `"${term}"`).join(" OR ");
-}
-
-/**
- * Whether the default attention/suppression heuristics apply.
- *
- * Exported (PR 2b) so the benchmark runner's production_ranker mode can
- * apply the same predicate per-query as `memory_query`. Don't cache the
- * result across queries — the gating depends on each query's params.
- *
- * Issue #59 tracks the planned relocation into src/internal/reranker.ts
- * along with the rest of the rerank pipeline.
- */
-export function shouldApplyDefaultQuerySuppression(params: QueryParams): boolean {
-  return !params.namespace && !params.entry_type && (!params.tags || params.tags.length === 0);
-}
-
-function isBroadOrientationQuery(query: string, params: QueryParams): boolean {
-  if (!shouldApplyDefaultQuerySuppression(params)) return false;
-
-  const normalized = query.toLowerCase();
-  if (ORIENTATION_QUERY_PHRASES.some((phrase) => normalized.includes(phrase))) {
-    return true;
-  }
-
-  const hasOrientationVerb = queryMentionsAny(normalized, ["orient", "orientation", "brief"]);
-  const hasSummaryIntent = queryMentionsAny(normalized, [
-    "working on",
-    "current work",
-    "active work",
-    "what should i know",
-    "context",
-    "catch up",
-  ]);
-
-  return hasOrientationVerb && hasSummaryIntent;
-}
-
-function isAttentionTriageQuery(query: string, params: QueryParams): boolean {
-  if (!shouldApplyDefaultQuerySuppression(params)) return false;
-
-  const normalized = query.toLowerCase();
-  if (ATTENTION_TRIAGE_QUERY_PHRASES.some((phrase) => normalized.includes(phrase))) {
-    return true;
-  }
-
-  const hasBlockedIntent = /\bblocked\b/.test(normalized);
-  const hasAttentionIntent = normalized.includes("attention");
-  const hasRiskIntent = queryMentionsAny(normalized, ["at risk", "stale", "urgent"]);
-  const hasWorkScope = queryMentionsAny(normalized, [
-    "project",
-    "projects",
-    "client",
-    "clients",
-    "work",
-    "right now",
-    "current",
-  ]);
-
-  return hasBlockedIntent || (hasAttentionIntent && hasWorkScope) || hasRiskIntent;
-}
-
-function looksLikeTombstone(content: string): boolean {
-  return /\bTOMBSTONE\b/i.test(content);
-}
-
-function queryMentionsAny(query: string, terms: string[]): boolean {
-  return terms.some((term) => query.includes(term));
-}
-
-function trackedStatusRowToEntry(row: TrackedStatusRow): Entry {
-  return {
-    id: row.id,
-    namespace: row.namespace,
-    key: row.key,
-    entry_type: "state",
-    content: row.content,
-    tags: row.tags,
-    agent_id: row.agent_id,
-    owner_principal_id: row.owner_principal_id,
-    created_at: row.created_at,
-    updated_at: row.updated_at,
-    valid_until: row.valid_until,
-    classification: row.classification,
-    embedding_status: "pending",
-    embedding_model: null,
-  };
-}
-
-function assessTrackedStatus(row: TrackedStatusRow): TrackedStatusAssessment {
-  const maintenanceItems: MaintenanceItem[] = [];
-  const tags = parseTags(row.tags);
-  const { canonical } = canonicalizeTags(tags);
-  const lifecycleTags = getLifecycleTags(canonical);
-
-  let lifecycle: string;
-  if (lifecycleTags.length === 0) {
-    lifecycle = "uncategorized";
-    maintenanceItems.push({
-      namespace: row.namespace,
-      issue: "missing_lifecycle",
-      suggestion: `Status has no lifecycle tag. Add one of: ${[...LIFECYCLE_TAGS].join(", ")}.`,
-    });
-  } else if (lifecycleTags.length > 1) {
-    lifecycle = lifecycleTags[0];
-    maintenanceItems.push({
-      namespace: row.namespace,
-      issue: "conflicting_lifecycle",
-      suggestion: `Status has tags [${lifecycleTags.join(", ")}]. Use exactly one.`,
-    });
-  } else {
-    lifecycle = lifecycleTags[0];
-  }
-
-  let needsAttention = false;
-  let attentionReason: TrackedStatusAssessment["attentionReason"];
-
-  if (lifecycle === "blocked") {
-    attentionReason = "blocked";
-  }
-
-  if (row.valid_until && isEntryExpired({ entry_type: "state", valid_until: row.valid_until })) {
-    needsAttention = true;
-    attentionReason = "expired";
-    maintenanceItems.push({
-      namespace: row.namespace,
-      issue: "expired",
-      suggestion: `Status expired at ${row.valid_until}. Refresh it or rewrite without valid_until if it should remain current.`,
-    });
-  } else if (row.valid_until && isEntryExpiringSoon({ entry_type: "state", valid_until: row.valid_until })) {
-    needsAttention = true;
-    attentionReason = "expiring_soon";
-    const daysUntil = Math.max(1, Math.ceil(getDaysUntil(row.valid_until)));
-    maintenanceItems.push({
-      namespace: row.namespace,
-      issue: "expiring_soon",
-      suggestion: `Status expires in ${daysUntil} day${daysUntil === 1 ? "" : "s"} (${row.valid_until}). Refresh it if it should remain current.`,
-    });
-  }
-
-  if (lifecycle === "active" && !needsAttention && isStale(row.updated_at)) {
-    needsAttention = true;
-    attentionReason = "active_but_stale";
-    const daysSince = Math.floor((Date.now() - new Date(row.updated_at).getTime()) / (24 * 60 * 60 * 1000));
-    maintenanceItems.push({
-      namespace: row.namespace,
-      issue: "active_but_stale",
-      suggestion: `Last updated ${daysSince} days ago. Update status or change lifecycle to maintenance/archived.`,
-    });
-  }
-
-  if (lifecycle === "active" && !needsAttention) {
-    const upcomingDate = findUpcomingEventDate(row.content, row.updated_at);
-    if (upcomingDate) {
-      needsAttention = true;
-      attentionReason = "upcoming_event_stale";
-      const daysUntil = Math.ceil((new Date(upcomingDate + "T23:59:59Z").getTime() - Date.now()) / (24 * 60 * 60 * 1000));
-      const daysSinceUpdate = Math.floor((Date.now() - new Date(row.updated_at).getTime()) / (24 * 60 * 60 * 1000));
-      maintenanceItems.push({
-        namespace: row.namespace,
-        issue: "upcoming_event_stale",
-        suggestion: `Event date ${upcomingDate} is ${daysUntil} day${daysUntil === 1 ? "" : "s"} away but status was last updated ${daysSinceUpdate} days ago. Verify status is current.`,
-      });
-    }
-  }
-
-  return {
-    row,
-    entry: trackedStatusRowToEntry(row),
-    lifecycle,
-    needsAttention,
-    attentionReason,
-    maintenanceItems,
-  };
-}
-
-/**
- * Build the per-entry tracked-status assessment map.
- *
- * Exported (PR 2b) for the benchmark runner's production_ranker mode.
- * Issue #59 tracks relocation into src/internal/reranker.ts.
- */
-export function getTrackedStatusAssessments(db: Database.Database): Map<string, TrackedStatusAssessment> {
-  const assessments = getTrackedStatuses(db).map(assessTrackedStatus);
-  return new Map(assessments.map((assessment) => [assessment.entry.id, assessment]));
-}
-
 function getVisibleTrackedStatusAssessments(
   db: Database.Database,
   ctx: AccessContext,
@@ -1358,203 +1067,6 @@ function getVisibleTrackedStatusAssessments(
     (assessment) => buildRedactableEntryMetadata(parseEntry(assessment.entry)),
     sessionId,
   );
-}
-
-function getQueryHeuristicScore(
-  entry: Entry,
-  queryLower: string,
-  trackedStatuses?: Map<string, TrackedStatusAssessment>,
-): number {
-  const tags = parseTags(entry.tags);
-  let score = 0;
-  const orientationQuery = isBroadOrientationQuery(queryLower, { query: queryLower });
-  const triageQuery = isAttentionTriageQuery(queryLower, { query: queryLower });
-  const trackedStatus = trackedStatuses?.get(entry.id);
-
-  if (entry.entry_type === "state") score += 6;
-
-  if (isTrackedNamespace(entry.namespace) && entry.key === "status") {
-    score += 20;
-    if (queryMentionsAny(queryLower, ["active", "work", "blocker", "blockers", "next", "steps", "project"])) {
-      score += 4;
-    }
-    if (orientationQuery) {
-      score += 2;
-    }
-    if (triageQuery) {
-      score += 6;
-    }
-  }
-
-  if (entry.namespace.startsWith("people/") && entry.key === "profile") {
-    score += 18;
-    if (queryMentionsAny(queryLower, ["personal", "profile", "collaboration", "style", "preference", "preferences", "context"])) {
-      score += 10;
-    }
-    if (queryMentionsAny(queryLower, ["magnus", "working on", "what should i know"])) {
-      score += 12;
-    }
-  }
-
-  if (entry.namespace === "meta/conventions" && entry.key === "conventions") {
-    score += 16;
-    if (queryMentionsAny(queryLower, ["convention", "handshake", "cas", "lifecycle", "write protocol"])) {
-      score += 8;
-    }
-  }
-
-  if (entry.namespace === "meta" && entry.key === "reference-index") {
-    score += 10;
-    if (orientationQuery) {
-      score += 18;
-    }
-  }
-
-  if (entry.entry_type === "log") {
-    score -= 3;
-    if (triageQuery) score -= 6;
-  }
-
-  if (looksLikeTombstone(entry.content)) {
-    score -= 30;
-  }
-
-  if (entry.key === "status") {
-    if (tags.includes("archived")) score -= 12;
-    if (tags.includes("completed")) score -= 8;
-    if (tags.includes("stopped")) score -= 8;
-  }
-
-  if (entry.namespace.startsWith("tasks/")) {
-    score -= 8;
-    if (triageQuery) score -= 14;
-  }
-
-  if (triageQuery && entry.key === "index") {
-    score -= 10;
-  }
-
-  if (triageQuery && trackedStatus) {
-    if (trackedStatus.lifecycle === "blocked") {
-      score += 36;
-    } else if (trackedStatus.needsAttention) {
-      score += 28;
-      if (trackedStatus.attentionReason === "upcoming_event_stale") score += 4;
-      if (trackedStatus.attentionReason === "active_but_stale") score += 2;
-    } else if (trackedStatus.lifecycle === "active") {
-      score -= 8;
-    }
-  }
-
-  return score;
-}
-
-/**
- * Inject canonical reference entries (reference-index, magnus profile,
- * conventions) when the query looks like a broad orientation request.
- *
- * Exported (PR 2b) for the benchmark runner. Issue #59 tracks the
- * relocation into src/internal/reranker.ts.
- */
-export function injectCanonicalQueryEntries(
-  db: Database.Database,
-  results: Entry[],
-  params: QueryParams,
-): Entry[] {
-  const query = params.query;
-  if (!query || !isBroadOrientationQuery(query, params)) return results;
-
-  const injected = [
-    readState(db, "meta", "reference-index"),
-    readState(db, "people/magnus", "profile"),
-    readState(db, "meta/conventions", "conventions"),
-  ].filter((entry): entry is Entry => entry !== null);
-
-  if (injected.length === 0) return results;
-
-  const seen = new Set(results.map((entry) => entry.id));
-  const merged = [...results];
-  for (const entry of injected) {
-    if (!params.include_expired && isEntryExpired(entry)) continue;
-    if (seen.has(entry.id)) continue;
-    seen.add(entry.id);
-    merged.push(entry);
-  }
-  return merged;
-}
-
-/**
- * Inject blocked/needs-attention tracked statuses when the query looks
- * like a triage request.
- *
- * Exported (PR 2b) for the benchmark runner. Issue #59 tracks the
- * relocation into src/internal/reranker.ts.
- */
-export function injectAttentionQueryEntries(
-  results: Entry[],
-  params: QueryParams,
-  trackedStatuses: Map<string, TrackedStatusAssessment>,
-): Entry[] {
-  const query = params.query;
-  if (!query || !isAttentionTriageQuery(query, params)) return results;
-
-  const injected = [...trackedStatuses.values()]
-    .filter((assessment) => assessment.lifecycle === "blocked" || assessment.needsAttention)
-    .map((assessment) => assessment.entry);
-
-  if (injected.length === 0) return results;
-
-  const seen = new Set(results.map((entry) => entry.id));
-  const merged = [...results];
-  for (const entry of injected) {
-    if (!params.include_expired && isEntryExpired(entry)) continue;
-    if (seen.has(entry.id)) continue;
-    seen.add(entry.id);
-    merged.push(entry);
-  }
-  return merged;
-}
-
-/**
- * Rerank query results by heuristic score + freshness, applying the
- * default suppression filter when appropriate.
- *
- * Exported (PR 2b) for the benchmark runner's production_ranker mode.
- * Issue #59 tracks the relocation into src/internal/reranker.ts along
- * with the supporting helpers (`getQueryHeuristicScore`,
- * `isBroadOrientationQuery`, `isAttentionTriageQuery`,
- * `looksLikeTombstone`, …).
- */
-export function rerankQueryResults(
-  results: Entry[],
-  params: QueryParams,
-  completedTasks: Set<string>,
-  trackedStatuses?: Map<string, TrackedStatusAssessment>,
-): Entry[] {
-  const query = params.query ?? "";
-  const queryLower = query.toLowerCase();
-  const searchRecencyWeight = params.search_recency_weight ?? DEFAULT_SEARCH_RECENCY_WEIGHT;
-  const suppressDefaults = shouldApplyDefaultQuerySuppression(params);
-  const filtered = results.filter((entry) => {
-    if (!suppressDefaults) return true;
-    if (entry.namespace === "demo" || entry.namespace.startsWith("demo/")) return false;
-    if (completedTasks.has(entry.namespace)) return false;
-    return true;
-  });
-
-  return filtered
-    .map((entry, index) => ({
-      entry,
-      index,
-      heuristic: getQueryHeuristicScore(entry, queryLower, trackedStatuses),
-      freshness: getFreshnessScore(entry.updated_at),
-    }))
-    .sort((a, b) => {
-      if (b.heuristic !== a.heuristic) return b.heuristic - a.heuristic;
-      if (searchRecencyWeight > 0 && b.freshness !== a.freshness) return b.freshness - a.freshness;
-      return a.index - b.index;
-    })
-    .map((item) => item.entry);
 }
 
 function clampOptionalLimit(value: unknown, max: number): number | undefined {
@@ -1591,39 +1103,6 @@ function getAttentionSeverity(category: AttentionItem["category"]): AttentionIte
     default:
       return "low";
   }
-}
-
-function getQueryExplainReasons(
-  entry: Entry,
-  queryLower: string,
-  trackedStatus: TrackedStatusAssessment | undefined,
-  match: NonNullable<QueryResult["match"]>,
-): string[] {
-  const reasons: string[] = [];
-
-  if (match.lexical_rank !== undefined) reasons.push("matched lexical terms");
-  if (match.semantic_rank !== undefined) reasons.push("matched semantic similarity");
-  if (match.hybrid_score !== undefined && match.lexical_rank !== undefined && match.semantic_rank !== undefined) {
-    reasons.push("combined lexical and semantic signals");
-  }
-  if (isTrackedNamespace(entry.namespace) && entry.key === "status") reasons.push("tracked status");
-  if (trackedStatus?.lifecycle === "blocked") reasons.push("blocked item");
-  else if (trackedStatus?.needsAttention) reasons.push("needs attention");
-  if (entry.namespace.startsWith("people/") && entry.key === "profile") reasons.push("profile entry");
-  if (entry.namespace === "meta/conventions" && entry.key === "conventions") reasons.push("conventions reference");
-  if (entry.namespace === "meta" && entry.key === "reference-index") reasons.push("reference index");
-  if (match.freshness_score !== undefined && match.freshness_score >= 0.5) reasons.push("recently updated");
-  if (isEntryExpired(entry)) reasons.push("expired entry included on request");
-
-  const queryTerms = queryLower
-    .split(/[^a-z0-9_-]+/i)
-    .map((term) => term.trim())
-    .filter((term) => term.length >= 4 && !RELAXED_QUERY_STOPWORDS.has(term));
-  const contentLower = entry.content.toLowerCase();
-  const matchedTerm = queryTerms.find((term) => contentLower.includes(term) || entry.namespace.toLowerCase().includes(term) || (entry.key?.toLowerCase().includes(term) ?? false));
-  if (matchedTerm) reasons.push(`matched term: ${matchedTerm}`);
-
-  return [...new Set(reasons)];
 }
 
 function buildAttentionItem(
@@ -3172,23 +2651,6 @@ function compareAttentionItems(a: AttentionItem, b: AttentionItem): number {
     return a.updated_at.localeCompare(b.updated_at);
   }
   return a.namespace.localeCompare(b.namespace);
-}
-
-function canonicalizeTags(tags: string[]): { canonical: string[]; normalized: string[] } {
-  const normalized: string[] = [];
-  const canonical = tags.map(t => {
-    const alias = TAG_ALIASES[t];
-    if (alias) {
-      normalized.push(`"${t}" → "${alias}"`);
-      return alias;
-    }
-    return t;
-  });
-  return { canonical, normalized };
-}
-
-function getLifecycleTags(tags: string[]): string[] {
-  return tags.filter(t => LIFECYCLE_TAGS.has(t));
 }
 
 /**

--- a/tests/benchmark-import-boundary.test.ts
+++ b/tests/benchmark-import-boundary.test.ts
@@ -1,16 +1,17 @@
 /**
- * PR 2b — load-bearing import boundary test.
+ * Load-bearing import boundary test (updated for issue #59).
  *
- * The benchmark runner is allowed to import only a small, curated set of
- * names from `src/tools.ts` (the reranker pipeline that PR 2b widened to
- * `export`). If new names creep in here we risk benchmark/ depending on
- * implementation detail that issue #59 is meant to extract into a
- * dedicated module. Lock the surface down now so a refactor stays
- * mechanical.
+ * The benchmark runner imports the reranker pipeline from the dedicated
+ * module `src/internal/reranker.ts` (extracted in issue #59). This test
+ * enforces two constraints:
  *
- * Update the allow-list when issue #59 lands or when a new pipeline name
- * needs benchmark visibility — and update issue #59's acceptance
- * criteria at the same time.
+ * 1. benchmark/ must NOT import any of the curated reranker names from
+ *    `src/tools.ts` — they now live in `src/internal/reranker.ts`.
+ * 2. benchmark/ may import from `src/internal/reranker.ts`, but only the
+ *    curated surface defined below.
+ *
+ * Update the allow-lists if the reranker surface changes, and keep the
+ * wildcard-import rejection in place.
  */
 
 import { describe, it, expect } from "vitest";
@@ -20,12 +21,12 @@ import { join, resolve } from "node:path";
 const BENCHMARK_DIR = resolve(__dirname, "..", "benchmark");
 
 /**
- * Names the benchmark surface is allowed to import from src/tools.js.
+ * Names the benchmark surface is allowed to import from
+ * src/internal/reranker.js (the dedicated module extracted in issue #59).
  * Anything else is a lint failure — either remove the new dependency or
- * propose a new public name on src/tools.ts and add it here in the
- * same PR that introduces it.
+ * add the name to the reranker's public surface and update this list.
  */
-const ALLOWED_TOOLS_IMPORTS = new Set<string>([
+const ALLOWED_RERANKER_IMPORTS = new Set<string>([
   "buildRelaxedLexicalQuery",
   "QUERY_RERANK_OVERFETCH_MULTIPLIER",
   "DEFAULT_SEARCH_RECENCY_WEIGHT",
@@ -148,7 +149,7 @@ describe("extractImports — lint primitive", () => {
 });
 
 describe("benchmark/ → src/tools.ts import boundary", () => {
-  it("benchmark/ only imports the curated reranker surface from src/tools", () => {
+  it("benchmark/ does not import any reranker names from src/tools", () => {
     const files = walkTypeScriptFiles(BENCHMARK_DIR);
     const violations: Array<{ file: string; name: string }> = [];
 
@@ -164,15 +165,14 @@ describe("benchmark/ → src/tools.ts import boundary", () => {
           || imp.from === "../../src/tools.js"
           || imp.from === "../../../src/tools.js";
         if (!isToolsImport) continue;
-        // Star and default imports are categorically forbidden: they
-        // pull every export off `src/tools.js` and trivially bypass the
-        // allow-list. Surface as a violation with a synthetic name so
-        // the error message points at the right pattern.
+        // Star and default imports are categorically forbidden.
         if (imp.wildcard) {
           violations.push({ file, name: "<star-or-default import>" });
         }
+        // The reranker names must now be imported from src/internal/reranker.js,
+        // not from src/tools.js. Any such import here is a boundary violation.
         for (const name of imp.names) {
-          if (!ALLOWED_TOOLS_IMPORTS.has(name)) {
+          if (ALLOWED_RERANKER_IMPORTS.has(name)) {
             violations.push({ file, name });
           }
         }
@@ -184,10 +184,49 @@ describe("benchmark/ → src/tools.ts import boundary", () => {
         .map((v) => `  ${v.file.replace(BENCHMARK_DIR, "benchmark")}: imports ${v.name}`)
         .join("\n");
       throw new Error(
-        `Benchmark surface imports unapproved names from src/tools.ts:\n${summary}\n\n` +
-          `If the new dependency is legitimate, add the name to ALLOWED_TOOLS_IMPORTS ` +
-          `in tests/benchmark-import-boundary.test.ts AND update issue #59's acceptance ` +
-          `criteria. If not, refactor the benchmark to not need it.`,
+        `Benchmark imports reranker names from src/tools.ts (should use src/internal/reranker.ts):\n${summary}\n\n` +
+          `The reranker pipeline now lives in src/internal/reranker.ts (issue #59). ` +
+          `Update the benchmark import to use "../src/internal/reranker.js".`,
+      );
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("benchmark/ only imports the curated reranker surface from src/internal/reranker", () => {
+    const files = walkTypeScriptFiles(BENCHMARK_DIR);
+    const violations: Array<{ file: string; name: string }> = [];
+
+    for (const file of files) {
+      const src = readFileSync(file, "utf-8");
+      const imports = extractImports(src);
+      for (const imp of imports) {
+        // Match paths that resolve to src/internal/reranker(.js).
+        const isRerankerImport = /(?:^|\/)src\/internal\/reranker(?:\.js)?$/.test(imp.from)
+          || imp.from === "../src/internal/reranker.js"
+          || imp.from === "../../src/internal/reranker.js"
+          || imp.from === "../../../src/internal/reranker.js";
+        if (!isRerankerImport) continue;
+        // Star and default imports are categorically forbidden: they
+        // pull every export off the module and trivially bypass the allow-list.
+        if (imp.wildcard) {
+          violations.push({ file, name: "<star-or-default import>" });
+        }
+        for (const name of imp.names) {
+          if (!ALLOWED_RERANKER_IMPORTS.has(name)) {
+            violations.push({ file, name });
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const summary = violations
+        .map((v) => `  ${v.file.replace(BENCHMARK_DIR, "benchmark")}: imports ${v.name}`)
+        .join("\n");
+      throw new Error(
+        `Benchmark surface imports unapproved names from src/internal/reranker.ts:\n${summary}\n\n` +
+          `If the new dependency is legitimate, add the name to ALLOWED_RERANKER_IMPORTS ` +
+          `in tests/benchmark-import-boundary.test.ts. If not, refactor the benchmark to not need it.`,
       );
     }
     expect(violations).toEqual([]);


### PR DESCRIPTION
Closes #59.

Behavior-preserving extraction of the query reranker pipeline out of the 6000-line `src/tools.ts` into two new **leaf** modules.

## What & why
The issue's premise ("move the reranker + transitive helpers") turned out more entangled than assumed: `getTrackedStatusAssessments` → `assessTrackedStatus` transitively needs cross-cutting **tag utilities** (`parseTags`, `canonicalizeTags`, `getLifecycleTags`, `LIFECYCLE_TAGS`, `TAG_ALIASES`) that ~10 unrelated `tools.ts` handlers also use. Three ways to resolve it; I took the clean one (two leaf modules) so neither file owns the wrong thing and there's no circular import:

- **`src/internal/retrieval-shared.ts`** — low-level helpers shared by the reranker *and* other handlers: time/staleness (`isStale`, `getFreshnessScore`, `getDaysUntil`, `isEntryExpiringSoon`, `findUpcomingEventDate` + thresholds + `DATE_PATTERN`), tag utilities, `isTrackedNamespace`, `RELAXED_QUERY_STOPWORDS`. **Pure leaf** — imports only `db.js` + `types.js`.
- **`src/internal/reranker.ts`** — the ranking/injection/assessment pipeline (the 8 public names + `TrackedStatusAssessment` + `getQueryExplainReasons`, `resolveSearchRecencyWeight` + private helpers). Imports `retrieval-shared` + `db` + `types`. **No import back into `tools.ts` → no cycle.**

## Module boundary
- `benchmark/runner.ts` imports the reranker surface from `src/internal/reranker.js` (was `src/tools.js`).
- `tests/benchmark-import-boundary.test.ts` now enforces: benchmark/ must **not** import reranker names from `src/tools.ts`, and may import **only** the curated surface from `src/internal/reranker.ts` (wildcard/default imports still rejected). Red/green verified.
- `tools.ts` no longer re-exports the pipeline — the dedicated module is the explicit public surface. It imports only the 12 names it uses internally (dropped 6 now-dead imports the initial pass left behind).

## Verification (byte-identical + behavioral)
- `rerankQueryResults` and `assessTrackedStatus` bodies **diff-clean vs `main`** (modulo the added `export` keyword) — static proof of a verbatim move.
- `tests/runner-parity.test.ts` passes: `production_ranker` top-k still matches `memory_query` across 4 corpus shapes — runtime proof `memory_query` behavior is preserved.
- `npm run build` clean; no `src/internal/` → `tools.js` import (no cycle).
- Full suite green (1152–1153 passing). The lone intermittent failure is the **pre-existing** `tests/onboarding/wizard-routes.test.ts` timing flake (passes in isolation and on clean `main`), unrelated to this change.

Pure refactor with no behavior change → no CHANGELOG entry, per the repo's documented policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)