### PR TITLE
test(fts): regression guard for slash/digit token matching; #42 already resolved

### DIFF
--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -342,6 +342,39 @@ describe("queryEntries (FTS5)", () => {
     expect(lowerHits.some((r) => r.content.includes("WebFetch"))).toBe(true);
   });
 
+  it("matches slash- and digit-separated tokens like 90/10 (#42)", () => {
+    // Regression guard: unicode61 tokenizes both the indexed content and the
+    // query phrase identically (`90/10` -> adjacent tokens `90`, `10`), so the
+    // ratio survives as a searchable phrase. No query-side expansion needed —
+    // this locks in that the slash case keeps working. The camelCase half is
+    // covered by the tests above (migration v17 / munin_split_tokens).
+    writeState(
+      db,
+      "projects/test",
+      "ratios",
+      "The split was 90/10 in favor of recall; a separate 80/20 rule applies",
+      ["notes"],
+    );
+
+    // Bare, quoted-phrase, and space-separated forms all find the 90/10 entry.
+    for (const q of ["90/10", '"90/10"', "90 10"]) {
+      expect(
+        queryEntries(db, { query: q }).some((r) => r.content.includes("90/10")),
+        `query ${JSON.stringify(q)} should match content containing 90/10`,
+      ).toBe(true);
+    }
+
+    // A different ratio in the same entry is independently findable.
+    expect(
+      queryEntries(db, { query: "80/20" }).some((r) => r.content.includes("80/20")),
+    ).toBe(true);
+
+    // And an absent ratio does not match (no over-eager false positive).
+    expect(
+      queryEntries(db, { query: "90/11" }).some((r) => r.content.includes("90/10")),
+    ).toBe(false);
+  });
+
   it("matches PascalCase identifiers and acronym boundaries (#42)", () => {
     writeState(
       db,


### PR DESCRIPTION
Re #42.

## TL;DR
#42 (FTS5 misses `90/10`, `WebFetch`, camelCase) is **already resolved** on `main`. This PR adds a regression guard for the slash/digit case and the issue can be closed as resolved-by-v17.

## Evidence
Empirical probe on current `main` — every case the issue lists already passes:

| query | result |
|---|---|
| `90/10` | ✅ matches |
| `"90/10"` (quoted) | ✅ matches |
| `90 10` | ✅ matches |
| `WebFetch` | ✅ matches (migration v17) |
| `web fetch` | ✅ matches (migration v17) |
| `80/20` | ✅ matches |
| `90/11` | ✅ correctly 0 hits (no false positive) |

## Why it already works
- **camelCase / PascalCase** — fixed by **migration v17** (`munin_split_tokens` write-side content augmentation). Existing tests at `tests/db.test.ts:326+`.
- **`90/10` slash case** — `unicode61` tokenizes the indexed content and the query phrase *identically* (`90/10` → adjacent tokens `90`,`10`), so the ratio survives as a searchable phrase. The issue's claim that `"90/10"` "would fail" predates v17 and does not reproduce.

Query-side expansion (the originally-floated approach) would be redundant here and risks false-positive regressions, so it's intentionally **not** implemented.

## Change
Adds one test — `matches slash- and digit-separated tokens like 90/10 (#42)` — locking in that `90/10`, `"90/10"`, `90 10`, and `80/20` match while `90/11` does not. No production code change. Full `db.test.ts` green (71 tests).

Suggest closing #42 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)