### PR TITLE
fix(db): honor MUNIN_MEMORY_DB_PATH in resolveDbPath for all entry points (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,17 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **`MUNIN_MEMORY_DB_PATH` is now honored by every entry point, not just the
+  server.** `resolveDbPath()` previously read the env var nowhere — only
+  `src/index.ts` consulted it explicitly and passed it into `initDatabase()`.
+  `munin-admin`, tests, and any bare `initDatabase()` call silently ignored it
+  and always resolved to the hardcoded `~/.munin-memory/memory.db` default,
+  contradicting the documented "configurable via `MUNIN_MEMORY_DB_PATH`"
+  contract. This was a footgun: an operator who set the env var expecting to
+  target a non-default DB could unknowingly read/write the production DB
+  instead. `resolveDbPath()` now applies the precedence **explicit path
+  (e.g. `munin-admin --db`) > `MUNIN_MEMORY_DB_PATH` > default**, so all entry
+  points resolve consistently. Existing explicit-path callers are unaffected.
 - **`memory_status` telemetry now reports a real 95th-percentile response
   size.** The `p95_response_size_bytes` field returned by
   `getToolCallAggregates` was previously computed as

--- a/src/db.ts
+++ b/src/db.ts
@@ -40,7 +40,13 @@ export function nowUTC(): string {
 }
 
 export function resolveDbPath(configuredPath?: string): string {
-  const raw = configuredPath || "~/.munin-memory/memory.db";
+  // Precedence: explicit path (e.g. `--db`, or the server's explicit env read)
+  // > MUNIN_MEMORY_DB_PATH > hardcoded default. Honoring the env var here means
+  // every entry point — server, munin-admin, tests, any bare initDatabase() —
+  // resolves to the same DB, matching the documented contract. Without this the
+  // CLI silently ignored MUNIN_MEMORY_DB_PATH and always hit the default,
+  // a footgun that could redirect writes to the production DB unexpectedly.
+  const raw = configuredPath || process.env.MUNIN_MEMORY_DB_PATH || "~/.munin-memory/memory.db";
   return raw.replace(/^~/, homedir());
 }
 

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -196,6 +196,36 @@ describe("path resolution", () => {
     );
   });
 
+  describe("MUNIN_MEMORY_DB_PATH precedence", () => {
+    const original = process.env.MUNIN_MEMORY_DB_PATH;
+    afterEach(() => {
+      if (original === undefined) delete process.env.MUNIN_MEMORY_DB_PATH;
+      else process.env.MUNIN_MEMORY_DB_PATH = original;
+    });
+
+    it("falls back to MUNIN_MEMORY_DB_PATH when no explicit path is given", () => {
+      process.env.MUNIN_MEMORY_DB_PATH = "/tmp/from-env.db";
+      expect(resolveDbPath()).toBe("/tmp/from-env.db");
+      // getDataDir/embedding cache derive from the same resolution.
+      expect(getDataDir()).toBe("/tmp");
+    });
+
+    it("lets an explicit path override the env var", () => {
+      process.env.MUNIN_MEMORY_DB_PATH = "/tmp/from-env.db";
+      expect(resolveDbPath("/tmp/explicit.db")).toBe("/tmp/explicit.db");
+    });
+
+    it("uses the hardcoded default when neither is set", () => {
+      delete process.env.MUNIN_MEMORY_DB_PATH;
+      expect(resolveDbPath()).toBe(`${homedir()}/.munin-memory/memory.db`);
+    });
+
+    it("expands a tilde coming from the env var", () => {
+      process.env.MUNIN_MEMORY_DB_PATH = "~/custom/memory.db";
+      expect(resolveDbPath()).toBe(`${homedir()}/custom/memory.db`);
+    });
+  });
+
   it("derives data dir from resolved DB path", () => {
     expect(getDataDir("~/.munin-memory/memory.db")).toBe(
       `${homedir()}/.munin-memory`,


### PR DESCRIPTION
Closes #67.

## Problem
`resolveDbPath()` (`src/db.ts`) never read `MUNIN_MEMORY_DB_PATH`. Only `src/index.ts:842` consulted the env var (explicitly, passing it into `initDatabase`). Every other entry point — **`munin-admin`**, tests, any bare `initDatabase()` — ignored it and always resolved to the hardcoded `~/.munin-memory/memory.db`, contradicting the documented "configurable via `MUNIN_MEMORY_DB_PATH`" contract.

**Footgun:** an operator who exports `MUNIN_MEMORY_DB_PATH` expecting `munin-admin` to target a non-default DB instead silently operates on the **production** DB. This bit me live during the issue-sweep session — a `munin-admin principals add` "dry-run" that set the env var to a `/tmp` path created a real principal in prod (since revoked).

## Fix
One centralized change to `resolveDbPath()` with precedence **explicit path (`--db` / explicit arg) > `MUNIN_MEMORY_DB_PATH` > default**. `getDataDir()` and `initDatabase()` both derive from `resolveDbPath()`, so all entry points are fixed at once. Explicit-path callers (including `index.ts`'s explicit env read) are unaffected.

## Verification
- 4 new precedence tests in `tests/embeddings.test.ts`: env fallback, explicit-arg override, default-when-unset, tilde-in-env. All pass.
- **End-to-end:** with `MUNIN_MEMORY_DB_PATH` set and no `--db`, `munin-admin principals add` now writes to the env-pointed temp DB and leaves the production DB **unchanged** (verified principal counts before/after).
- Full suite green: 1156 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)