### PR TITLE
fix(admin-cli): honor MUNIN_MEMORY_DB_PATH in resolveDbPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,16 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **`munin-admin` now honors `MUNIN_MEMORY_DB_PATH`.** The admin CLI
+  previously only accepted a `--db` flag and ignored the
+  `MUNIN_MEMORY_DB_PATH` env var that the server respects — so a dry-run
+  that exported the env var to a throwaway path silently wrote to the
+  production database instead. `resolveDbPath()` now falls back to
+  `MUNIN_MEMORY_DB_PATH` when no explicit path is given, with precedence
+  `--db` flag > env var > `~/.munin-memory/memory.db` default. The server
+  and embedding-cache paths are unaffected (they already passed the env
+  value explicitly). Help text and the `--db` docstring updated to
+  document the precedence.
 - **`memory_status` telemetry now reports a real 95th-percentile response
   size.** The `p95_response_size_bytes` field returned by
   `getToolCallAggregates` was previously computed as

--- a/src/admin-cli.ts
+++ b/src/admin-cli.ts
@@ -16,7 +16,8 @@
  *   munin-admin classification audit [namespace-prefix]
  *
  * Global flags:
- *   --db <path>     Database path (default: ~/.munin-memory/memory.db)
+ *   --db <path>     Database path. Precedence: --db > MUNIN_MEMORY_DB_PATH
+ *                   env var > ~/.munin-memory/memory.db (default).
  *   --json          Machine-readable JSON output
  *   --init          Allow creating a new DB if it doesn't exist
  *   --help          Show usage
@@ -904,7 +905,8 @@ Usage:
   munin-admin bearer revoke <key-id>
 
 Global flags:
-  --db <path>     Database path (default: ~/.munin-memory/memory.db)
+  --db <path>     Database path. Precedence: --db > MUNIN_MEMORY_DB_PATH
+                  env var > ~/.munin-memory/memory.db (default).
   --json          Machine-readable JSON output
   --init          Allow creating a new DB if it doesn't exist
   --force         Required for --type owner

--- a/src/db.ts
+++ b/src/db.ts
@@ -40,7 +40,14 @@ export function nowUTC(): string {
 }
 
 export function resolveDbPath(configuredPath?: string): string {
-  const raw = configuredPath || "~/.munin-memory/memory.db";
+  // Precedence: explicit path (e.g. admin CLI --db) > MUNIN_MEMORY_DB_PATH
+  // env var > default. The env fallback keeps the admin CLI and the server
+  // pointed at the same database; without it, `munin-admin` silently ignored
+  // MUNIN_MEMORY_DB_PATH and wrote to the production DB during dry-runs.
+  const raw =
+    configuredPath ||
+    process.env.MUNIN_MEMORY_DB_PATH ||
+    "~/.munin-memory/memory.db";
   return raw.replace(/^~/, homedir());
 }
 

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -219,6 +219,34 @@ describe("path resolution", () => {
       "/var/lib/munin-memory/hf-cache",
     );
   });
+
+  describe("MUNIN_MEMORY_DB_PATH fallback", () => {
+    const original = process.env.MUNIN_MEMORY_DB_PATH;
+    afterEach(() => {
+      if (original === undefined) {
+        delete process.env.MUNIN_MEMORY_DB_PATH;
+      } else {
+        process.env.MUNIN_MEMORY_DB_PATH = original;
+      }
+    });
+
+    it("falls back to MUNIN_MEMORY_DB_PATH when no path is given", () => {
+      process.env.MUNIN_MEMORY_DB_PATH = "/tmp/munin-throwaway.db";
+      expect(resolveDbPath(undefined)).toBe("/tmp/munin-throwaway.db");
+    });
+
+    it("prefers an explicit path over the env var", () => {
+      process.env.MUNIN_MEMORY_DB_PATH = "/tmp/munin-throwaway.db";
+      expect(resolveDbPath("/explicit/path.db")).toBe("/explicit/path.db");
+    });
+
+    it("falls back to the default when neither is set", () => {
+      delete process.env.MUNIN_MEMORY_DB_PATH;
+      expect(resolveDbPath(undefined)).toBe(
+        `${homedir()}/.munin-memory/memory.db`,
+      );
+    });
+  });
 });
 
 describe("vec store/remove operations", () => {


### PR DESCRIPTION
## Problem

`munin-admin` only accepted a `--db` flag and ignored the `MUNIN_MEMORY_DB_PATH` env var that the server (`index.ts`) respects. A dry-run that exported the env var to a throwaway path therefore wrote to the **production** DB instead — caught during #5 Sara onboarding prep (logged as a high-severity friction).

## Fix

`resolveDbPath()` now falls back to `MUNIN_MEMORY_DB_PATH` when no explicit path is given. Precedence: `--db` flag > env var > `~/.munin-memory/memory.db` default. Centralizing it in `resolveDbPath` means the admin CLI inherits it via `openDb` → `initDatabase`.

- Server and embedding-cache paths are unaffected — they already pass the env value explicitly, so the result is identical.
- Updated `--db` help text and docstring to document the precedence.
- Added `resolveDbPath` precedence tests (env fallback, explicit-path precedence, default-when-unset).

## Verification

Full suite green: **1155 passed, 3 skipped**; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)