### PR TITLE
fix(reranker): deterministic recency tie-break to fix runner-parity flake (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deterministic recency tie-break in query reranking** — `rerankQueryResults`
+  now breaks heuristic ties by the entries' stored `updated_at` rather than by a
+  freshness score computed from the wall clock. `getFreshnessScore` clamps age
+  to `>= 0`, so any entry whose `updated_at` is at or after the instant the
+  ranker reads the clock collapsed to freshness `1.0`. Two entries written ~1ms
+  apart therefore compared *equal* when ranked immediately but *distinct* a few
+  milliseconds later — so the result order depended on **when** the ranker ran.
+  `memory_query` and the benchmark runner run milliseconds apart, which made
+  their result ordering disagree for score-tied recent entries under load (the
+  flaky `runner-parity` test, #74). The stored `updated_at` is fixed data and
+  order-equivalent to freshness for already-aged entries, so rankings over real
+  corpora are unchanged. (#74)
+- **Deterministic tracked-status ordering** — `getTrackedStatuses` now orders by
+  `updated_at DESC, rowid` instead of `updated_at DESC` alone, so tied rows
+  (same-millisecond writes) can't come back in different relative order across
+  connections. (#74)
+
 ## [0.3.0] — 2026-05-30
 
 Roughly six weeks past v0.2.0. Headline items: DB-managed bearer-token rotation,

--- a/src/db.ts
+++ b/src/db.ts
@@ -156,13 +156,21 @@ export function rebuildFTS(db: Database.Database): void {
 // --- Tracked status queries ---
 
 export function getTrackedStatuses(db: Database.Database): TrackedStatusRow[] {
+  // `updated_at` ties are common (entries written in the same millisecond,
+  // e.g. test fixtures or bulk seeds). SQL does not guarantee a stable order
+  // for equal sort keys, so two different connections can return tied rows in
+  // different relative order — which leaks into attention-injection order and
+  // the computed dashboard, and makes the runner/memory_query parity test
+  // (tests/runner-parity.test.ts) flaky under load. `rowid` (insertion order)
+  // makes the order total and connection-independent, matching the de-facto
+  // tie-break already codified in queryEntriesLexicalScored.
   return db
     .prepare(
       `SELECT id, namespace, key, substr(content, 1, 300) as content_preview, content, tags, agent_id, owner_principal_id, created_at, updated_at, valid_until, classification
        FROM entries
        WHERE entry_type = 'state' AND key = 'status'
          AND (namespace LIKE 'projects/%' ESCAPE '\\' OR namespace LIKE 'clients/%' ESCAPE '\\')
-       ORDER BY updated_at DESC`,
+       ORDER BY updated_at DESC, rowid`,
     )
     .all() as TrackedStatusRow[];
 }

--- a/src/internal/reranker.ts
+++ b/src/internal/reranker.ts
@@ -17,7 +17,6 @@ import {
   getLifecycleTags,
   LIFECYCLE_TAGS,
   isStale,
-  getFreshnessScore,
   getDaysUntil,
   isEntryExpiringSoon,
   findUpcomingEventDate,
@@ -453,11 +452,22 @@ export function rerankQueryResults(
       entry,
       index,
       heuristic: getQueryHeuristicScore(entry, queryLower, trackedStatuses),
-      freshness: getFreshnessScore(entry.updated_at),
     }))
     .sort((a, b) => {
       if (b.heuristic !== a.heuristic) return b.heuristic - a.heuristic;
-      if (searchRecencyWeight > 0 && b.freshness !== a.freshness) return b.freshness - a.freshness;
+      // Recency tie-break by EXACT updated_at, not the float freshness score.
+      // getFreshnessScore clamps age to >= 0, so any entry whose updated_at is
+      // at/after the instant the ranker reads the clock collapses to freshness
+      // 1.0. Two entries written ~1ms apart therefore compare *equal* when
+      // ranked immediately (both clamped) but *distinct* when ranked a few ms
+      // later — so the order depended on WHEN the ranker ran. memory_query and
+      // the benchmark runner run milliseconds apart, so they disagreed on
+      // score-tied recent entries under load (the #74 parity flake). The
+      // stored updated_at is fixed data and order-equivalent to freshness for
+      // already-aged entries, so rankings over real corpora are unchanged.
+      if (searchRecencyWeight > 0 && a.entry.updated_at !== b.entry.updated_at) {
+        return a.entry.updated_at < b.entry.updated_at ? 1 : -1; // newer first
+      }
       return a.index - b.index;
     })
     .map((item) => item.entry);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -16,6 +16,7 @@ import {
   executeDelete,
   getOtherKeysInNamespace,
   getCompletedTaskNamespaces,
+  getTrackedStatuses,
   rebuildFTS,
   logToolCall,
   getToolCallAggregates,
@@ -56,6 +57,36 @@ describe("initDatabase", () => {
   it("sets WAL journal mode", () => {
     const mode = db.pragma("journal_mode", { simple: true });
     expect(mode).toBe("wal");
+  });
+});
+
+describe("getTrackedStatuses ordering (#74)", () => {
+  it("returns a total, connection-independent order when updated_at ties", () => {
+    // Seed several tracked statuses, then force identical updated_at to
+    // simulate same-millisecond bulk writes (test fixtures, seeds). Without a
+    // total-order tie-break, two connections can return tied rows in different
+    // order — the root cause of the runner-parity flake (#74).
+    writeState(db, "projects/alpha", "status", "Active alpha.", ["active"]);
+    writeState(db, "projects/bravo", "status", "Blocked bravo.", ["blocked"]);
+    writeState(db, "clients/delta", "status", "Active delta.", ["active"]);
+    writeState(db, "projects/charlie", "status", "Active charlie.", ["active"]);
+    db.prepare(
+      "UPDATE entries SET updated_at = '2026-01-01T00:00:00.000Z' WHERE key = 'status'",
+    ).run();
+
+    // Insertion order (rowid) is the documented tie-break.
+    const expected = ["projects/alpha", "projects/bravo", "clients/delta", "projects/charlie"];
+
+    // Stable across repeated calls AND across a fresh connection to the same DB.
+    const first = getTrackedStatuses(db).map((r) => r.namespace);
+    const second = getTrackedStatuses(db).map((r) => r.namespace);
+    const other = initDatabase(TEST_DB_PATH);
+    const third = getTrackedStatuses(other).map((r) => r.namespace);
+    other.close();
+
+    expect(first).toEqual(expected);
+    expect(second).toEqual(expected);
+    expect(third).toEqual(expected);
   });
 });
 

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -144,6 +144,19 @@ describe("generateEmbedding", () => {
 });
 
 describe("circuit breaker", () => {
+  // The failing extractor in these tests deliberately rejects with
+  // "model crashed"; generateEmbedding logs each failure via console.error.
+  // Capture it so the *expected* failures don't leak to full-suite stderr —
+  // that noise was misread as a real model crash in #74 — while still
+  // asserting the failure path logs as intended.
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
   it("disables after maxFailures consecutive failures", async () => {
     const failingExtractor = () => Promise.reject(new Error("model crashed"));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -155,6 +168,10 @@ describe("circuit breaker", () => {
     }
 
     expect(isEmbeddingAvailable()).toBe(false);
+    // The failure path logs each attempt — confirm it did (and was captured).
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("model crashed"),
+    );
 
     // generateEmbedding returns null when circuit breaker is tripped
     const result = await generateEmbedding("test");

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, unlinkSync } from "node:fs";
+import type Database from "better-sqlite3";
+import { initDatabase, writeState, getById } from "../src/db.js";
+import { rerankQueryResults } from "../src/internal/reranker.js";
+import type { Entry } from "../src/types.js";
+
+const TEST_DB_PATH = "/tmp/munin-memory-reranker-test.db";
+
+function cleanup() {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const p = TEST_DB_PATH + suffix;
+    if (existsSync(p)) unlinkSync(p);
+  }
+}
+
+let db: Database.Database;
+
+beforeEach(() => {
+  cleanup();
+  db = initDatabase(TEST_DB_PATH);
+});
+
+afterEach(() => {
+  db.close();
+  cleanup();
+});
+
+/**
+ * Regression guard for #74: the recency tie-break must order heuristic-tied
+ * entries by their stored `updated_at`, not by a freshness score that depends
+ * on the wall-clock instant the ranker runs.
+ *
+ * The old implementation compared `getFreshnessScore(updated_at)`, which clamps
+ * age to >= 0 — so any entry written at/after "now" collapsed to freshness 1.0.
+ * Two entries written ~1ms apart then compared *equal* when ranked immediately
+ * (both clamped) but *distinct* a few ms later, making the order depend on
+ * timing. memory_query and the benchmark runner run milliseconds apart, so they
+ * disagreed on score-tied recent entries under load.
+ */
+describe("rerankQueryResults recency tie-break (#74)", () => {
+  function tiedEntries(olderTs: string, newerTs: string): [Entry, Entry] {
+    // Two entries with identical heuristic score (both decisions/* state
+    // entries tagged "decision"). `older` is placed first in input order so
+    // the index tie-break alone would keep it first.
+    writeState(db, "decisions/older", "v1", "decision content one", ["decision"]);
+    writeState(db, "decisions/newer", "v1", "decision content two", ["decision"]);
+    const olderId = (db.prepare("SELECT id FROM entries WHERE namespace='decisions/older'").get() as { id: string }).id;
+    const newerId = (db.prepare("SELECT id FROM entries WHERE namespace='decisions/newer'").get() as { id: string }).id;
+    db.prepare("UPDATE entries SET updated_at=? WHERE id=?").run(olderTs, olderId);
+    db.prepare("UPDATE entries SET updated_at=? WHERE id=?").run(newerTs, newerId);
+    return [getById(db, olderId)!, getById(db, newerId)!];
+  }
+
+  const params = { query: "decision", search_recency_weight: 0.2 } as Parameters<typeof rerankQueryResults>[1];
+
+  it("orders the newer entry first even when both timestamps are in the future (freshness would clamp to 1.0)", () => {
+    const future = Date.now() + 60_000;
+    const older = new Date(future).toISOString();
+    const newer = new Date(future + 1).toISOString();
+    const [eOlder, eNewer] = tiedEntries(older, newer);
+    // Input order is [older, newer]; recency must override it.
+    const order = rerankQueryResults([eOlder, eNewer], params, new Set()).map((e) => e.namespace);
+    expect(order).toEqual(["decisions/newer", "decisions/older"]);
+  });
+
+  it("produces the same order regardless of how much time has elapsed since the write", () => {
+    // Timestamps just before "now" — the regime where the old clamp made
+    // freshness flip between equal and distinct depending on elapsed time.
+    const base = Date.now();
+    const older = new Date(base - 2).toISOString();
+    const newer = new Date(base - 1).toISOString();
+    const [eOlder, eNewer] = tiedEntries(older, newer);
+
+    const orderNow = rerankQueryResults([eOlder, eNewer], params, new Set()).map((e) => e.namespace);
+    const busyUntil = Date.now() + 1500;
+    while (Date.now() < busyUntil) {
+      /* burn wall-clock so a second rank runs at a very different "now" */
+    }
+    const orderLater = rerankQueryResults([eOlder, eNewer], params, new Set()).map((e) => e.namespace);
+
+    expect(orderNow).toEqual(["decisions/newer", "decisions/older"]);
+    expect(orderLater).toEqual(orderNow);
+  });
+
+  it("falls back to input order when timestamps are identical", () => {
+    const ts = new Date(Date.now() - 1000).toISOString();
+    const [eOlder, eNewer] = tiedEntries(ts, ts);
+    // Same updated_at → recency is a true tie → stable input order preserved.
+    const order = rerankQueryResults([eOlder, eNewer], params, new Set()).map((e) => e.namespace);
+    expect(order).toEqual(["decisions/older", "decisions/newer"]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the intermittent `runner-parity` failure (#74). `memory_query` and the benchmark runner's `production_ranker` mode returned the same score-tied entries in **different order** under parallel load.

## Root cause
`getFreshnessScore` clamps age with `Math.max(0, ageMs)`, so any entry whose `updated_at` is at/after the instant the ranker reads the clock collapses to freshness `1.0`. Two heuristic-tied entries written ~1ms apart therefore compared **equal** when ranked immediately (both clamped → fall through to the input-order tiebreak) but **distinct** a few milliseconds later (→ ordered by recency). `memory_query` and the runner run milliseconds apart, so they disagreed on tied recent entries. Load both widened that inter-call gap *and* made `seedCorpus`'s sequential writes straddle a millisecond — exposing the swap.

Reproduced **~28%** under CPU-stressed parallel runs; **0/30** after the fix.

The reported `"model crashed"` symptom was a red herring — that string is a deliberate fixture in the embeddings circuit-breaker test (no test loads the real model). Its stderr is now captured via a `console.error` spy so it no longer pollutes full-suite output.

## Changes
- **`rerankQueryResults`** — break heuristic ties by the **exact stored `updated_at`** instead of the clock-dependent float freshness. Order-equivalent to freshness for already-aged entries, so real-corpus rankings and the CI gate baseline are unchanged.
- **`getTrackedStatuses`** — `ORDER BY updated_at DESC, rowid` (total, connection-independent; same latent bug class for tied same-millisecond statuses).
- **Tests** — `tests/reranker.test.ts` recency tie-break regression guards (fail pre-fix); `getTrackedStatuses` ordering determinism; circuit-breaker stderr assertion/suppression.

## Verification
- Full suite: **1185 passed, 0 failed**.
- Contention loop (5-file subset under 8 CPU stressors): **0/30** failures (was ~28% pre-fix).

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)