### PR TITLE
fix(query): validate namespace filter in memory_query (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **`memory_query` validates the `namespace` filter** — an invalid namespace
+  filter (e.g. containing a dot or space) now returns a `validation_error`
+  instead of silently returning zero results, matching the write/read/log
+  paths. Valid prefix filters with a trailing slash (e.g. `projects/`) are
+  still accepted. (#79)
 - **Deterministic recency tie-break in query reranking** — `rerankQueryResults`
   now breaks heuristic ties by the entries' stored `updated_at` rather than by a
   freshness score computed from the wall clock. `getFreshnessScore` clamps age

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5224,6 +5224,15 @@ export function registerTools(
             }
             const searchRecencyWeight = recencyWeightCheck.value;
 
+            // Validate the namespace filter (parity with write/read/log paths).
+            // A trailing slash is permitted for prefix filters (e.g. "projects/").
+            if (namespace !== undefined && namespace !== null) {
+              const nsCheck = validateNamespace(namespace as string);
+              if (!nsCheck.valid) {
+                return errResult("query", "validation_error", nsCheck.error!);
+              }
+            }
+
             // Filter-only mode: no query text, just browse by filters
             if (!query || typeof query !== "string") {
               // Must have at least one filter to avoid returning everything

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1598,6 +1598,25 @@ describe("memory_query", () => {
     expect(result.results[0].provenance.principal_id).toBe("owner");
   });
 
+  it("rejects an invalid namespace filter with a validation error", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", namespace: "foo.bar" });
+    const result = parseToolResponse(raw) as { error?: string; results?: unknown[] };
+    expect(result.error).toBe("validation_error");
+  });
+
+  it("rejects an invalid namespace filter in filter-only mode", async () => {
+    const raw = await callTool("memory_query", { namespace: "bad ns", tags: ["active"] });
+    const result = parseToolResponse(raw) as { error?: string };
+    expect(result.error).toBe("validation_error");
+  });
+
+  it("accepts a valid namespace prefix filter (trailing slash)", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", namespace: "projects/" });
+    const result = parseToolResponse(raw) as { error?: string; total?: number };
+    expect(result.error).toBeUndefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+  });
+
   it("defaults search_mode to hybrid (degrades to lexical in test env)", async () => {
     const raw = await callTool("memory_query", { query: "SQLite" });
     const result = parseToolResponse(raw) as { search_mode: string; search_mode_actual?: string };


### PR DESCRIPTION
## Summary

`memory_query` accepted an invalid `namespace` filter (e.g. a dot or space) and silently returned **zero results** instead of a validation error — inconsistent with the write/read/log/update_status paths which all reject via `validateNamespace`.

This adds the same validation at the top of the `memory_query` handler, covering both search mode and filter-only mode. Trailing-slash prefix filters (e.g. `projects/`) remain valid because `NAMESPACE_RE` already permits `/`.

## Testing

- TDD: added failing tests for invalid filter (search + filter-only) and a passing-prefix guard, then implemented.
- `npm run build` passes; full vitest suite green (1188 passed).
- Cross-model review (codex gpt-5.5): no findings.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)