### PR TITLE
docs(write): document namespace grammar; name offending char (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ changelog is the canonical record of what moved.
   `memory_write` description, the `expected_updated_at` parameter description,
   and the compact conventions returned by `memory_orient` to match the actual
   behavior. (#80)
+- **Namespace grammar documented in the write/log tool descriptions** — the
+  `memory_write` and `memory_log` namespace (and key) parameter descriptions now
+  state the allowed grammar inline (start alphanumeric, then alphanumeric/`_`/
+  `-`/`/`; dots and spaces invalid). `validateNamespace` now names the offending
+  character and its position in the error message. (#82)
 
 ### Fixed
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -36,12 +36,18 @@ export function validateNamespace(namespace: string): SecurityResult {
     return { valid: false, error: "Namespace is required and must be a non-empty string." };
   }
   if (!NAMESPACE_RE.test(namespace)) {
-    const offending = findOffendingChar(namespace, /[a-zA-Z0-9/_-]/);
-    const detail = offending
-      ? offending.index === 0 && !/[a-zA-Z0-9]/.test(offending.char)
-        ? ` Namespaces must start with a letter or digit, but this starts with '${offending.char}'.`
-        : ` Character '${offending.char}' (position ${offending.index}) is not allowed.`
-      : "";
+    let detail = "";
+    if (!/[a-zA-Z0-9]/.test(namespace[0])) {
+      // First character must be alphanumeric. Characters like '/', '_', '-' are
+      // allowed *after* the start but not as the first character, so they would
+      // be missed by the general body scan below.
+      detail = ` Namespaces must start with a letter or digit, but this starts with '${namespace[0]}'.`;
+    } else {
+      const offending = findOffendingChar(namespace, /[a-zA-Z0-9/_-]/);
+      if (offending) {
+        detail = ` Character '${offending.char}' (position ${offending.index}) is not allowed.`;
+      }
+    }
     return {
       valid: false,
       error: `Invalid namespace "${namespace}". Must match pattern: starts with alphanumeric, then alphanumeric/underscore/hyphen/slash only.${detail}`,

--- a/src/security.ts
+++ b/src/security.ts
@@ -36,12 +36,31 @@ export function validateNamespace(namespace: string): SecurityResult {
     return { valid: false, error: "Namespace is required and must be a non-empty string." };
   }
   if (!NAMESPACE_RE.test(namespace)) {
+    const offending = findOffendingChar(namespace, /[a-zA-Z0-9/_-]/);
+    const detail = offending
+      ? offending.index === 0 && !/[a-zA-Z0-9]/.test(offending.char)
+        ? ` Namespaces must start with a letter or digit, but this starts with '${offending.char}'.`
+        : ` Character '${offending.char}' (position ${offending.index}) is not allowed.`
+      : "";
     return {
       valid: false,
-      error: `Invalid namespace "${namespace}". Must match pattern: starts with alphanumeric, then alphanumeric/underscore/hyphen/slash only.`,
+      error: `Invalid namespace "${namespace}". Must match pattern: starts with alphanumeric, then alphanumeric/underscore/hyphen/slash only.${detail}`,
     };
   }
   return { valid: true };
+}
+
+/**
+ * Return the first character (and its index) that is not in the allowed set.
+ * Used to give actionable validation errors that name the offending character.
+ */
+function findOffendingChar(value: string, allowed: RegExp): { char: string; index: number } | null {
+  for (let i = 0; i < value.length; i++) {
+    if (!allowed.test(value[i])) {
+      return { char: value[i], index: i };
+    }
+  }
+  return null;
 }
 
 export function validateKey(key: string): SecurityResult {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2933,12 +2933,12 @@ const TOOL_DEFINITIONS = [
         namespace: {
           type: "string",
           description:
-            "Hierarchical namespace using / separator. E.g. 'projects/hugin-munin', 'people/magnus', 'decisions/tech-stack'",
+            "Hierarchical namespace using / separator. E.g. 'projects/hugin-munin', 'people/magnus', 'decisions/tech-stack'. Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens instead, e.g. 'testing/foo-bar' not 'testing/foo.bar').",
         },
         key: {
           type: "string",
           description:
-            "Short descriptive slug for this entry. E.g. 'status', 'architecture', 'preferences'",
+            "Short descriptive slug for this entry. E.g. 'status', 'architecture', 'preferences'. Grammar: must start with a letter or digit, then only letters, digits, '_', and '-' (no '/', dots, or spaces).",
         },
         content: {
           type: "string",
@@ -3217,7 +3217,8 @@ const TOOL_DEFINITIONS = [
       properties: {
         namespace: {
           type: "string",
-          description: "The namespace to log to",
+          description:
+            "The namespace to log to (hierarchical, '/' separator). Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens, e.g. 'testing/foo-bar' not 'testing/foo.bar').",
         },
         content: {
           type: "string",

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -135,6 +135,17 @@ describe("validateNamespace", () => {
     expect(validateNamespace("projects@home").valid).toBe(false);
     expect(validateNamespace("projects.v1").valid).toBe(false);
   });
+
+  it("names the offending character in the error message", () => {
+    const dot = validateNamespace("testing/foo.bar");
+    expect(dot.valid).toBe(false);
+    expect(dot.error).toContain(".");
+    expect(dot.error).toContain("'.'");
+
+    const space = validateNamespace("bad ns");
+    expect(space.valid).toBe(false);
+    expect(space.error).toContain("' '");
+  });
 });
 
 describe("validateKey", () => {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -146,6 +146,15 @@ describe("validateNamespace", () => {
     expect(space.valid).toBe(false);
     expect(space.error).toContain("' '");
   });
+
+  it("names the offending start character for leading separators", () => {
+    for (const bad of ["/projects", "_foo", "-foo"]) {
+      const res = validateNamespace(bad);
+      expect(res.valid).toBe(false);
+      expect(res.error).toContain("start");
+      expect(res.error).toContain(`'${bad[0]}'`);
+    }
+  });
 });
 
 describe("validateKey", () => {


### PR DESCRIPTION
## Summary

Namespaces with a dot (e.g. `testing/foo.bar`) or space are rejected by the validator, but the grammar wasn't documented near the write tools — the failure was surprising (it blocked the Codex write phase of the user-test).

- Document the namespace grammar inline in `memory_write` and `memory_log` tool descriptions (and the `key` grammar).
- `validateNamespace` now names the offending character and its position in the error message.

## Testing

- TDD: added a failing security test asserting the error names the offending char (`.` and space), then implemented.
- `npm run build` passes; full vitest suite green.
- `tests/claude-md-tool-inventory.test.ts` stays green (no tool names changed).

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)