### PR TITLE
docs(query): explain match{} parity across search modes (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ changelog is the canonical record of what moved.
   `memory_history` clarifies cursor direction (`next_cursor` points to the
   oldest row of a cursorless page); the compact conventions add two inline
   example workflows.
+- **`memory_query` explain parity across search modes (#81)** — documented that
+  the per-result `match{}` block (already populated by the result formatter for
+  lexical, semantic, and hybrid modes) carries `heuristic_score`,
+  `freshness_score`, and `reasons` in every mode, plus the mode-specific
+  signals (`lexical_rank`/`lexical_score`, `semantic_rank`/`semantic_distance`,
+  and `hybrid_score`). Added a unit guard pinning the explain reasons for
+  semantic-only and hybrid match objects so the three modes stay at parity.
 
 ### Fixed
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3152,7 +3152,7 @@ const TOOL_DEFINITIONS = [
         },
         explain: {
           type: "boolean",
-          description: "Optional. If true, include retrieval metadata and per-result match explanations.",
+          description: "Optional. If true, include retrieval metadata and a per-result `match{}` block. The block carries `heuristic_score`, `freshness_score`, and `reasons` in every mode, plus the mode-specific signals: `lexical_rank`/`lexical_score` for lexical, `semantic_rank`/`semantic_distance` for semantic, and all of those plus `hybrid_score` (the RRF fusion score) for hybrid. Use it to debug ranking in any search mode.",
         },
         since: {
           type: "string",

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync, unlinkSync } from "node:fs";
 import type Database from "better-sqlite3";
 import { initDatabase, writeState, getById } from "../src/db.js";
-import { rerankQueryResults } from "../src/internal/reranker.js";
+import { rerankQueryResults, getQueryExplainReasons } from "../src/internal/reranker.js";
 import type { Entry } from "../src/types.js";
+import type { QueryResult } from "../src/types.js";
 
 const TEST_DB_PATH = "/tmp/munin-memory-reranker-test.db";
 
@@ -89,5 +90,52 @@ describe("rerankQueryResults recency tie-break (#74)", () => {
     // Same updated_at → recency is a true tie → stable input order preserved.
     const order = rerankQueryResults([eOlder, eNewer], params, new Set()).map((e) => e.namespace);
     expect(order).toEqual(["decisions/older", "decisions/newer"]);
+  });
+});
+
+/**
+ * Regression guard for #81: the per-result explain `match{}` block must reach
+ * parity across lexical / semantic / hybrid modes — including human-readable
+ * reasons derived from the mode-specific rank/score fields. The
+ * `formatQueryResult` builder in src/tools.ts already populates the
+ * mode-specific fields (semantic_rank/distance, hybrid_score, etc.); this test
+ * pins the reasons logic that turns those fields into explanations so
+ * semantic-only and hybrid results are never left without a debuggable reason.
+ */
+describe("getQueryExplainReasons mode parity (#81)", () => {
+  function entry(): Entry {
+    writeState(db, "projects/explain", "status", "explainable status content", ["active"]);
+    const id = (db.prepare("SELECT id FROM entries WHERE namespace='projects/explain'").get() as { id: string }).id;
+    return getById(db, id)!;
+  }
+
+  it("explains a semantic-only match", () => {
+    const match: NonNullable<QueryResult["match"]> = {
+      heuristic_score: 0.5,
+      freshness_score: 0.9,
+      semantic_rank: 1,
+      semantic_distance: 0.12,
+      reasons: [],
+    };
+    const reasons = getQueryExplainReasons(entry(), "vector neighbour", undefined, match);
+    expect(reasons).toContain("matched semantic similarity");
+    expect(reasons.length).toBeGreaterThan(0);
+  });
+
+  it("explains a hybrid match that fused both signals", () => {
+    const match: NonNullable<QueryResult["match"]> = {
+      heuristic_score: 0.7,
+      freshness_score: 0.9,
+      hybrid_score: 0.031,
+      lexical_rank: 2,
+      lexical_score: -3.1,
+      semantic_rank: 1,
+      semantic_distance: 0.2,
+      reasons: [],
+    };
+    const reasons = getQueryExplainReasons(entry(), "explainable status", undefined, match);
+    expect(reasons).toContain("matched lexical terms");
+    expect(reasons).toContain("matched semantic similarity");
+    expect(reasons).toContain("combined lexical and semantic signals");
   });
 });


### PR DESCRIPTION
## Summary

The issue reported that hybrid/semantic results omit the per-result `match{}` explain block that lexical provides.

**On investigation, `formatQueryResult` (src/tools.ts) already builds `match{}` for all three modes** under `explain:true`:
- every mode: `heuristic_score`, `freshness_score`, `reasons`
- lexical: `lexical_rank`, `lexical_score`
- semantic: `semantic_rank`, `semantic_distance`
- hybrid: `hybrid_score` + the lexical and semantic sub-fields

The likely cause of the field report is that the live server under test predated this code (v0.3.0 was freshly cut). This PR therefore makes the parity explicit and guarded rather than changing ranking logic:

- Documented the per-mode `match{}` fields on the `explain` parameter description.
- Added a unit guard on `getQueryExplainReasons` covering semantic-only and hybrid match objects (the test env degrades semantic/hybrid to lexical, so the reasons builder is the deterministic seam for asserting parity).

No behavior change to ranking.

## Testing

- `npm run build` passes; full vitest suite green (incl. the new reranker parity tests and claude-md-tool-inventory).

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)