### PR TITLE
fix(orient): bound dashboard and maintenance output (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ changelog is the canonical record of what moved.
   signals (`lexical_rank`/`lexical_score`, `semantic_rank`/`semantic_distance`,
   and `hybrid_score`). Added a unit guard pinning the explain reasons for
   semantic-only and hybrid match objects so the three modes stay at parity.
+- **`memory_orient` output is now bounded (#78)** — `standard`/`full` modes
+  default `dashboard_limit_per_group` to 10 (was unbounded), and
+  `maintenance_needed` is collapsed to an oldest-first top-10 list plus a new
+  `maintenance_meta` block (`total`, `shown`, `truncated`, and a
+  `full_list_hint`) in compact/standard modes. The full maintenance list is
+  available with `detail:"full"`. This prevents the standard/full response from
+  growing large enough to overflow the MCP output limit and stops the
+  maintenance list from flooding the compact handshake.
 
 ### Fixed
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2726,7 +2726,7 @@ const TOOL_DEFINITIONS = [
         dashboard_limit_per_group: {
           type: "integer",
           description:
-            "Optional. Maximum entries to return per lifecycle group in the dashboard. `compact` defaults to 5; other detail levels return all entries unless this is set.",
+            "Optional. Maximum entries to return per lifecycle group in the dashboard. `standard`/`full` default to 10 (bounds output size); `compact` returns all groups (already one-liners). Set explicitly to override. `dashboard_meta.truncated_groups` lists groups that were capped.",
         },
         namespace_limit: {
           type: "integer",
@@ -3561,7 +3561,12 @@ export function registerTools(
             const { include_demo, include_completed_tasks } = orientArgs;
             const detail = resolveOrientDetail(orientArgs);
             const includeNamespaces = orientArgs.include_namespaces ?? detail !== "compact";
-            const dashboardLimit = clampOptionalLimit(orientArgs.dashboard_limit_per_group, 50) ?? undefined;
+            // Default a sensible per-group cap in non-compact modes so
+            // standard/full output can't grow unbounded (#78). Compact already
+            // emits one-liners and is bounded by namespace_limit. Callers can
+            // override explicitly.
+            const dashboardLimit = clampOptionalLimit(orientArgs.dashboard_limit_per_group, 50)
+              ?? (detail === "compact" ? undefined : 10);
             const namespaceLimit = clampOptionalLimit(orientArgs.namespace_limit, 200) ?? (detail === "compact" ? 20 : undefined);
             // Read conventions and namespace list
             const conventions = ctx.principalType === "owner" ? readState(db, "meta/conventions", "conventions") : null;
@@ -3622,6 +3627,9 @@ export function registerTools(
               uncategorized: [],
             };
             const maintenanceNeeded: MaintenanceItem[] = [];
+            // Sort key (oldest-first) per maintenance item, so the collapsed
+            // top-N surfaces the stalest work. Keyed by item identity.
+            const maintenanceSortKey = new Map<MaintenanceItem, string>();
 
             for (const assessment of trackedStatusAssessments) {
               const entry: DashboardEntry = {
@@ -3637,7 +3645,10 @@ export function registerTools(
               if (assessment.needsAttention) {
                 entry.needs_attention = true;
               }
-              maintenanceNeeded.push(...assessment.maintenanceItems);
+              for (const item of assessment.maintenanceItems) {
+                maintenanceSortKey.set(item, assessment.row.updated_at);
+                maintenanceNeeded.push(item);
+              }
 
               // Enrich with synthesis — skip entirely in compact mode
               if (detail !== "compact") {
@@ -3695,11 +3706,13 @@ export function registerTools(
             ]);
             for (const ns of namespaces) {
               if (isTrackedNamespace(ns.namespace) && !trackedNsWithStatus.has(ns.namespace)) {
-                maintenanceNeeded.push({
+                const missingItem: MaintenanceItem = {
                   namespace: ns.namespace,
                   issue: "missing_status",
                   suggestion: "Has entries but no 'status' key. Write a status entry with a lifecycle tag.",
-                });
+                };
+                maintenanceSortKey.set(missingItem, ns.last_activity_at);
+                maintenanceNeeded.push(missingItem);
               }
             }
 
@@ -3774,9 +3787,28 @@ export function registerTools(
               }
             }
 
-            // Maintenance suggestions
+            // Maintenance suggestions. The full list can flood the response
+            // (one line per stale tracked status), so for compact/standard we
+            // collapse to the oldest-first top-N plus a count; the full list is
+            // gated behind detail:"full" (#78).
             if (maintenanceNeeded.length > 0) {
-              response.maintenance_needed = maintenanceNeeded;
+              const MAINTENANCE_TOP_N = 10;
+              // Oldest-first: items with an earlier sort key (updated_at /
+              // last_activity_at) surface first. Items lacking a key sort last.
+              const sorted = [...maintenanceNeeded].sort((a, b) => {
+                const ka = maintenanceSortKey.get(a) ?? "￿";
+                const kb = maintenanceSortKey.get(b) ?? "￿";
+                return ka < kb ? -1 : ka > kb ? 1 : 0;
+              });
+              const showAll = detail === "full" || sorted.length <= MAINTENANCE_TOP_N;
+              const shown = showAll ? sorted : sorted.slice(0, MAINTENANCE_TOP_N);
+              response.maintenance_needed = shown;
+              response.maintenance_meta = {
+                total: maintenanceNeeded.length,
+                shown: shown.length,
+                truncated: !showAll,
+                ...(showAll ? {} : { full_list_hint: 'Pass detail:"full" to see all maintenance items.' }),
+              };
             }
 
             // Legacy workbench (transition period) — owner only

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -5414,6 +5414,63 @@ describe("maintenance suggestions (memory_orient)", () => {
     const aliceIssue = (result.maintenance_needed ?? []).find(m => m.namespace === "people/alice");
     expect(aliceIssue).toBeUndefined();
   });
+
+  it("collapses maintenance_needed to a top-N list with a count in compact/standard (#78)", async () => {
+    // Create 25 active-but-stale tracked statuses.
+    for (let i = 0; i < 25; i++) {
+      const ns = `projects/stale-${String(i).padStart(2, "0")}`;
+      await callTool("memory_write", { namespace: ns, key: "status", content: `Stale ${i}`, tags: ["active"] });
+      // Backdate so they are flagged active_but_stale; older index = older entry.
+      const ts = new Date(Date.UTC(2020, 0, 1 + i)).toISOString();
+      db.prepare("UPDATE entries SET updated_at = ? WHERE namespace = ? AND key = 'status'").run(ts, ns);
+    }
+
+    const raw = await callTool("memory_orient", {});
+    const result = parseToolResponse(raw) as {
+      maintenance_needed?: Array<{ namespace: string; issue: string }>;
+      maintenance_meta?: { total: number; shown: number; truncated: boolean };
+    };
+
+    expect(result.maintenance_meta).toBeDefined();
+    expect(result.maintenance_meta!.total).toBeGreaterThanOrEqual(25);
+    expect(result.maintenance_needed!.length).toBeLessThanOrEqual(10);
+    expect(result.maintenance_meta!.truncated).toBe(true);
+    expect(result.maintenance_meta!.shown).toBe(result.maintenance_needed!.length);
+    // Oldest first: the earliest-backdated namespace should be present.
+    expect(result.maintenance_needed!.some(m => m.namespace === "projects/stale-00")).toBe(true);
+  });
+
+  it("returns the full maintenance_needed list when detail is full (#78)", async () => {
+    for (let i = 0; i < 25; i++) {
+      const ns = `projects/stale-${String(i).padStart(2, "0")}`;
+      await callTool("memory_write", { namespace: ns, key: "status", content: `Stale ${i}`, tags: ["active"] });
+      const ts = new Date(Date.UTC(2020, 0, 1 + i)).toISOString();
+      db.prepare("UPDATE entries SET updated_at = ? WHERE namespace = ? AND key = 'status'").run(ts, ns);
+    }
+
+    const raw = await callTool("memory_orient", { detail: "full" });
+    const result = parseToolResponse(raw) as {
+      maintenance_needed?: Array<{ namespace: string }>;
+      maintenance_meta?: { total: number; truncated: boolean };
+    };
+    expect(result.maintenance_needed!.length).toBeGreaterThanOrEqual(25);
+    expect(result.maintenance_meta!.truncated).toBe(false);
+  });
+
+  it("defaults a dashboard_limit_per_group for non-compact modes (#78)", async () => {
+    for (let i = 0; i < 15; i++) {
+      await callTool("memory_write", { namespace: `projects/active-${String(i).padStart(2, "0")}`, key: "status", content: `Active ${i}`, tags: ["active"] });
+    }
+
+    const raw = await callTool("memory_orient", { detail: "standard" });
+    const result = parseToolResponse(raw) as {
+      dashboard: { active: unknown[] };
+      dashboard_meta: { counts: Record<string, number>; truncated_groups: string[] };
+    };
+    expect(result.dashboard.active.length).toBeLessThanOrEqual(10);
+    expect(result.dashboard_meta.counts.active).toBeGreaterThanOrEqual(15);
+    expect(result.dashboard_meta.truncated_groups).toContain("active");
+  });
 });
 
 describe("reference index (memory_orient)", () => {


### PR DESCRIPTION
## Summary

`memory_orient` non-compact output was unbounded — `standard` mode produced 76k+ chars in the user-test, exceeded the MCP output limit, and silently spilled to a file. Even compact mode was dominated by `maintenance_needed` (~37 near-identical `active_but_stale` lines).

Two bounding changes:

1. **Dashboard:** `standard`/`full` now default `dashboard_limit_per_group` to **10** (was unbounded). `compact` is unchanged (already one-liners). `dashboard_meta.truncated_groups` lists capped groups (pre-existing mechanism).
2. **Maintenance:** `maintenance_needed` is collapsed to an **oldest-first top-10** in compact/standard, with a new `maintenance_meta` block:
   ```json
   { "total": 37, "shown": 10, "truncated": true, "full_list_hint": "Pass detail:\"full\" to see all maintenance items." }
   ```
   The full list is returned when `detail:"full"`. Items sort oldest-first by source `updated_at` / `last_activity_at`, so the stalest work surfaces.

## Testing

- TDD: added three failing tests (compact collapse + meta, full-list passthrough, non-compact dashboard cap), then implemented.
- `npm run build` passes; full vitest suite green (1188); access-enforcement + claude-md-tool-inventory green.
- Existing maintenance tests (small datasets) unaffected — items remain in the top-10.

## Note
Did not add a runtime "may exceed output limit" warning string for standard/full (the issue suggested it as optional); the hard bounding above addresses the overflow directly and keeps the response schema clean.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)