### PR TITLE
feat(query): lexical-anchor controls for semantic/hybrid recall (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Added
+
+- **`memory_query` lexical-anchor controls for semantic/hybrid recall (#77)** —
+  semantic/hybrid search ran pure KNN with no distance threshold, so a query
+  with no lexical match (e.g. a made-up identifier) still returned up to `limit`
+  loosely-related vector neighbours. Three additive controls, none of which
+  change default recall:
+  - `require_lexical_match` (boolean, default `false`) on `memory_query`: in
+    semantic/hybrid modes, drop results that have no lexical (FTS5) anchor.
+    Injected canonical/attention entries are exempt. Uses a scoped FTS existence
+    check so a genuine lexical match is never dropped for ranking low.
+  - A `warning` is now always emitted when a hybrid query degrades to
+    semantic-only (zero FTS5 matches), so callers know recall came purely from
+    vectors.
+  - `MUNIN_SEMANTIC_MAX_DISTANCE` (env, unset = unbounded): optional L2 distance
+    cutoff applied in `queryEntriesSemanticScored` to drop far vector candidates.
+
 ### Changed
 
 - **CAS docs corrected to cover all state writes** — `expected_updated_at`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -590,6 +590,7 @@ See `technical-spec.md` § Security Module for the full pattern list.
 | `MUNIN_HYBRID_ENABLED` | `true` | Gate 2: accept `search_mode: "hybrid"` |
 | `MUNIN_EMBEDDINGS_MODEL` | `Xenova/all-MiniLM-L6-v2` | HuggingFace model for embeddings |
 | `MUNIN_EMBEDDINGS_MAX_FAILURES` | `5` | Circuit breaker failure threshold |
+| `MUNIN_SEMANTIC_MAX_DISTANCE` | — (unset = unbounded) | Optional L2 distance cutoff for semantic/hybrid KNN. When set to a finite, non-negative value, vector candidates farther than the cutoff are dropped so pure-KNN search can't return unrelated "nearest" neighbours. Embeddings are normalized 384-dim, so L2² = 2(1−cosine); L2 ranges 0 (identical) to 2 (opposite). Unset preserves prior unbounded behavior. |
 | `MUNIN_ALLOWED_HOSTS` | — | Comma-separated extra Host headers to accept |
 | `MUNIN_OAUTH_ISSUER_URL` | `http://localhost:3030` | OAuth issuer URL (set to your public domain in production) |
 | `MUNIN_OAUTH_ACCESS_TOKEN_TTL` | `3600` | Access token lifetime (seconds) |

--- a/src/db.ts
+++ b/src/db.ts
@@ -699,6 +699,37 @@ export function queryEntriesLexicalScored(
   });
 }
 
+/**
+ * Of the given entry IDs, return the subset that lexically match `query` via
+ * FTS5. Unlike `queryEntriesLexicalScored` this is an existence check scoped to
+ * a specific ID set with no rank/limit window, so it is safe for
+ * `require_lexical_match`: a semantic hit that matches FTS5 is never falsely
+ * dropped just because it ranks low lexically. Returns an empty set when `ids`
+ * is empty.
+ */
+export function filterIdsMatchingFts(
+  db: Database.Database,
+  query: string,
+  ids: string[],
+): Set<string> {
+  if (ids.length === 0) return new Set();
+  const placeholders = ids.map(() => "?").join(",");
+  const sql = `
+    SELECT e.id FROM entries e
+    JOIN entries_fts fts ON e.rowid = fts.rowid
+    WHERE entries_fts MATCH ? AND e.id IN (${placeholders})
+  `;
+  let rows: Array<{ id: string }>;
+  try {
+    rows = db.prepare(sql).all(escapeFtsQuery(query), ...ids) as Array<{ id: string }>;
+  } catch {
+    // Malformed FTS expression for the escaped query — treat as no matches
+    // rather than throwing inside the query path.
+    return new Set();
+  }
+  return new Set(rows.map((r) => r.id));
+}
+
 export interface FilterOptions {
   namespace?: string;
   entryType?: EntryType;
@@ -1576,6 +1607,13 @@ export interface SemanticQueryOptions {
   includeExpired?: boolean;
   since?: string;
   until?: string;
+  /**
+   * Optional maximum vec0 distance (L2 over normalized embeddings). When set,
+   * candidates whose distance exceeds this cutoff are dropped — this prevents
+   * pure-KNN search from returning unrelated "nearest" neighbours when nothing
+   * is actually close. Unset (default) preserves the prior unbounded behavior.
+   */
+  maxDistance?: number;
 }
 
 export function queryEntriesSemantic(
@@ -1589,7 +1627,7 @@ export function queryEntriesSemanticScored(
   db: Database.Database,
   options: SemanticQueryOptions,
 ): SemanticQueryResult[] {
-  const { queryEmbedding, namespace, entryType, tags, limit = 10, includeExpired = false, since, until } = options;
+  const { queryEmbedding, namespace, entryType, tags, limit = 10, includeExpired = false, since, until, maxDistance } = options;
   const clampedLimit = Math.min(Math.max(limit, 1), 50);
   const now = nowUTC();
 
@@ -1617,6 +1655,10 @@ export function queryEntriesSemanticScored(
 
   for (const { entry_id, distance } of vecResults) {
     if (results.length >= clampedLimit) break;
+
+    // Distance cutoff: vec0 returns candidates in ascending distance order, so
+    // once we exceed the cutoff every remaining candidate is farther — stop.
+    if (maxDistance !== undefined && distance > maxDistance) break;
 
     const entry = getEntry.get(entry_id) as Entry | undefined;
     if (!entry) continue;

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -13,6 +13,15 @@ const config = {
   batchDelayMs: parseInt(process.env.MUNIN_EMBEDDINGS_BATCH_DELAY_MS ?? "200", 10) || 200,
   maxFailures: parseInt(process.env.MUNIN_EMBEDDINGS_MAX_FAILURES ?? "5", 10) || 5,
   localOnly: (process.env.MUNIN_EMBEDDINGS_LOCAL_ONLY ?? "false") === "true",
+  // Optional L2 distance cutoff for semantic/hybrid KNN. Unset = unbounded
+  // (current behavior). A finite, non-negative value drops vector candidates
+  // farther than the cutoff so unrelated "nearest" neighbours aren't returned.
+  semanticMaxDistance: (() => {
+    const raw = process.env.MUNIN_SEMANTIC_MAX_DISTANCE;
+    if (raw === undefined || raw === "") return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  })(),
 };
 
 const EMBEDDING_DIM = 384;
@@ -147,6 +156,14 @@ export function isEmbeddingAvailable(): boolean {
 
 export function isSemanticEnabled(): boolean {
   return config.semanticEnabled && isEmbeddingAvailable();
+}
+
+/**
+ * Optional configured L2 distance cutoff for semantic/hybrid KNN, or undefined
+ * when MUNIN_SEMANTIC_MAX_DISTANCE is unset/invalid (unbounded — default).
+ */
+export function getSemanticMaxDistance(): number | undefined {
+  return config.semanticMaxDistance;
 }
 
 export function isHybridEnabled(): boolean {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5461,12 +5461,25 @@ export function registerTools(
               const vectorIds = actualMode === "hybrid"
                 ? hybridResults.map((r) => r.entry.id)
                 : semanticResults.map((r) => r.entry.id);
-              // For hybrid, lexicalRank already tells us the anchor set. For
-              // semantic mode (no FTS run), do a scoped existence check so a
-              // genuine lexical match isn't missed due to lexical rank depth.
-              const anchored = actualMode === "hybrid"
-                ? new Set(hybridResults.filter((r) => r.lexicalRank !== undefined).map((r) => r.entry.id))
-                : filterIdsMatchingFts(db, query, vectorIds);
+              // Anchor set = union of two signals (#77):
+              //  1. A scoped FTS existence check on the exact query. The hybrid
+              //     RRF result only carries `lexicalRank` for entries inside the
+              //     limited FTS over-fetch window, so a genuine exact match whose
+              //     rank falls below that window would otherwise be misclassified
+              //     as anchorless. The scoped check is authoritative for exact
+              //     matches and avoids that rank-depth false negative.
+              //  2. Any hybrid-leg result that already carries a `lexicalRank`.
+              //     This preserves relaxed-fallback anchors: when the hybrid leg
+              //     found matches only via the relaxed lexical query (e.g. a
+              //     natural-language query with stopwords), those entries are
+              //     legitimately lexically anchored even though the exact-query
+              //     scoped check above would not match them.
+              const anchored = filterIdsMatchingFts(db, query, vectorIds);
+              if (actualMode === "hybrid") {
+                for (const r of hybridResults) {
+                  if (r.lexicalRank !== undefined) anchored.add(r.entry.id);
+                }
+              }
               for (const id of vectorIds) {
                 if (!anchored.has(id)) anchorlessVectorIds.add(id);
               }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -27,6 +27,7 @@ import {
   appendLog,
   queryEntries,
   queryEntriesLexicalScored,
+  filterIdsMatchingFts,
   queryEntriesSemantic,
   queryEntriesSemanticScored,
   queryEntriesHybrid,
@@ -101,6 +102,7 @@ import {
   isSemanticEnabled,
   isHybridEnabled,
   getSearchModeUnavailableReason,
+  getSemanticMaxDistance,
 } from "./embeddings.js";
 import {
   consolidateNamespace,
@@ -3162,6 +3164,10 @@ const TOOL_DEFINITIONS = [
           type: "string",
           description: "Optional. ISO 8601 timestamp. Only return entries updated at or before this time.",
         },
+        require_lexical_match: {
+          type: "boolean",
+          description: "Optional (default false). In semantic/hybrid modes, drop results that have no lexical (FTS5) match — i.e. require a lexical anchor for every result. Use when you want to avoid loosely-related vector neighbours (e.g. searching for an exact identifier). No effect in lexical mode. Note: a hybrid query that collapses to semantic-only always emits a `warning` regardless of this flag.",
+        },
       },
       required: [],
     },
@@ -5218,6 +5224,7 @@ export function registerTools(
             const { query, namespace, entry_type, tags, limit, search_mode, since, until } = queryArgs;
             const explain = queryArgs.explain === true;
             const includeExpired = queryArgs.include_expired === true;
+            const requireLexicalMatch = queryArgs.require_lexical_match === true;
             const recencyWeightCheck = resolveSearchRecencyWeight(queryArgs);
             if (!recencyWeightCheck.ok) {
               return errResult("query", "validation_error", recencyWeightCheck.error);
@@ -5358,6 +5365,7 @@ export function registerTools(
                   includeExpired: true,
                   since,
                   until,
+                  maxDistance: getSemanticMaxDistance(),
                 });
                 const filteredExpired = filterExpiredEntries(semanticResults, includeExpired);
                 semanticResults = filteredExpired.items;
@@ -5377,7 +5385,7 @@ export function registerTools(
                 const relaxedQuery = buildRelaxedLexicalQuery(query);
                 const hybridScored = queryEntriesHybridScored(db, {
                   ftsOptions: { query, namespace, entryType: entry_type, tags, limit: internalLimit, includeExpired: true, since, until },
-                  semanticOptions: { queryEmbedding: buf, namespace, entryType: entry_type, tags, limit: internalLimit, includeExpired: true, since, until },
+                  semanticOptions: { queryEmbedding: buf, namespace, entryType: entry_type, tags, limit: internalLimit, includeExpired: true, since, until, maxDistance: getSemanticMaxDistance() },
                   ftsFallbackOptions: relaxedQuery
                     ? { query: relaxedQuery, namespace, entryType: entry_type, tags, limit: internalLimit, includeExpired: true, since, until, rawFts5: true }
                     : undefined,
@@ -5439,6 +5447,36 @@ export function registerTools(
               }
             }
 
+            // #77: surface and optionally suppress purely-semantic recall.
+            // A semantic/hybrid query can return vector "nearest neighbours"
+            // that have no lexical anchor at all — useful for paraphrase recall,
+            // misleading for made-up identifiers. Determine which *vector-
+            // derived* results lack a lexical (FTS5) anchor. We always warn when
+            // a hybrid query degraded to semantic-only, and (when
+            // require_lexical_match) drop the anchorless vector results below —
+            // after canonical/attention injection, so intentionally-injected
+            // entries are never dropped by this flag.
+            const anchorlessVectorIds = new Set<string>();
+            if (actualMode === "hybrid" || actualMode === "semantic") {
+              const vectorIds = actualMode === "hybrid"
+                ? hybridResults.map((r) => r.entry.id)
+                : semanticResults.map((r) => r.entry.id);
+              // For hybrid, lexicalRank already tells us the anchor set. For
+              // semantic mode (no FTS run), do a scoped existence check so a
+              // genuine lexical match isn't missed due to lexical rank depth.
+              const anchored = actualMode === "hybrid"
+                ? new Set(hybridResults.filter((r) => r.lexicalRank !== undefined).map((r) => r.entry.id))
+                : filterIdsMatchingFts(db, query, vectorIds);
+              for (const id of vectorIds) {
+                if (!anchored.has(id)) anchorlessVectorIds.add(id);
+              }
+              // Warn when a hybrid query produced results but none were lexically
+              // anchored (recall came purely from vectors).
+              if (actualMode === "hybrid" && results.length > 0 && anchored.size === 0 && !warning) {
+                warning = "Hybrid query had zero lexical (FTS5) matches; all results came from vector similarity only. Recall may be loosely related — pass require_lexical_match: true to require a lexical anchor.";
+              }
+            }
+
             const trackedStatuses = (shouldApplyDefaultQuerySuppression(queryParams) || explain)
               ? getTrackedStatusAssessments(db)
               : undefined;
@@ -5447,6 +5485,18 @@ export function registerTools(
             if (trackedStatuses) {
               results = injectAttentionQueryEntries(results, queryParams, trackedStatuses);
             }
+
+            // Apply require_lexical_match after injection so injected
+            // canonical/attention entries survive; only drop anchorless
+            // vector-derived results.
+            if (requireLexicalMatch && anchorlessVectorIds.size > 0) {
+              const before = results.length;
+              results = results.filter((entry) => !anchorlessVectorIds.has(entry.id));
+              if (results.length < before && !warning) {
+                warning = `require_lexical_match dropped ${before - results.length} result(s) with no lexical (FTS5) anchor.`;
+              }
+            }
+
             results = filterByAccess(ctx, results);
             const completedTasks = shouldApplyDefaultQuerySuppression(queryParams)
               ? getCompletedTaskNamespaces(db)

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,12 @@ export interface QueryParams {
   explain?: boolean;
   since?: string;
   until?: string;
+  /**
+   * In semantic/hybrid modes, drop results that had no lexical (FTS5) match —
+   * i.e. require a lexical anchor for every returned result. Default false
+   * (preserves recall). No effect in lexical mode.
+   */
+  require_lexical_match?: boolean;
 }
 
 export interface OrientParams extends ListParams {

--- a/tests/semantic-threshold.test.ts
+++ b/tests/semantic-threshold.test.ts
@@ -165,6 +165,29 @@ describe("memory_query require_lexical_match + semantic-only warning (#77)", () 
     expect(withoutFlag.results.length).toBeGreaterThan(0);
   });
 
+  it.skipIf(!vecAvailable)("keeps relaxed-fallback lexical anchors under require_lexical_match", async () => {
+    // A natural-language query has no exact (AND-of-all-terms) FTS match, so the
+    // hybrid leg falls back to the relaxed lexical query and anchors the entry
+    // via the "cat" token. require_lexical_match must not drop it just because
+    // the scoped *exact*-query existence check finds nothing.
+    seedEntry("animals/cat", "info", "all about the cat", 1);
+
+    const withFlag = parse(await callTool("memory_query", {
+      query: "tell me about cat",
+      search_mode: "hybrid",
+      require_lexical_match: true,
+    })) as { results: Array<{ namespace: string }> };
+
+    const withoutFlag = parse(await callTool("memory_query", {
+      query: "tell me about cat",
+      search_mode: "hybrid",
+    })) as { results: Array<{ namespace: string }> };
+
+    // Whatever the relaxed leg returns without the flag must survive with it.
+    expect(withoutFlag.results.some((r) => r.namespace === "animals/cat")).toBe(true);
+    expect(withFlag.results.some((r) => r.namespace === "animals/cat")).toBe(true);
+  });
+
   it.skipIf(!vecAvailable)("keeps lexically-anchored hybrid results under require_lexical_match", async () => {
     seedEntry("animals/cat", "info", "all about the cat", 1);
 
@@ -175,5 +198,44 @@ describe("memory_query require_lexical_match + semantic-only warning (#77)", () 
     })) as { results: Array<{ namespace: string }> };
     expect(result.results.length).toBeGreaterThan(0);
     expect(result.results.some((r) => r.namespace === "animals/cat")).toBe(true);
+  });
+
+  it.skipIf(!vecAvailable)("keeps a lexically-matching hybrid result whose FTS rank is below the over-fetch window", async () => {
+    // The anchor check for require_lexical_match must rely on a scoped FTS
+    // existence query (filterIdsMatchingFts) rather than the RRF result's
+    // lexicalRank, which is only populated for entries inside the limit*5 FTS
+    // over-fetch window. Seed many strong "cat" lexical matches so a sparse,
+    // exact-vector-match entry ranks below that window, then assert it is not
+    // dropped as anchorless.
+    for (let i = 0; i < 14; i++) {
+      writeState(db, `bulk/cat-${i}`, "info", `cat cat cat cats cats note ${i}`, []);
+    }
+    const targetId = seedEntry("animals/special", "info", "a special cat", 1);
+
+    const result = parse(await callTool("memory_query", {
+      query: "cat",
+      search_mode: "hybrid",
+      require_lexical_match: true,
+      limit: 2,
+    })) as { results: Array<{ id: string }> };
+
+    expect(result.results.some((r) => r.id === targetId)).toBe(true);
+  });
+
+  it("computes the lexical anchor set via a scoped FTS existence check, not rank depth", () => {
+    // Direct guard for the #77 fix: filterIdsMatchingFts must report a lexical
+    // match for an entry regardless of how it would rank in a windowed FTS
+    // query. Seed many higher-ranking matches, then confirm a low-ranked but
+    // genuine match is still reported as anchored.
+    const ids: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      const { id } = writeState(db, `bulk/cat-${i}`, "info", `cat cat cat cats cats ${i}`, []);
+      ids.push(id);
+    }
+    const { id: sparseId } = writeState(db, "animals/sparse", "info", "a special cat here", []);
+    ids.push(sparseId);
+
+    const anchored = filterIdsMatchingFts(db, "cat", ids);
+    expect(anchored.has(sparseId)).toBe(true);
   });
 });

--- a/tests/semantic-threshold.test.ts
+++ b/tests/semantic-threshold.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { unlinkSync, existsSync } from "node:fs";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  initDatabase,
+  writeState,
+  vecLoaded,
+  storeEmbedding,
+  queryEntriesSemanticScored,
+  filterIdsMatchingFts,
+} from "../src/db.js";
+import {
+  embeddingToBuffer,
+  _setExtractorForTesting,
+  resetCircuitBreaker,
+} from "../src/embeddings.js";
+import { registerTools } from "../src/tools.js";
+
+const TEST_DB_PATH = "/tmp/munin-memory-semantic-threshold-test.db";
+const EMBEDDING_DIM = 384;
+
+function cleanupTestDb() {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const path = TEST_DB_PATH + suffix;
+    if (existsSync(path)) unlinkSync(path);
+  }
+}
+
+function makeEmbedding(seed: number): Float32Array {
+  const arr = new Float32Array(EMBEDDING_DIM);
+  for (let i = 0; i < EMBEDDING_DIM; i++) arr[i] = Math.sin(seed * (i + 1) * 0.1) * 0.1;
+  let norm = 0;
+  for (let i = 0; i < EMBEDDING_DIM; i++) norm += arr[i] * arr[i];
+  norm = Math.sqrt(norm);
+  if (norm > 0) for (let i = 0; i < EMBEDDING_DIM; i++) arr[i] /= norm;
+  return arr;
+}
+
+// Maps query/content keywords to embedding seeds so we can drive hybrid mode
+// deterministically without a real model.
+function mockExtractor(text: string) {
+  const seeds: Record<string, number> = { cat: 1, dog: 2, fish: 3, zebraclock: 99 };
+  const lower = text.toLowerCase();
+  for (const [kw, seed] of Object.entries(seeds)) {
+    if (lower.includes(kw)) return Promise.resolve({ data: makeEmbedding(seed) });
+  }
+  return Promise.resolve({ data: makeEmbedding(42) });
+}
+
+const probeDb = initDatabase("/tmp/munin-memory-semantic-threshold-probe.db");
+const vecAvailable = vecLoaded();
+probeDb.close();
+cleanupTestDb();
+for (const suffix of ["", "-wal", "-shm"]) {
+  const p = "/tmp/munin-memory-semantic-threshold-probe.db" + suffix;
+  if (existsSync(p)) unlinkSync(p);
+}
+
+let db: Database.Database;
+let server: Server;
+
+async function callTool(name: string, args: Record<string, unknown> = {}): Promise<unknown> {
+  const handler = (server as unknown as { _requestHandlers: Map<string, Function> })._requestHandlers?.get("tools/call");
+  if (!handler) throw new Error("no handler");
+  return await handler({ method: "tools/call", params: { name, arguments: args } });
+}
+
+function parse(response: unknown): Record<string, unknown> {
+  const resp = response as { content: Array<{ text: string }> };
+  return JSON.parse(resp.content[0].text);
+}
+
+beforeEach(() => {
+  cleanupTestDb();
+  db = initDatabase(TEST_DB_PATH);
+  resetCircuitBreaker();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _setExtractorForTesting(mockExtractor as any);
+  server = new Server({ name: "test-munin", version: "0.0.1" }, { capabilities: { tools: {} } });
+  registerTools(server, db, "session-semantic-threshold");
+});
+
+afterEach(() => {
+  _setExtractorForTesting(null);
+  db.close();
+  cleanupTestDb();
+});
+
+function seedEntry(namespace: string, key: string, content: string, seed: number, tags: string[] = []) {
+  const { id } = writeState(db, namespace, key, content, tags);
+  storeEmbedding(db, id, embeddingToBuffer(makeEmbedding(seed)), "test");
+  db.prepare("UPDATE entries SET embedding_status = 'generated' WHERE id = ?").run(id);
+  return id;
+}
+
+describe("queryEntriesSemanticScored maxDistance cutoff (#77)", () => {
+  it.skipIf(!vecAvailable)("drops candidates beyond the max distance", () => {
+    const close = seedEntry("animals/cat", "info", "all about cat", 1);
+    seedEntry("animals/fish", "info", "all about fish", 3);
+
+    const queryEmb = embeddingToBuffer(makeEmbedding(1)); // identical to the cat vector
+
+    const unbounded = queryEntriesSemanticScored(db, { queryEmbedding: queryEmb });
+    expect(unbounded.length).toBe(2);
+
+    // A tight cutoff keeps only the (near-)exact match.
+    const bounded = queryEntriesSemanticScored(db, { queryEmbedding: queryEmb, maxDistance: 0.01 });
+    expect(bounded.length).toBe(1);
+    expect(bounded[0].entry.id).toBe(close);
+  });
+
+  it.skipIf(!vecAvailable)("is unbounded by default (no regression)", () => {
+    seedEntry("animals/cat", "info", "all about cat", 1);
+    seedEntry("animals/fish", "info", "all about fish", 3);
+    const results = queryEntriesSemanticScored(db, { queryEmbedding: embeddingToBuffer(makeEmbedding(50)) });
+    expect(results.length).toBe(2);
+  });
+});
+
+describe("filterIdsMatchingFts (#77 anchor existence check)", () => {
+  it("returns the subset of ids that lexically match, regardless of lexical rank", () => {
+    const { id: catId } = writeState(db, "animals/cat", "info", "all about the cat", []);
+    const { id: dogId } = writeState(db, "animals/dog", "info", "all about the dog", []);
+
+    const matches = filterIdsMatchingFts(db, "cat", [catId, dogId]);
+    expect(matches.has(catId)).toBe(true);
+    expect(matches.has(dogId)).toBe(false);
+  });
+
+  it("returns an empty set for an empty id list", () => {
+    expect(filterIdsMatchingFts(db, "anything", []).size).toBe(0);
+  });
+});
+
+describe("memory_query require_lexical_match + semantic-only warning (#77)", () => {
+  it.skipIf(!vecAvailable)("warns when a hybrid query degrades to semantic-only (no FTS5 match)", async () => {
+    // Entry has a 'cat' vector but the query token 'zebraclock' shares no
+    // lexical term with it, so FTS5 finds nothing and recall is vector-only.
+    seedEntry("animals/cat", "info", "all about the cat", 1);
+
+    const raw = await callTool("memory_query", { query: "zebraclock", search_mode: "hybrid" });
+    const result = parse(raw) as { results: unknown[]; warning?: string; search_mode_actual?: string };
+
+    // Vector recall returned the (unrelated) entry, but with a warning.
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.warning).toBeTruthy();
+    expect(String(result.warning)).toContain("lexical");
+  });
+
+  it.skipIf(!vecAvailable)("suppresses semantic-only results when require_lexical_match is true", async () => {
+    seedEntry("animals/cat", "info", "all about the cat", 1);
+
+    const withFlag = parse(await callTool("memory_query", {
+      query: "zebraclock",
+      search_mode: "hybrid",
+      require_lexical_match: true,
+    })) as { results: unknown[] };
+    expect(withFlag.results.length).toBe(0);
+
+    const withoutFlag = parse(await callTool("memory_query", {
+      query: "zebraclock",
+      search_mode: "hybrid",
+    })) as { results: unknown[] };
+    expect(withoutFlag.results.length).toBeGreaterThan(0);
+  });
+
+  it.skipIf(!vecAvailable)("keeps lexically-anchored hybrid results under require_lexical_match", async () => {
+    seedEntry("animals/cat", "info", "all about the cat", 1);
+
+    const result = parse(await callTool("memory_query", {
+      query: "cat",
+      search_mode: "hybrid",
+      require_lexical_match: true,
+    })) as { results: Array<{ namespace: string }> };
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results.some((r) => r.namespace === "animals/cat")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Semantic/hybrid search ran pure KNN (`queryEntriesSemanticScored`) with **no distance threshold**, so a query for a made-up identifier (`zebraclock-...`) still returned up to `limit` unrelated vector neighbours, while lexical mode correctly returned 0. The vec0 table uses **L2 distance over normalized 384-dim MiniLM embeddings** (no metric specified → sqlite-vec default L2; `L2² = 2(1−cosine)`).

Three additive controls, **none of which change default recall**:

1. **`require_lexical_match`** (boolean, default `false`) on `memory_query`: in semantic/hybrid modes, drop results with no lexical (FTS5) anchor. Applied *after* canonical/attention injection so intentionally-injected entries survive. Pure-semantic mode uses a scoped FTS existence check (`filterIdsMatchingFts`) so a genuine lexical match is never dropped just for ranking low lexically.
2. **Semantic-only warning**: a hybrid query that collapses to zero FTS5 matches now always emits a `warning`, so callers know recall came purely from vectors.
3. **`MUNIN_SEMANTIC_MAX_DISTANCE`** (env, unset = unbounded): optional L2 cutoff applied in `queryEntriesSemanticScored`. KNN rows come back ascending by distance, so the cutoff short-circuits safely. Documented in the CLAUDE.md env table.

## Cross-model review
Ran `codex exec -m gpt-5.5` on the diff. It flagged two real issues, **both fixed in this PR**:
- `require_lexical_match` was applied before injection (could let injected anchorless entries through / drop injected ones) → moved after injection, scoped to vector-derived anchorless IDs only.
- Semantic-mode anchor lookup used a rank-limited (≤50) lexical query → replaced with `filterIdsMatchingFts`, an FTS `MATCH` existence check scoped to the semantic result IDs.

Codex confirmed default recall is preserved when the flag/env are unset, and the distance break is safe.

## Testing
- TDD: `tests/semantic-threshold.test.ts` (7 tests) covers the `maxDistance` cutoff (with default-unbounded regression), `filterIdsMatchingFts`, the semantic-only warning, `require_lexical_match` suppression, and that lexically-anchored hybrid results survive the flag. Exercises the real hybrid path via a stubbed extractor + stored embeddings.
- `npm run build` passes; full vitest suite green (1190 passed).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)