### PR TITLE
chore: gitignore .antigravitycli/ (agy CLI state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ benchmark/generated/
 !benchmark/generated/
 benchmark/generated/*
 !benchmark/generated/README.md
+
+# Antigravity (agy) CLI per-conversation state, created when run inside the repo
+.antigravitycli/


### PR DESCRIPTION
Running the Antigravity CLI (`agy`) inside the repo creates an untracked `.antigravitycli/` directory (per-conversation state), which shows up as an uncommitted change and trips the "1 uncommitted change" warning on `gh pr create`. Ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)