### PR TITLE
fix(backup): tolerate empty grep result in backup retention

### DIFF
--- a/scripts/backup-to-nas.sh
+++ b/scripts/backup-to-nas.sh
@@ -48,7 +48,7 @@ for f in $(ls -1t memory-*.db 2>/dev/null); do
         echo "$f"
     fi
 done | head -n 4 >> "$keep"
-ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" | xargs -r rm --
+{ ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" || true; } | xargs -r rm --
 REMOTE
 
 echo "$(date -Iseconds) Backup complete: ${FILENAME}"


### PR DESCRIPTION
## Summary

- `grep -vxFf "$keep"` exits 1 when every backup file is in the keep list (nothing to delete), which kills `backup-to-nas.sh` under `set -e`.
- Wrap in `{ ... || true; }` so an empty grep result is not treated as an error.

## Test plan
- [ ] Deploy to Pi and run a backup cycle where all files are within retention — script should complete without error
- [ ] Verify files outside retention window are still deleted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)