### PR TITLE
feat(security): cross-zone exfil guard on consolidation cross-references (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ changelog is the canonical record of what moved.
 
 ### Security
 
+- **Cross-zone exfil guard on consolidation cross-references (#96)** — the
+  consolidation worker derives `cross_references` across `projects/*`,
+  `clients/*`, `people/*`, and `decisions/*`. A synthesis in a less-sensitive
+  namespace (e.g. `projects/*`, floor `internal`) could previously emit a
+  reference revealing the existence of a more-sensitive namespace (e.g.
+  `clients/*` / `people/*`, floor `client-confidential`) — exfil-by-aggregation.
+  A cross-reference for a source namespace whose classification floor is `F_S`
+  may now only point at a target whose floor is `≤ F_S`. The orphan scanner
+  prunes out-of-zone targets before it even reads their content, and an
+  authoritative chokepoint drops any remaining out-of-zone reference
+  (LLM- or scanner-sourced), recording a `cross_zone_block` security event in
+  `audit_log`. The guard is a **blanket floor independent of the requester**, so
+  it also protects the autonomous background worker, and it is enforced
+  regardless of `MUNIN_LIBRARIAN_ENABLED` (it only suppresses derived links,
+  never owner-authored content). The `memory_consolidate` tool additionally
+  threads the requester's `AccessContext` so its ceiling applies as
+  defense-in-depth. Reuses the existing per-namespace classification floor table
+  (no new sensitivity model). Mirrors PAI's `ContainmentGuard`.
 - **Write-time prompt-injection / memory-poisoning advisory scan (#94)** — a new
   `scanForInjection` heuristic flags instruction-shaped content (e.g. "ignore
   previous instructions", concealment directives, jailbreak markers, chat-control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,17 @@ changelog is the canonical record of what moved.
   regardless of `MUNIN_LIBRARIAN_ENABLED` (it only suppresses derived links,
   never owner-authored content). The `memory_consolidate` tool additionally
   threads the requester's `AccessContext` so its ceiling applies as
-  defense-in-depth. Reuses the existing per-namespace classification floor table
+  defense-in-depth: the scanner now prunes out-of-zone targets *before* reading
+  their state content, and a source whose own floor exceeds the requester's
+  ceiling fails closed before any logs are read. The floor lookup is hardened
+  against case-variation near-misses (e.g. `Clients/acme` evading the lowercase
+  `clients/*` floor) and fails closed on malformed targets, since cross-reference
+  targets are untrusted model output. The read path is closed too:
+  `memory_orient` now filters dashboard cross-references so an inbound edge from a
+  namespace the requester cannot read (a permitted sensitive→less-sensitive link)
+  is hidden from both the `cross_references` array and the count (the owner still
+  sees everything). The new `cross_zone_block` audit action is filterable via
+  `memory_history`. Reuses the existing per-namespace classification floor table
   (no new sensitivity model). Mirrors PAI's `ContainmentGuard`.
 - **Write-time prompt-injection / memory-poisoning advisory scan (#94)** — a new
   `scanForInjection` heuristic flags instruction-shaped content (e.g. "ignore

--- a/docs/authorization-matrix.md
+++ b/docs/authorization-matrix.md
@@ -148,6 +148,14 @@ Invisible denial is critical: non-owner principals must not be able to distingui
 | **Who can call** | Owner only |
 | **Non-owner** | Return empty results (not an error). Insights expose retrieval patterns that could leak information about hidden namespaces. |
 
+### memory_consolidate
+
+| Field | Rule |
+|-------|------|
+| **Who can call** | Owner only |
+| **Non-owner** | Invisible denial (`access_denied` for agents) |
+| **Cross-zone guard (#96)** | The derived `cross_references` are floor-bounded: a reference for a source namespace whose classification floor is `F_S` may only point at a target whose floor is `≤ F_S`. The orphan scanner prunes out-of-zone targets before reading their content; an authoritative chokepoint drops any remaining out-of-zone reference (LLM- or scanner-sourced) and records a `cross_zone_block` event in `audit_log`. This is a **blanket floor independent of the requester** (it also protects the autonomous background worker) and is enforced regardless of `MUNIN_LIBRARIAN_ENABLED`. When invoked via the tool, the requester's `AccessContext` ceiling (`canRead` + `maxClassification`) applies as additional defense-in-depth. |
+
 ### memory_history (admin view)
 
 | Field | Rule |

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -18,6 +18,8 @@ import {
 } from "./librarian.js";
 import { canRead, getContextMaxClassification } from "./access.js";
 import type { AccessContext } from "./access.js";
+import { validateNamespace } from "./security.js";
+import type { ClassificationLevel } from "./types.js";
 import type { Entry, SynthesisResult, ConsolidationRunResult, CrossReferenceType } from "./types.js";
 
 // --- Cross-zone containment guard (#96) ---
@@ -31,6 +33,20 @@ import type { Entry, SynthesisResult, ConsolidationRunResult, CrossReferenceType
 // never owner-authored content.
 
 /**
+ * Effective classification floor of a (possibly untrusted, LLM-proposed) target
+ * namespace. Takes the most restrictive floor of the literal string and its
+ * lower-cased form, so a case-variation near-miss (e.g. "Clients/acme" evading
+ * the lower-case `clients/*` floor pattern, falling through to the `internal`
+ * default) cannot be used to smuggle a sensitive namespace into a less-sensitive
+ * output. Model output is data, not a trusted boundary.
+ */
+function effectiveTargetFloor(db: Database.Database, targetNamespace: string): ClassificationLevel {
+  const literal = resolveNamespaceClassificationFloor(db, targetNamespace);
+  const lowered = resolveNamespaceClassificationFloor(db, targetNamespace.toLowerCase());
+  return compareClassificationLevels(lowered, literal) > 0 ? lowered : literal;
+}
+
+/**
  * Is `targetNamespace` within the containment zone of a source namespace whose
  * classification floor is `sourceFloor`? Optionally also enforces the
  * requester's ceiling (canRead + maxClassification) when an AccessContext is
@@ -38,11 +54,14 @@ import type { Entry, SynthesisResult, ConsolidationRunResult, CrossReferenceType
  */
 function isTargetWithinZone(
   db: Database.Database,
-  sourceFloor: ReturnType<typeof resolveNamespaceClassificationFloor>,
+  sourceFloor: ClassificationLevel,
   targetNamespace: string,
   ctx?: AccessContext,
 ): boolean {
-  const targetFloor = resolveNamespaceClassificationFloor(db, targetNamespace);
+  // Fail closed on malformed targets — untrusted model output must not bypass
+  // the floor check by being unparseable.
+  if (!validateNamespace(targetNamespace).valid) return false;
+  const targetFloor = effectiveTargetFloor(db, targetNamespace);
   // Blanket floor: target must not be more sensitive than the source.
   if (compareClassificationLevels(targetFloor, sourceFloor) > 0) return false;
   // Requester ceiling (only when a context is threaded through the tool path).
@@ -71,11 +90,16 @@ function filterCrossZoneRefs(
       allowed.push(ref);
       continue;
     }
-    const targetFloor = resolveNamespaceClassificationFloor(db, ref.target_namespace);
-    const reason =
-      compareClassificationLevels(targetFloor, sourceFloor) > 0
-        ? `target floor ${targetFloor} exceeds source floor ${sourceFloor}`
-        : `requester ${ctx?.principalId ?? "unknown"} not permitted target floor ${targetFloor}`;
+    let reason: string;
+    if (!validateNamespace(ref.target_namespace).valid) {
+      reason = "malformed target namespace";
+    } else {
+      const targetFloor = effectiveTargetFloor(db, ref.target_namespace);
+      reason =
+        compareClassificationLevels(targetFloor, sourceFloor) > 0
+          ? `target floor ${targetFloor} exceeds source floor ${sourceFloor}`
+          : `requester ${ctx?.principalId ?? "unknown"} not permitted target floor ${targetFloor}`;
+    }
     recordCrossZoneBlock(db, sourceNamespace, ref.target_namespace, `Blocked cross-reference: ${reason}`);
   }
   return allowed;
@@ -241,6 +265,25 @@ export async function consolidateNamespace(
   callApi?: (prompt: string) => Promise<ChatCompletionResponse>,
   ctx?: AccessContext,
 ): Promise<ConsolidationRunResult> {
+  // Step 0: Source-ceiling guard. When a requester context is threaded through
+  // the tool path, never read a source whose own classification floor exceeds
+  // the requester's ceiling — fail closed before touching its logs.
+  if (ctx) {
+    const sourceFloor = resolveNamespaceClassificationFloor(db, namespace);
+    if (!canRead(ctx, namespace) || !classificationAllowed(sourceFloor, getContextMaxClassification(ctx))) {
+      return {
+        namespace,
+        logs_processed: 0,
+        synthesis_model: config.model,
+        token_count: null,
+        duration_ms: 0,
+        cross_references_found: 0,
+        orphans_discovered: 0,
+        error: "access_denied",
+      };
+    }
+  }
+
   // Step 1: Read current state
   const metadata = getConsolidationMetadata(db, namespace);
   const sinceTimestamp = metadata?.last_log_created_at ?? null;
@@ -309,26 +352,27 @@ export async function consolidateNamespace(
     }
     const result = parseSynthesisResponse(text);
 
-    // Step 5: Discover orphaned cross-references via scanner, merge with LLM refs
-    const scanner = discoverOrphanedReferences(db, namespace, logs);
+    // Step 5: Discover orphaned cross-references via scanner, merge with LLM refs.
+    // ctx is threaded so the scanner prunes out-of-zone targets BEFORE reading
+    // their state content (not just at the chokepoint below).
+    const scanner = discoverOrphanedReferences(db, namespace, logs, ctx);
     const scannerOrphans = scanner.orphans;
-    // Authoritative cross-zone chokepoint: drop any ref (LLM- or scanner-
-    // sourced) that points above the source floor or past the requester's
-    // ceiling, audit-logging each block.
-    const mergedRefs = filterCrossZoneRefs(
-      db,
-      namespace,
-      mergeCrossReferences(result.cross_references, scannerOrphans),
-      ctx,
-    );
-    const droppedByLlmMerge = scannerOrphans.length - (mergedRefs.length - result.cross_references.length);
+    // Merge first so the LLM-vs-scanner collision diagnostic reflects only the
+    // merge, then apply the authoritative cross-zone chokepoint: drop any ref
+    // (LLM- or scanner-sourced) that points above the source floor or past the
+    // requester's ceiling, audit-logging each block.
+    const merged = mergeCrossReferences(result.cross_references, scannerOrphans);
+    const droppedByLlmMerge = scannerOrphans.length - (merged.length - result.cross_references.length);
+    const mergedRefs = filterCrossZoneRefs(db, namespace, merged, ctx);
+    const droppedByCrossZone = merged.length - mergedRefs.length;
 
-    if (scanner.diagnostics.candidates_above_threshold > 0) {
+    if (scanner.diagnostics.candidates_above_threshold > 0 || droppedByCrossZone > 0) {
       console.log(
         `Scanner[${namespace}]: targets=${scanner.diagnostics.targets_considered} ` +
           `candidates=${scanner.diagnostics.candidates_above_threshold} ` +
           `dropped_reciprocal=${scanner.diagnostics.dropped_by_reciprocal} ` +
           `dropped_llm_merge=${droppedByLlmMerge} ` +
+          `dropped_cross_zone=${droppedByCrossZone} ` +
           `kept=${scannerOrphans.length - droppedByLlmMerge}`,
       );
     }
@@ -428,6 +472,7 @@ function escapeRegex(s: string): string {
 export function loadTargetVocabulary(
   db: Database.Database,
   sourceNamespace: string,
+  ctx?: AccessContext,
 ): TargetNamespace[] {
   const rows = db
     .prepare(
@@ -449,7 +494,7 @@ export function loadTargetVocabulary(
     const segments = row.namespace.split("/");
     const bareName = segments[segments.length - 1] ?? "";
     if (bareName.length < MIN_BARE_NAME_LENGTH) continue;
-    if (!isTargetWithinZone(db, sourceFloor, row.namespace)) continue;
+    if (!isTargetWithinZone(db, sourceFloor, row.namespace, ctx)) continue;
     targets.push({ namespace: row.namespace, bareName });
   }
   return targets;
@@ -540,8 +585,9 @@ export function discoverOrphanedReferences(
   db: Database.Database,
   sourceNamespace: string,
   logs: Entry[],
+  ctx?: AccessContext,
 ): ScannerResult {
-  const targets = loadTargetVocabulary(db, sourceNamespace);
+  const targets = loadTargetVocabulary(db, sourceNamespace, ctx);
   const hits = scanMentions(logs, targets);
   const orphans: SynthesisResult["cross_references"] = [];
   let droppedByReciprocal = 0;

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -8,9 +8,78 @@ import {
   addCrossReferences,
   hasMoreLogsAfter,
   writeState,
+  recordCrossZoneBlock,
   nowUTC,
 } from "./db.js";
+import {
+  resolveNamespaceClassificationFloor,
+  compareClassificationLevels,
+  classificationAllowed,
+} from "./librarian.js";
+import { canRead, getContextMaxClassification } from "./access.js";
+import type { AccessContext } from "./access.js";
 import type { Entry, SynthesisResult, ConsolidationRunResult, CrossReferenceType } from "./types.js";
+
+// --- Cross-zone containment guard (#96) ---
+//
+// Aggregate/derived operations must not surface a more-sensitive namespace
+// inside a less-sensitive output. A cross-reference written for source
+// namespace S (floor F_S) may not point at a target namespace T whose floor
+// F_T is higher than F_S. This is a blanket rule independent of the requester
+// (so it also protects the autonomous background worker), and is enforced
+// regardless of MUNIN_LIBRARIAN_ENABLED — it only suppresses derived links,
+// never owner-authored content.
+
+/**
+ * Is `targetNamespace` within the containment zone of a source namespace whose
+ * classification floor is `sourceFloor`? Optionally also enforces the
+ * requester's ceiling (canRead + maxClassification) when an AccessContext is
+ * supplied (defense-in-depth for the tool path).
+ */
+function isTargetWithinZone(
+  db: Database.Database,
+  sourceFloor: ReturnType<typeof resolveNamespaceClassificationFloor>,
+  targetNamespace: string,
+  ctx?: AccessContext,
+): boolean {
+  const targetFloor = resolveNamespaceClassificationFloor(db, targetNamespace);
+  // Blanket floor: target must not be more sensitive than the source.
+  if (compareClassificationLevels(targetFloor, sourceFloor) > 0) return false;
+  // Requester ceiling (only when a context is threaded through the tool path).
+  if (ctx) {
+    if (!canRead(ctx, targetNamespace)) return false;
+    if (!classificationAllowed(targetFloor, getContextMaxClassification(ctx))) return false;
+  }
+  return true;
+}
+
+/**
+ * Drop cross-references that would exfiltrate a more-sensitive namespace into a
+ * less-sensitive synthesis, audit-logging each block. Catches both LLM-proposed
+ * and scanner-discovered refs (the authoritative chokepoint).
+ */
+function filterCrossZoneRefs(
+  db: Database.Database,
+  sourceNamespace: string,
+  refs: SynthesisResult["cross_references"],
+  ctx?: AccessContext,
+): SynthesisResult["cross_references"] {
+  const sourceFloor = resolveNamespaceClassificationFloor(db, sourceNamespace);
+  const allowed: SynthesisResult["cross_references"] = [];
+  for (const ref of refs) {
+    if (isTargetWithinZone(db, sourceFloor, ref.target_namespace, ctx)) {
+      allowed.push(ref);
+      continue;
+    }
+    const targetFloor = resolveNamespaceClassificationFloor(db, ref.target_namespace);
+    const reason =
+      compareClassificationLevels(targetFloor, sourceFloor) > 0
+        ? `target floor ${targetFloor} exceeds source floor ${sourceFloor}`
+        : `requester ${ctx?.principalId ?? "unknown"} not permitted target floor ${targetFloor}`;
+    recordCrossZoneBlock(db, sourceNamespace, ref.target_namespace, `Blocked cross-reference: ${reason}`);
+  }
+  return allowed;
+}
 
 // --- Configuration from env vars ---
 
@@ -170,6 +239,7 @@ export async function consolidateNamespace(
   db: Database.Database,
   namespace: string,
   callApi?: (prompt: string) => Promise<ChatCompletionResponse>,
+  ctx?: AccessContext,
 ): Promise<ConsolidationRunResult> {
   // Step 1: Read current state
   const metadata = getConsolidationMetadata(db, namespace);
@@ -242,7 +312,15 @@ export async function consolidateNamespace(
     // Step 5: Discover orphaned cross-references via scanner, merge with LLM refs
     const scanner = discoverOrphanedReferences(db, namespace, logs);
     const scannerOrphans = scanner.orphans;
-    const mergedRefs = mergeCrossReferences(result.cross_references, scannerOrphans);
+    // Authoritative cross-zone chokepoint: drop any ref (LLM- or scanner-
+    // sourced) that points above the source floor or past the requester's
+    // ceiling, audit-logging each block.
+    const mergedRefs = filterCrossZoneRefs(
+      db,
+      namespace,
+      mergeCrossReferences(result.cross_references, scannerOrphans),
+      ctx,
+    );
     const droppedByLlmMerge = scannerOrphans.length - (mergedRefs.length - result.cross_references.length);
 
     if (scanner.diagnostics.candidates_above_threshold > 0) {
@@ -362,11 +440,16 @@ export function loadTargetVocabulary(
     )
     .all(sourceNamespace) as Array<{ namespace: string }>;
 
+  // Blanket cross-zone guard: never scan or link namespaces more sensitive than
+  // the source — prevents the orphan scanner from even reading their content.
+  const sourceFloor = resolveNamespaceClassificationFloor(db, sourceNamespace);
+
   const targets: TargetNamespace[] = [];
   for (const row of rows) {
     const segments = row.namespace.split("/");
     const bareName = segments[segments.length - 1] ?? "";
     if (bareName.length < MIN_BARE_NAME_LENGTH) continue;
+    if (!isTargetWithinZone(db, sourceFloor, row.namespace)) continue;
     targets.push({ namespace: row.namespace, bareName });
   }
   return targets;

--- a/src/db.ts
+++ b/src/db.ts
@@ -218,6 +218,23 @@ function insertAuditRow(
   ).run(timestamp, agentId, action, namespace, key, detail, entryId);
 }
 
+/**
+ * Record a cross-zone containment block as a security event in the audit log.
+ * Used when an aggregate/derived operation (e.g. consolidation cross-references)
+ * would otherwise surface a more-sensitive namespace inside a less-sensitive
+ * output. `namespace` is the source (output) namespace; `key` is the blocked
+ * target namespace.
+ */
+export function recordCrossZoneBlock(
+  db: Database.Database,
+  sourceNamespace: string,
+  targetNamespace: string,
+  detail: string,
+  agentId = "consolidation-worker",
+): void {
+  insertAuditRow(db, nowUTC(), agentId, "cross_zone_block", sourceNamespace, targetNamespace, detail);
+}
+
 function resolveWriteClassification(
   db: Database.Database,
   namespace: string,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -77,6 +77,7 @@ import {
   enforceClassification,
   filterSourcesByClassification,
   getLibrarianConfigWarnings,
+  classificationAllowed,
   isClassificationLevel,
   isLibrarianEnabled,
   isRedactionLogEnabled,
@@ -155,6 +156,7 @@ import type {
   AuditAction,
   AuditEntry,
   ConsolidationRunResult,
+  CrossReference,
   RetrievalFeedbackParams,
   RetrievalAggregates,
   ClassificationLevel,
@@ -820,11 +822,36 @@ const VALID_AUDIT_ACTIONS: Array<AuditAction | "delete_namespace" | "log"> = [
   "log_append",
   "delete_namespace",
   "log",
+  "cross_zone_block",
 ];
 
 function contentPreview(content: string, maxLen = 500): string {
   if (content.length <= maxLen) return content;
   return content.slice(0, maxLen) + "...";
+}
+
+/**
+ * Cross-references are stored directionally but `getCrossReferences` returns
+ * both outgoing and incoming rows for a namespace. An allowed down-reference
+ * (a sensitive source linking a less-sensitive target) therefore surfaces as an
+ * *inbound* edge on the less-sensitive namespace's dashboard, leaking the
+ * sensitive source's name/count to a requester who can see the target but not
+ * the source (#96). Filter cross-references so the *other* endpoint is only
+ * surfaced when the requester may actually read it (canRead + classification
+ * ceiling). Owner/local connections see everything (no behaviour change).
+ */
+function visibleCrossReferences(
+  db: Database.Database,
+  ctx: AccessContext,
+  namespace: string,
+): CrossReference[] {
+  const maxClassification = getContextMaxClassification(ctx);
+  return getCrossReferences(db, namespace).filter((ref) => {
+    const other = ref.source_namespace === namespace ? ref.target_namespace : ref.source_namespace;
+    if (!canRead(ctx, other)) return false;
+    if (!classificationAllowed(resolveNamespaceClassificationFloor(db, other), maxClassification)) return false;
+    return true;
+  });
 }
 
 /**
@@ -3310,8 +3337,8 @@ const TOOL_DEFINITIONS = [
         },
         action: {
           type: "string",
-          enum: ["write", "update", "delete", "delete_namespace", "log"],
-          description: "Optional. Filter by action type.",
+          enum: ["write", "update", "delete", "delete_namespace", "log", "cross_zone_block"],
+          description: "Optional. Filter by action type. 'cross_zone_block' surfaces containment-guard security events.",
         },
         cursor: {
           type: "integer",
@@ -3670,7 +3697,7 @@ export function registerTools(
 
                   if (detail === "standard") {
                     // Standard: synthesis summary (or stale marker) + cross-ref count, no full cross-ref array
-                    const crossRefCount = getCrossReferences(db, assessment.row.namespace).length;
+                    const crossRefCount = visibleCrossReferences(db, ctx, assessment.row.namespace).length;
                     entry.synthesis = {
                       ...(synthesisIsStale ? { stale: true as const } : { summary: contentPreview(synthesis.content) }),
                       updated_at: synthesis.updated_at,
@@ -3683,7 +3710,7 @@ export function registerTools(
                     };
                   } else {
                     // Full: everything
-                    const crossRefs = getCrossReferences(db, assessment.row.namespace);
+                    const crossRefs = visibleCrossReferences(db, ctx, assessment.row.namespace);
                     entry.synthesis = {
                       ...(synthesisIsStale ? { stale: true as const } : { summary: contentPreview(synthesis.content) }),
                       updated_at: synthesis.updated_at,
@@ -6105,7 +6132,7 @@ export function registerTools(
               return errResult(
                 "history",
                 "validation_error",
-                `Invalid action "${action}". Must be one of: write, update, delete, delete_namespace, log. Legacy aliases namespace_delete and log_append are also accepted.`,
+                `Invalid action "${action}". Must be one of: write, update, delete, delete_namespace, log, cross_zone_block. Legacy aliases namespace_delete and log_append are also accepted.`,
               );
             }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6148,7 +6148,7 @@ export function registerTools(
                 return errResult("consolidate", "validation_error", nsCheck.error!);
               }
 
-              const result = await consolidateNamespace(db, consolidateNs);
+              const result = await consolidateNamespace(db, consolidateNs, undefined, ctx);
               if (result.error) {
                 return errResult("consolidate", "synthesis_error", result.error);
               }
@@ -6169,7 +6169,7 @@ export function registerTools(
 
             const consolidateResults: ConsolidationRunResult[] = [];
             for (const candidate of candidates) {
-              const result = await consolidateNamespace(db, candidate.namespace);
+              const result = await consolidateNamespace(db, candidate.namespace, undefined, ctx);
               consolidateResults.push(result);
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type EntryType = "state" | "log";
 export type EmbeddingStatus = "pending" | "processing" | "generated" | "failed";
 export type SearchMode = "lexical" | "semantic" | "hybrid";
 export type OrientDetail = "compact" | "standard" | "full";
-export type AuditAction = "write" | "update" | "patch" | "delete" | "namespace_delete" | "log_append";
+export type AuditAction = "write" | "update" | "patch" | "delete" | "namespace_delete" | "log_append" | "cross_zone_block";
 export type CommitmentStatus = "open" | "done" | "cancelled";
 export type ClassificationLevel =
   | "public"

--- a/tests/access-enforcement.test.ts
+++ b/tests/access-enforcement.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { initDatabase } from "../src/db.js";
+import { initDatabase, writeState, replaceCrossReferences } from "../src/db.js";
 import { registerTools } from "../src/tools.js";
 import type { AccessContext } from "../src/access.js";
 import { ownerContext } from "../src/access.js";
@@ -608,6 +608,81 @@ describe("memory_orient — access enforcement", () => {
     // projects/foo appears in dashboard
     const allDashboardNamespaces = Object.values(result.dashboard).flat().map((e) => e.namespace);
     expect(allDashboardNamespaces).toContain("projects/foo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// memory_orient — cross-zone cross-reference leak (#96)
+// ---------------------------------------------------------------------------
+
+describe("memory_orient — cross-zone cross-reference exposure", () => {
+  function seedCrossZoneRef() {
+    // A project the requester may read, with a synthesis so orient enriches it.
+    writeState(db, "projects/shared", "status", "## Phase: Active\nShared work", ["active"]);
+    writeState(db, "projects/shared", "synthesis", "## Phase: Active\nSynthesis", ["active"]);
+    // A sensitive client namespace the agent cannot read.
+    writeState(db, "clients/secret", "status", "## Phase\nSensitive", ["active"]);
+    // A down-reference clients/secret -> projects/shared (allowed at generation
+    // time) surfaces as an INBOUND edge on projects/shared.
+    replaceCrossReferences(db, "clients/secret", [
+      { source_namespace: "clients/secret", target_namespace: "projects/shared", reference_type: "related_to", context: "x", confidence: 0.9 },
+    ]);
+  }
+
+  function sharedReaderContext(): AccessContext {
+    return {
+      principalId: "agent:shared",
+      principalType: "agent",
+      accessibleNamespaces: [{ pattern: "projects/shared", permissions: "rw" }],
+      maxClassification: "internal",
+    };
+  }
+
+  function findRow(result: unknown, namespace: string): { synthesis?: { cross_references?: Array<{ target_namespace: string }>; cross_reference_count?: number } } | undefined {
+    const dashboard = (result as { dashboard: Record<string, Array<{ namespace: string }>> }).dashboard ?? {};
+    return Object.values(dashboard).flat().find((e) => e.namespace === namespace) as never;
+  }
+
+  it("does not surface a sensitive inbound source to a requester who cannot read it (full)", async () => {
+    seedCrossZoneRef();
+    const call = makeServer(db, sharedReaderContext());
+    const result = parse(await call("memory_orient", { detail: "full" }));
+
+    const shared = findRow(result, "projects/shared");
+    expect(shared).toBeDefined();
+    const names = (shared!.synthesis?.cross_references ?? []).map((r) => r.target_namespace);
+    expect(names).not.toContain("clients/secret");
+  });
+
+  it("does not leak a sensitive inbound source via the count (standard)", async () => {
+    seedCrossZoneRef();
+    const call = makeServer(db, sharedReaderContext());
+    const result = parse(await call("memory_orient", { detail: "standard" }));
+
+    const shared = findRow(result, "projects/shared");
+    expect(shared).toBeDefined();
+    expect(shared!.synthesis?.cross_reference_count).toBe(0);
+  });
+
+  it("owner still sees the cross-reference (no over-redaction)", async () => {
+    seedCrossZoneRef();
+    const result = parse(await ownerCall("memory_orient", { detail: "full" }));
+
+    const shared = findRow(result, "projects/shared");
+    expect(shared).toBeDefined();
+    const names = (shared!.synthesis?.cross_references ?? []).map((r) => r.target_namespace);
+    expect(names).toContain("clients/secret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// memory_history — cross_zone_block filter (#96)
+// ---------------------------------------------------------------------------
+
+describe("memory_history — cross_zone_block action filter", () => {
+  it("accepts the cross_zone_block action without a validation error", async () => {
+    const result = parse(await ownerCall("memory_history", { action: "cross_zone_block" })) as { error?: string };
+    expect(result.error).toBeUndefined();
   });
 });
 

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -30,6 +30,7 @@ import {
   type ChatCompletionResponse,
 } from "../src/consolidation.js";
 import type { Entry } from "../src/types.js";
+import type { AccessContext } from "../src/access.js";
 
 const TEST_DB_PATH = "/tmp/munin-memory-consolidation-synthesis-test.db";
 
@@ -534,6 +535,80 @@ describe("cross-zone exfil guard", () => {
     const refs = getCrossReferences(db, "clients/acme").map((r) => r.target_namespace);
     expect(refs).toContain("projects/beta");
     expect(crossZoneBlocks(db).length).toBe(0);
+  });
+
+  it("blocks a case-variation near-miss that would evade the lowercase floor pattern", async () => {
+    writeState(db, "clients/acme", "status", "acme status", ["active"]);
+    for (let i = 0; i < 3; i++) appendLog(db, "projects/alpha", `Log ${i}`, []);
+
+    const mock = vi
+      .fn<(prompt: string) => Promise<ChatCompletionResponse>>()
+      .mockResolvedValue(
+        // "Clients/acme" would resolve to the default `internal` floor unless the
+        // guard normalizes case — and thus smuggle a near-exact client name.
+        mockResponseWith([
+          { target_namespace: "Clients/acme", reference_type: "related_to", context: "leak", confidence: 0.9 },
+        ]),
+      );
+
+    await consolidateNamespace(db, "projects/alpha", mock);
+
+    const refs = getCrossReferences(db, "projects/alpha").map((r) => r.target_namespace);
+    expect(refs).not.toContain("Clients/acme");
+    expect(crossZoneBlocks(db).some((b) => b.key === "Clients/acme")).toBe(true);
+  });
+
+  it("drops a malformed target namespace (fail-closed) and audit-logs it", async () => {
+    for (let i = 0; i < 3; i++) appendLog(db, "projects/alpha", `Log ${i}`, []);
+
+    const mock = vi
+      .fn<(prompt: string) => Promise<ChatCompletionResponse>>()
+      .mockResolvedValue(
+        mockResponseWith([
+          { target_namespace: "../clients/acme", reference_type: "related_to", context: "x", confidence: 0.9 },
+        ]),
+      );
+
+    await consolidateNamespace(db, "projects/alpha", mock);
+
+    expect(getCrossReferences(db, "projects/alpha").length).toBe(0);
+    expect(crossZoneBlocks(db).some((b) => b.key === "../clients/acme")).toBe(true);
+  });
+
+  it("loadTargetVocabulary applies the requester ceiling (canRead) when ctx is supplied", () => {
+    writeState(db, "projects/beta", "status", "beta", ["active"]);
+    writeState(db, "projects/gamma", "status", "gamma", ["active"]);
+
+    const ctx: AccessContext = {
+      principalId: "agent:x",
+      principalType: "agent",
+      accessibleNamespaces: [
+        { pattern: "projects/alpha/*", permissions: "rw" },
+        { pattern: "projects/beta", permissions: "read" },
+      ],
+      maxClassification: "internal",
+    };
+
+    const targets = loadTargetVocabulary(db, "projects/alpha", ctx).map((t) => t.namespace);
+    expect(targets).toEqual(["projects/beta"]); // gamma is not readable by this principal
+  });
+
+  it("fails closed before reading logs when the source floor exceeds the requester ceiling", async () => {
+    for (let i = 0; i < 3; i++) appendLog(db, "clients/secret", `Sensitive log ${i}`, []);
+
+    const ctx: AccessContext = {
+      principalId: "agent:x",
+      principalType: "agent",
+      accessibleNamespaces: [{ pattern: "clients/*", permissions: "rw" }],
+      maxClassification: "internal", // below clients/* floor (client-confidential)
+    };
+
+    const mock = vi.fn<(prompt: string) => Promise<ChatCompletionResponse>>();
+    const result = await consolidateNamespace(db, "clients/secret", mock, ctx);
+
+    expect(result.error).toBe("access_denied");
+    expect(result.logs_processed).toBe(0);
+    expect(mock).not.toHaveBeenCalled(); // never built a prompt / read content
   });
 });
 

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -414,6 +414,129 @@ describe("consolidateNamespace", () => {
   });
 });
 
+// ─── Cross-zone exfil guard (#96) ────────────────────────────────────────────
+
+function mockResponseWith(
+  crossRefs: Array<{
+    target_namespace: string;
+    reference_type: string;
+    context: string;
+    confidence: number;
+  }>,
+): ChatCompletionResponse {
+  return {
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({
+            status_content: "## Phase: Active\n\nSynthesis content.",
+            tags: ["active"],
+            cross_references: crossRefs,
+          }),
+        },
+      },
+    ],
+    usage: { prompt_tokens: 500, completion_tokens: 300 },
+  };
+}
+
+function crossZoneBlocks(
+  database: Database.Database,
+): Array<{ namespace: string; key: string | null; detail: string | null }> {
+  return database
+    .prepare("SELECT namespace, key, detail FROM audit_log WHERE action = 'cross_zone_block'")
+    .all() as Array<{ namespace: string; key: string | null; detail: string | null }>;
+}
+
+describe("cross-zone exfil guard", () => {
+  it("loadTargetVocabulary prunes targets above the source namespace floor", () => {
+    writeState(db, "projects/beta", "status", "beta", ["active"]);
+    writeState(db, "decisions/architecture", "status", "arch", []);
+    writeState(db, "clients/acme", "status", "acme", ["active"]); // client-confidential
+    writeState(db, "people/sara", "status", "sara", []); // client-confidential
+
+    const targets = loadTargetVocabulary(db, "projects/alpha") // internal floor
+      .map((t) => t.namespace)
+      .sort();
+
+    expect(targets).toEqual(["decisions/architecture", "projects/beta"]);
+    expect(targets).not.toContain("clients/acme");
+    expect(targets).not.toContain("people/sara");
+  });
+
+  it("loadTargetVocabulary keeps equal/lower-floor targets when the source is more sensitive", () => {
+    writeState(db, "projects/beta", "status", "beta", ["active"]); // internal
+    writeState(db, "clients/other", "status", "other", ["active"]); // client-confidential
+
+    const targets = loadTargetVocabulary(db, "clients/acme") // client-confidential floor
+      .map((t) => t.namespace)
+      .sort();
+
+    expect(targets).toEqual(["clients/other", "projects/beta"]);
+  });
+
+  it("drops an LLM-proposed cross-reference above the source floor and audit-logs it", async () => {
+    writeState(db, "clients/acme", "status", "acme status", ["active"]);
+    for (let i = 0; i < 3; i++) appendLog(db, "projects/alpha", `Log ${i}`, []);
+
+    const mock = vi
+      .fn<(prompt: string) => Promise<ChatCompletionResponse>>()
+      .mockResolvedValue(
+        mockResponseWith([
+          { target_namespace: "clients/acme", reference_type: "related_to", context: "leak", confidence: 0.9 },
+        ]),
+      );
+
+    const result = await consolidateNamespace(db, "projects/alpha", mock);
+
+    expect(result.error).toBeUndefined();
+    const refs = getCrossReferences(db, "projects/alpha").map((r) => r.target_namespace);
+    expect(refs).not.toContain("clients/acme");
+    expect(result.cross_references_found).toBe(0);
+
+    const blocks = crossZoneBlocks(db);
+    expect(blocks.some((b) => b.namespace === "projects/alpha" && b.key === "clients/acme")).toBe(true);
+  });
+
+  it("keeps a cross-reference at an equal-or-lower floor and writes no block", async () => {
+    writeState(db, "projects/beta", "status", "beta status", ["active"]);
+    for (let i = 0; i < 3; i++) appendLog(db, "projects/alpha", `Log ${i}`, []);
+
+    const mock = vi
+      .fn<(prompt: string) => Promise<ChatCompletionResponse>>()
+      .mockResolvedValue(
+        mockResponseWith([
+          { target_namespace: "projects/beta", reference_type: "related_to", context: "ok", confidence: 0.9 },
+        ]),
+      );
+
+    await consolidateNamespace(db, "projects/alpha", mock);
+
+    const refs = getCrossReferences(db, "projects/alpha").map((r) => r.target_namespace);
+    expect(refs).toContain("projects/beta");
+    expect(crossZoneBlocks(db).length).toBe(0);
+  });
+
+  it("allows a sensitive source to reference a less-sensitive namespace", async () => {
+    writeState(db, "projects/beta", "status", "beta status", ["active"]);
+    for (let i = 0; i < 3; i++) appendLog(db, "clients/acme", `Log ${i}`, []);
+
+    const mock = vi
+      .fn<(prompt: string) => Promise<ChatCompletionResponse>>()
+      .mockResolvedValue(
+        mockResponseWith([
+          { target_namespace: "projects/beta", reference_type: "related_to", context: "ok", confidence: 0.9 },
+        ]),
+      );
+
+    await consolidateNamespace(db, "clients/acme", mock);
+
+    const refs = getCrossReferences(db, "clients/acme").map((r) => r.target_namespace);
+    expect(refs).toContain("projects/beta");
+    expect(crossZoneBlocks(db).length).toBe(0);
+  });
+});
+
 // ─── Worker lifecycle ────────────────────────────────────────────────────────
 
 describe("initConsolidation", () => {
@@ -522,16 +645,17 @@ describe("isConsolidationAvailable", () => {
 
 describe("loadTargetVocabulary", () => {
   it("returns tracked namespaces and excludes the source", () => {
+    // Targets at or below the source floor only; cross-zone pruning is covered
+    // by the dedicated "cross-zone exfil guard" tests below.
     writeState(db, "projects/alpha", "status", "alpha status", ["active"]);
     writeState(db, "projects/beta", "status", "beta status", ["active"]);
-    writeState(db, "clients/acme", "status", "acme status", ["active"]);
-    writeState(db, "people/sara", "status", "sara profile", []);
+    writeState(db, "decisions/memory-arch", "status", "decision", []);
     writeState(db, "meta/workbench", "status", "irrelevant", []);
 
     const targets = loadTargetVocabulary(db, "projects/alpha");
     const namespaces = targets.map((t) => t.namespace).sort();
 
-    expect(namespaces).toEqual(["clients/acme", "people/sara", "projects/beta"]);
+    expect(namespaces).toEqual(["decisions/memory-arch", "projects/beta"]);
     expect(namespaces).not.toContain("projects/alpha");
     expect(namespaces).not.toContain("meta/workbench");
   });


### PR DESCRIPTION
Closes #96.

## Problem
PAI's `ContainmentGuard` blocks cross-zone data movement before a tool runs. Munin had per-principal namespace rules and a classification floor, but a gap remained around **aggregate/derived** operations. The consolidation worker derives `cross_references` across `projects/*`, `clients/*`, `people/*`, and `decisions/*`. A synthesis in a less-sensitive namespace (e.g. `projects/*`, floor `internal`) could emit a reference revealing the existence of a more-sensitive namespace (e.g. `clients/*` / `people/*`, floor `client-confidential`) — **exfil-by-aggregation**. The autonomous background worker bypassed the owner-only tool guard entirely.

## Fix
A cross-reference for a source namespace whose classification floor is `F_S` may now only point at a target whose floor is `≤ F_S`.

- **`loadTargetVocabulary`** prunes out-of-zone targets *before* the orphan scanner reads their content (mirrors the existing "authorize each source before computing derived fields" rule).
- **`filterCrossZoneRefs`** — an authoritative chokepoint after merge — drops any remaining out-of-zone reference (LLM- *or* scanner-sourced) and records a `cross_zone_block` security event in `audit_log` via the new `recordCrossZoneBlock` helper.

## Design notes
- **Blanket floor, requester-independent** — so it also protects the autonomous background worker, which has no principal.
- **Enforced regardless of `MUNIN_LIBRARIAN_ENABLED`** (default `false`) — it only suppresses *derived links*, never owner-authored content, so it's safe to always apply. Gating it on the librarian flag would make the security fix inert on default installs.
- **`memory_consolidate` threads the requester's `AccessContext`** (`canRead` + `maxClassification`) as additional defense-in-depth. Owner-only today, so it changes nothing now, but future-proofs the path.
- **Reuses the existing per-namespace classification floor table** (`DEFAULT_NAMESPACE_CLASSIFICATION_FLOORS`, seeded by migration) — satisfies issue item #1 with no new sensitivity model.

## Out of scope
Entry-level ownership (Phase 3+), per the issue.

## Tests
New `cross-zone exfil guard` block in `tests/consolidation.test.ts`: vocabulary pruning (both directions), LLM-proposed cross-zone ref dropped + audited, same/lower-floor refs kept, sensitive→less-sensitive allowed. Full suite: **1248 passing** (+5), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)