### PR TITLE
docs: document lint/typecheck workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,25 @@ npm run test:watch  # Runs vitest in watch mode
 
 For substantive code changes, default to red/green TDD: write the failing test first, confirm it fails, then implement until it passes. Skip for refactors with no behavior change, config tweaks, and trivial fixes.
 
+## How to lint and type-check
+
+```bash
+npm run lint            # ESLint — bug-focused, type-aware, src/ only
+npm run typecheck       # tsc --noEmit over src/ + tests/ (tsconfig.test.json)
+npm run typecheck:tools # tsc --noEmit over benchmark/ + scripts/ (tsconfig.tools.json)
+```
+
+CI gates every push/PR on `lint`, `typecheck`, `typecheck:tools`, `build`, `test`, and the
+benchmark regression gate, across a Node 20 + 22 matrix (`.github/workflows/ci.yml`). CodeQL
+(`security-extended`) and Dependabot run separately.
+
+- **ESLint is deliberately minimal** — not a style/formatting config. `eslint.config.js` enables
+  only high-signal, type-aware rules (`no-floating-promises`, `no-misused-promises`,
+  `await-thenable`) over `src/`, because a dropped Promise in the worker/DB/OAuth paths is a real
+  corruption/race risk. Prettier is intentionally omitted. Tests are type-checked, not linted.
+- `tsconfig.json` runs `strict` plus `noUnusedLocals` / `noUnusedParameters` /
+  `noFallthroughCasesInSwitch`. Mark intentional fire-and-forget Promises with `void`.
+
 ## How to run locally
 
 **Stdio mode** (default — for Claude Code, Claude Desktop local):


### PR DESCRIPTION
Adds a **How to lint and type-check** section to CLAUDE.md covering the dev workflow introduced in #103:

- `npm run lint` / `npm run typecheck` / `npm run typecheck:tools`
- The CI gate set (Node 20+22 matrix, CodeQL, Dependabot)
- Notes that ESLint is bug-focused (not style), Prettier is intentionally omitted, and the tsconfig strict flags require `void` on intentional fire-and-forget Promises

Doc-only; CLAUDE.md tool-inventory table untouched (inventory test passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)