### PR TITLE
feat(query): opt-in boundary serialization for memory_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,12 @@ changelog is the canonical record of what moved.
   — the result set and underlying ranks are identical, it is applied **after**
   analytics logging so `retrieval_events` keep the true linear rank order (the
   outcome-correlation signal is never corrupted), and it has no effect on
-  filter-only browse queries. `retrieval.serialization` echoes the mode applied.
-  Additive: no schema change, no migration, no new env var. Distilled from the
-  Letta memory-design harvest (see `decisions/letta-harvest`; Lost in the
-  Middle).
+  filter-only browse queries. `retrieval.serialization` is always present and
+  echoes the mode actually applied (always `"linear"` on the filter-only browse
+  path). An unrecognized value fails with a `validation_error` rather than being
+  silently coerced. Additive: no schema change, no migration, no new env var.
+  Distilled from the Letta memory-design harvest (see `decisions/letta-harvest`;
+  Lost in the Middle).
 - **Synthesis provenance tag + age on the query read path** — the consolidation
   worker now force-stamps a reserved `source:synthesis` tag on the `synthesis`
   entry server-side (deduped, regardless of what the LLM proposed), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,19 @@ changelog is the canonical record of what moved.
   via silently stale synthesis. Additive: no schema change, no migration, no new
   env var. Distilled from the Letta memory-design harvest (see
   `decisions/letta-harvest`; Sleep-time Compute).
+- **Opt-in boundary serialization for `memory_query`** — a new
+  `serialization: "boundary"` parameter reorders ranked search results so the
+  strongest sit at the two context edges (rank 1 first, rank 2 last, rank 3
+  second, …) instead of strict best-first, countering the "Lost in the Middle"
+  attention dip (arXiv 2307.03172) when a long result list is dropped straight
+  into context. Default (`"linear"`) is unchanged. The transform is display-only
+  — the result set and underlying ranks are identical, it is applied **after**
+  analytics logging so `retrieval_events` keep the true linear rank order (the
+  outcome-correlation signal is never corrupted), and it has no effect on
+  filter-only browse queries. `retrieval.serialization` echoes the mode applied.
+  Additive: no schema change, no migration, no new env var. Distilled from the
+  Letta memory-design harvest (see `decisions/letta-harvest`; Lost in the
+  Middle).
 - **Synthesis provenance tag + age on the query read path** — the consolidation
   worker now force-stamps a reserved `source:synthesis` tag on the `synthesis`
   entry server-side (deduped, regardless of what the LLM proposed), and

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5361,7 +5361,18 @@ export function registerTools(
             const explain = queryArgs.explain === true;
             const includeExpired = queryArgs.include_expired === true;
             const requireLexicalMatch = queryArgs.require_lexical_match === true;
-            const serialization = queryArgs.serialization === "boundary" ? "boundary" : "linear";
+            // Validate serialization up front (parity with namespace/recency
+            // validation) so a typo like "boundry" fails loudly instead of being
+            // silently coerced to "linear". Applies to both the ranked and
+            // filter-only paths since it is read before the branch.
+            if (
+              queryArgs.serialization !== undefined &&
+              queryArgs.serialization !== "linear" &&
+              queryArgs.serialization !== "boundary"
+            ) {
+              return errResult("query", "validation_error", "serialization must be 'linear' or 'boundary'.");
+            }
+            const serialization = queryArgs.serialization ?? "linear";
             const recencyWeightCheck = resolveSearchRecencyWeight(queryArgs);
             if (!recencyWeightCheck.ok) {
               return errResult("query", "validation_error", recencyWeightCheck.error);
@@ -5441,6 +5452,9 @@ export function registerTools(
                   recency_applied: false,
                   search_recency_weight: 0,
                   expired_filtered_count: filteredExpired.expiredFilteredCount,
+                  // Browse results are not relevance-ranked, so boundary
+                  // placement never applies here — always report linear.
+                  serialization: "linear",
                 },
               });
             }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -433,6 +433,26 @@ function buildReadMissHint(
     : `No entries found in namespace "${namespace}".`;
 }
 
+/**
+ * Reorder a rank-sorted array so the strongest items sit at the two edges and
+ * the weakest in the middle — countering the "Lost in the Middle" attention dip
+ * (arXiv 2307.03172) when a long result list is dropped straight into context.
+ * Given best-first input [r1, r2, r3, r4, r5] it returns [r1, r3, r5, r4, r2]:
+ * rank 1 at the start, rank 2 at the end. Pure and order-only — the same items
+ * come back, so callers must not derive ranks from the returned order. A no-op
+ * for 0–2 items.
+ */
+function boundarySerialize<T>(items: T[]): T[] {
+  const front: T[] = [];
+  const back: T[] = [];
+  items.forEach((item, i) => {
+    if (i % 2 === 0) front.push(item);
+    else back.push(item);
+  });
+  back.reverse();
+  return [...front, ...back];
+}
+
 function formatQueryResult(
   db: Database.Database,
   ctx: AccessContext,
@@ -3180,6 +3200,11 @@ const TOOL_DEFINITIONS = [
           type: "boolean",
           description: "Optional (default false). In semantic/hybrid modes, drop results that have no lexical (FTS5) match — i.e. require a lexical anchor for every result. Use when you want to avoid loosely-related vector neighbours (e.g. searching for an exact identifier). No effect in lexical mode. Note: a hybrid query that collapses to semantic-only always emits a `warning` regardless of this flag.",
         },
+        serialization: {
+          type: "string",
+          enum: ["linear", "boundary"],
+          description: "Optional (default \"linear\"). Output ordering of ranked results. \"linear\" returns strict best-first rank order. \"boundary\" places the strongest results at the two context edges (rank 1 first, rank 2 last, rank 3 second, …) to counter the \"Lost in the Middle\" attention dip when dropping a long result list straight into context. The result set and underlying ranks are unchanged — only display order — and retrieval analytics always record the true linear rank order. No effect on filter-only browse queries.",
+        },
       },
       required: [],
     },
@@ -5336,6 +5361,7 @@ export function registerTools(
             const explain = queryArgs.explain === true;
             const includeExpired = queryArgs.include_expired === true;
             const requireLexicalMatch = queryArgs.require_lexical_match === true;
+            const serialization = queryArgs.serialization === "boundary" ? "boundary" : "linear";
             const recencyWeightCheck = resolveSearchRecencyWeight(queryArgs);
             if (!recencyWeightCheck.ok) {
               return errResult("query", "validation_error", recencyWeightCheck.error);
@@ -5668,6 +5694,7 @@ export function registerTools(
               recency_applied: searchRecencyWeight > 0,
               search_recency_weight: searchRecencyWeight,
               expired_filtered_count: expiredFilteredCount,
+              serialization,
             };
             if (actualMode === "hybrid" && hybridResults.length > 0) {
               const inFts = hybridResults.filter((r) => r.lexicalRank !== undefined).length;
@@ -5696,6 +5723,13 @@ export function registerTools(
                 resultNamespaces,
                 resultRanks,
               });
+            }
+
+            // Boundary serialization is purely a display-order transform, applied
+            // AFTER analytics so retrieval_events keep the true linear rank order
+            // (outcome correlation must not see the reordered list).
+            if (serialization === "boundary") {
+              response.results = boundarySerialize(formatted);
             }
 
             return okResult("query", response);

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,16 @@ export interface QueryParams {
    * (preserves recall). No effect in lexical mode.
    */
   require_lexical_match?: boolean;
+  /**
+   * Output ordering of ranked search results. `"linear"` (default) returns
+   * strict best-first rank order. `"boundary"` places the strongest results at
+   * the two context edges (rank 1 first, rank 2 last, rank 3 second, …) to
+   * counter the "Lost in the Middle" attention dip in long contexts. The set of
+   * results and their underlying ranks are unchanged — only display order — and
+   * retrieval analytics always record the true linear rank order. No effect on
+   * filter-only browse queries.
+   */
+  serialization?: "linear" | "boundary";
 }
 
 export interface OrientParams extends ListParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -363,6 +363,8 @@ export interface QueryResponse {
     recency_applied: boolean;
     search_recency_weight: number;
     expired_filtered_count: number;
+    /** Output ordering actually applied. Filter-only browse is always "linear". */
+    serialization: "linear" | "boundary";
   };
 }
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1687,6 +1687,49 @@ describe("memory_query", () => {
       expect(loggedIds).toEqual(linearIds);
       expect(loggedRanks).toEqual(linearIds.map((_, i) => i + 1));
     });
+
+    it("rejects an invalid serialization value on a ranked query", async () => {
+      const raw = await callTool("memory_query", { query: "boundarykeyword", search_mode: "lexical", serialization: "boundry" });
+      const result = parseToolResponse(raw) as { ok: boolean; error?: string };
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("validation_error");
+    });
+
+    it("rejects an invalid serialization value on the filter-only path", async () => {
+      const raw = await callTool("memory_query", { tags: ["active"], serialization: "sideways" });
+      const result = parseToolResponse(raw) as { ok: boolean; error?: string };
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("validation_error");
+    });
+
+    it("reports serialization: linear and does not reorder the filter-only browse path", async () => {
+      await seedBoundaryCorpus();
+      const browseLinear = parseToolResponse(
+        await callTool("memory_query", { namespace: "projects/", limit: 50 }),
+      ) as { results: Array<{ id: string }> };
+      const browseBoundary = parseToolResponse(
+        await callTool("memory_query", { namespace: "projects/", limit: 50, serialization: "boundary" }),
+      ) as { results: Array<{ id: string }>; retrieval: { serialization: string } };
+
+      expect(browseBoundary.retrieval.serialization).toBe("linear");
+      // Browse order is unaffected by serialization.
+      expect(browseBoundary.results.map((r) => r.id)).toEqual(browseLinear.results.map((r) => r.id));
+    });
+
+    it("is a no-op for a 2-result boundary query (rank 1 first, rank 2 last == identity)", async () => {
+      await callTool("memory_write", { namespace: "projects/two-a", key: "status", content: "twoword corpus alpha", tags: ["active"] });
+      await callTool("memory_write", { namespace: "projects/two-b", key: "status", content: "twoword corpus beta", tags: ["active"] });
+
+      const linear = (parseToolResponse(
+        await callTool("memory_query", { query: "twoword", search_mode: "lexical", limit: 50 }),
+      ) as { results: Array<{ id: string }> }).results.map((r) => r.id);
+      const boundary = (parseToolResponse(
+        await callTool("memory_query", { query: "twoword", search_mode: "lexical", limit: 50, serialization: "boundary" }),
+      ) as { results: Array<{ id: string }> }).results.map((r) => r.id);
+
+      expect(linear.length).toBe(2);
+      expect(boundary).toEqual(linear);
+    });
   });
 
   it("marks consolidation synthesis with is_synthesis + synthesis_age_days", async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1618,6 +1618,77 @@ describe("memory_query", () => {
     expect(result.results[0].provenance.principal_id).toBe("owner");
   });
 
+  describe("boundary serialization", () => {
+    async function seedBoundaryCorpus() {
+      for (let i = 0; i < 5; i++) {
+        await callTool("memory_write", {
+          namespace: `projects/bs${i}`,
+          key: "status",
+          content: `boundarykeyword entry number ${i}`,
+          tags: ["active"],
+        });
+      }
+    }
+
+    it("defaults to linear order and reports serialization: linear", async () => {
+      await seedBoundaryCorpus();
+      const raw = await callTool("memory_query", { query: "boundarykeyword", search_mode: "lexical", limit: 50 });
+      const result = parseToolResponse(raw) as { retrieval: { serialization: string } };
+      expect(result.retrieval.serialization).toBe("linear");
+    });
+
+    it("reorders display to boundary placement while preserving the result set and ranks", async () => {
+      await seedBoundaryCorpus();
+
+      const linear = parseToolResponse(
+        await callTool("memory_query", { query: "boundarykeyword", search_mode: "lexical", limit: 50 }),
+      ) as { results: Array<{ id: string }> };
+      const linearIds = linear.results.map((r) => r.id);
+      expect(linearIds.length).toBeGreaterThanOrEqual(5);
+
+      const boundary = parseToolResponse(
+        await callTool("memory_query", { query: "boundarykeyword", search_mode: "lexical", limit: 50, serialization: "boundary" }),
+      ) as { results: Array<{ id: string }>; retrieval: { serialization: string } };
+      const boundaryIds = boundary.results.map((r) => r.id);
+
+      expect(boundary.retrieval.serialization).toBe("boundary");
+      // Same set of results — only the order differs.
+      expect([...boundaryIds].sort()).toEqual([...linearIds].sort());
+      // Strongest results at the two edges: rank 1 first, rank 2 last.
+      expect(boundaryIds[0]).toBe(linearIds[0]);
+      expect(boundaryIds[boundaryIds.length - 1]).toBe(linearIds[1]);
+      // Matches the documented interleave: front = even indices, back = odd reversed.
+      const front: string[] = [];
+      const back: string[] = [];
+      linearIds.forEach((id, i) => (i % 2 === 0 ? front : back).push(id));
+      back.reverse();
+      expect(boundaryIds).toEqual([...front, ...back]);
+    });
+
+    it("records true linear rank order in analytics even when serialization is boundary", async () => {
+      await seedBoundaryCorpus();
+
+      const linearIds = (parseToolResponse(
+        await callTool("memory_query", { query: "boundarykeyword", search_mode: "lexical", limit: 50 }),
+      ) as { results: Array<{ id: string }> }).results.map((r) => r.id);
+
+      const sessionCall = makeContextCallTool(ownerContext(), "boundary-analytics-session");
+      await sessionCall("memory_query", { query: "boundarykeyword", search_mode: "lexical", limit: 50, serialization: "boundary" });
+
+      const row = db
+        .prepare(
+          "SELECT result_ids, result_ranks FROM retrieval_events WHERE session_id = ? AND tool_name = 'memory_query' ORDER BY rowid DESC LIMIT 1",
+        )
+        .get("boundary-analytics-session") as { result_ids: string; result_ranks: string };
+      const loggedIds = JSON.parse(row.result_ids) as string[];
+      const loggedRanks = JSON.parse(row.result_ranks) as number[];
+
+      // Analytics must see the true linear order, not the boundary display order.
+      expect(loggedIds).toEqual(linearIds);
+      expect(loggedRanks).toEqual(linearIds.map((_, i) => i + 1));
+    });
+  });
+
   it("marks consolidation synthesis with is_synthesis + synthesis_age_days", async () => {
     writeState(
       db,


### PR DESCRIPTION
Third and final adopt from the **Letta memory-design harvest** (`decisions/letta-harvest`).

## What
New `serialization: "boundary"` parameter on `memory_query`. When set, ranked results are reordered so the strongest sit at the two **context edges** (rank 1 first, rank 2 last, rank 3 second, …) instead of strict best-first — countering the "Lost in the Middle" attention dip ([arXiv 2307.03172](https://arxiv.org/abs/2307.03172)) when a long result list is dropped straight into context.

- Default (`"linear"`) is unchanged.
- **Display-only:** the result set and underlying ranks are identical.
- **Analytics-safe:** the reorder is applied *after* `logRetrievalEvent`, so `retrieval_events` keep the true linear rank order — the outcome-correlation signal (Feature 4) is never corrupted. A test asserts this invariant directly by reading `retrieval_events`.
- No effect on filter-only browse queries. `retrieval.serialization` echoes the applied mode.

## Changes
- `types.ts` — `serialization` field on `QueryParams`.
- `tools.ts` — `boundarySerialize()` pure helper, schema enum, gated post-analytics apply.
- Tests — default-linear, boundary reorder (set preserved / strongest at edges / documented interleave), and analytics-preserves-linear-order.

Additive: no schema change, no migration, no new env var. 1264 tests pass; lint/typecheck/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)