### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-06-05
+
 ### Security
 
 - **Cross-zone exfil guard on consolidation cross-references (#96)** — the
@@ -605,7 +607,9 @@ Initial public release (commit `c40c127`). Core MCP tool surface
 `memory_list`, `memory_delete`), SQLite + FTS5 storage, Bearer token auth,
 stdio transport, and the first HTTP transport for Raspberry Pi deployment.
 
-[Unreleased]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Magnus-Gille/munin-memory/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Magnus-Gille/munin-memory/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Magnus-Gille/munin-memory/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munin-memory",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munin-memory",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munin-memory",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MCP server providing persistent memory across conversations",
   "author": "Magnus Gille",
   "license": "MIT",


### PR DESCRIPTION
Rolls `[Unreleased]` into `[0.3.2]` (2026-06-05) and bumps `0.3.1 → 0.3.2` in `package.json` + `package-lock.json`. Also backfills the missing `[0.3.1]` compare link and repoints `[Unreleased]`.

## Highlights since v0.3.1
**Security**
- Cross-zone exfil guard on consolidation cross-references (#96)
- Write-time prompt-injection / memory-poisoning advisory scan (#94)

**Added**
- Synthesis provenance tag + age on the query read path
- Telos ideal-state anchor surfaced by orient/resume (#95)
- Consolidation-pressure `consolidation_backlog` orient signal
- Opt-in boundary serialization for `memory_query`
- Ground-truth benchmark query pipeline (#70, Phase 3)

No schema migration — safe to deploy to Pi by replacing the binary and restarting.

Docs-/metadata-only diff; skips Codex review per the carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)