### PR TITLE
feat(consolidation): loud failure signal — stop the worker failing silently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,29 @@ To grep for 4xx captures:
 ssh magnus@huginmunin.local "journalctl -u munin-memory -n 500 --no-pager | grep -E '\"status\":4[0-9]{2}' | grep '/mcp'"
 ```
 
+### Consolidation worker health alert
+
+The consolidation worker writes a pollable state entry at `meta/system-health`, key `consolidation`, **only on status transitions** (not every run). An external consumer (e.g. Ratatoskr) can poll this entry for Telegram alerts.
+
+JSON shape:
+```json
+{
+  "status": "healthy" | "failing" | "tripped",
+  "failures": 2,
+  "max_failures": 3,
+  "last_error": "OpenRouter API error 401: ...",
+  "last_error_at": "2026-06-15T10:30:00.000Z",
+  "updated_at": "2026-06-15T10:30:00.000Z"
+}
+```
+
+- `status: "healthy"` — no failures; entry written once when the worker recovers from a prior alert.
+- `status: "failing"` — one or more failures have occurred but the circuit breaker has not yet tripped.
+- `status: "tripped"` — circuit breaker tripped; worker will not process any batches until `resetConsolidationCircuitBreaker()` is called (requires server restart in production).
+- Tags: `["system_alert", "consolidation"]`
+- The entry is also surfaced as a `consolidation_circuit_breaker` maintenance item in `memory_orient` (owner-only), even when `isConsolidationAvailable()` is false — this is the key property: the warning is **louder when the breaker is tripped**, not silent.
+- `memory_status` exposes `consolidation_health` (owner-only) with the full breakdown including `circuit_breaker_tripped`, `failures`, `last_error`, etc. The existing `features.consolidation` boolean remains for backward compat.
+
 ## Code style
 
 - TypeScript strict mode

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -8,6 +8,7 @@ import {
   addCrossReferences,
   hasMoreLogsAfter,
   writeState,
+  readState,
   recordCrossZoneBlock,
   nowUTC,
 } from "./db.js";
@@ -18,7 +19,7 @@ import {
 } from "./librarian.js";
 import { canRead, getContextMaxClassification } from "./access.js";
 import type { AccessContext } from "./access.js";
-import { validateNamespace, scanForSecrets } from "./security.js";
+import { validateNamespace, scanForSecrets, redactSecrets } from "./security.js";
 import type { ClassificationLevel } from "./types.js";
 import type { Entry, SynthesisResult, ConsolidationRunResult, CrossReferenceType, ConsolidationCandidate } from "./types.js";
 
@@ -253,6 +254,34 @@ export function initConsolidation(): boolean {
 export function startConsolidationWorker(db: Database.Database): void {
   if (apiKey === null) return;
   workerDb = db;
+
+  // Reconcile stale persisted alert on startup. If a previous run tripped or
+  // failed but the server restarted (clearing in-memory state) without being
+  // able to persist the healthy transition (no-db reset path), the stored entry
+  // still says "tripped" or "failing" while in-memory health is already healthy.
+  // Detect that mismatch and write the healthy entry now before the first run.
+  if (circuitBreakerFailures === 0 && !circuitBreakerTripped) {
+    try {
+      const existing = readState(db, "meta/system-health", "consolidation");
+      if (existing) {
+        let persistedStatus: string | undefined;
+        try {
+          persistedStatus = (JSON.parse(existing.content) as { status?: string }).status;
+        } catch {
+          // malformed entry — skip reconciliation
+        }
+        if (persistedStatus && persistedStatus !== "healthy") {
+          // Force a write: clear lastWrittenStatus so maybeWriteHealthAlert
+          // sees a transition from the stale status to healthy.
+          lastWrittenStatus = null;
+          maybeWriteHealthAlert(db);
+        }
+      }
+    } catch (err) {
+      console.warn("consolidation: startup reconciliation failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
+
   scheduleNextRun();
 }
 
@@ -289,13 +318,15 @@ export function resetConsolidationCircuitBreaker(): void {
   circuitBreakerTripped = false;
   lastError = null;
   lastErrorAt = null;
-  // Write the healthy-transition alert if we have a db and the status changed
+  // Write the healthy-transition alert if we have a db and the status changed.
   if (workerDb) {
     maybeWriteHealthAlert(workerDb);
   } else {
-    // Without a db (e.g. after stopConsolidationWorker), just update the tracked
-    // status so the next batch run will write on its first real transition.
-    lastWrittenStatus = "healthy";
+    // Without a db (e.g. after stopConsolidationWorker), we cannot persist the
+    // healthy transition. Do NOT advance lastWrittenStatus here — the persisted
+    // entry still reflects the old (tripped/failing) status. The next call to
+    // startConsolidationWorker will reconcile the stale persisted entry.
+    console.warn("consolidation: resetConsolidationCircuitBreaker called without a workerDb — healthy transition cannot be persisted");
   }
 }
 
@@ -325,8 +356,9 @@ export async function processConsolidationBatch(): Promise<void> {
 
       if (result.error) {
         circuitBreakerFailures++;
-        // Truncate error to 300 chars to avoid storing large blobs in the health entry
-        lastError = result.error.slice(0, 300);
+        // Sanitize then truncate: redact secrets (API key literal + known patterns)
+        // before storing so the health entry and memory_status never leak credentials.
+        lastError = redactSecrets(apiKey ? result.error.replace(apiKey, "[REDACTED]") : result.error).slice(0, 300);
         lastErrorAt = new Date().toISOString();
         console.error(`Consolidation failed for ${candidate.namespace} (${circuitBreakerFailures}/${config.maxFailures}): ${result.error}`);
 

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -358,7 +358,7 @@ export async function processConsolidationBatch(): Promise<void> {
         circuitBreakerFailures++;
         // Sanitize then truncate: redact secrets (API key literal + known patterns)
         // before storing so the health entry and memory_status never leak credentials.
-        lastError = redactSecrets(apiKey ? result.error.replace(apiKey, "[REDACTED]") : result.error).slice(0, 300);
+        lastError = redactSecrets(apiKey ? result.error.split(apiKey).join("[REDACTED]") : result.error).slice(0, 300);
         lastErrorAt = new Date().toISOString();
         console.error(`Consolidation failed for ${candidate.namespace} (${circuitBreakerFailures}/${config.maxFailures}): ${result.error}`);
 

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -139,6 +139,13 @@ let workerProcessing = false;
 let workerInflightPromise: Promise<void> | null = null;
 let workerDb: Database.Database | null = null;
 
+// Health tracking state (for loud failure signal)
+let lastError: string | null = null;
+let lastErrorAt: string | null = null;
+// Tracks the last status written to meta/system-health:consolidation so we
+// only write on transitions, not on every failure.
+let lastWrittenStatus: "healthy" | "failing" | "tripped" | null = null;
+
 // --- API call ---
 
 async function callOpenRouter(prompt: string): Promise<ChatCompletionResponse> {
@@ -164,6 +171,66 @@ async function callOpenRouter(prompt: string): Promise<ChatCompletionResponse> {
   }
 
   return response.json() as Promise<ChatCompletionResponse>;
+}
+
+// --- Health reporting ---
+
+export interface ConsolidationHealth {
+  enabled: boolean;
+  api_key_present: boolean;
+  available: boolean;
+  circuit_breaker_tripped: boolean;
+  failures: number;
+  max_failures: number;
+  last_error: string | null;
+  last_error_at: string | null;
+}
+
+export function getConsolidationHealth(): ConsolidationHealth {
+  return {
+    enabled: config.enabled,
+    api_key_present: apiKey !== null,
+    available: isConsolidationAvailable(),
+    circuit_breaker_tripped: circuitBreakerTripped,
+    failures: circuitBreakerFailures,
+    max_failures: config.maxFailures,
+    last_error: lastError,
+    last_error_at: lastErrorAt,
+  };
+}
+
+/** Compute the current alert status bucket. */
+function currentAlertStatus(): "healthy" | "failing" | "tripped" {
+  if (circuitBreakerTripped) return "tripped";
+  if (circuitBreakerFailures > 0) return "failing";
+  return "healthy";
+}
+
+/**
+ * Write the alert state entry to meta/system-health:consolidation only when
+ * the status has changed (transition-only). Wrapped in try/catch so a write
+ * failure never propagates out of the worker. The entry content must not
+ * contain secrets — only status strings and truncated error messages.
+ */
+function maybeWriteHealthAlert(db: Database.Database): void {
+  const status = currentAlertStatus();
+  if (status === lastWrittenStatus) return;
+
+  const content = JSON.stringify({
+    status,
+    failures: circuitBreakerFailures,
+    max_failures: config.maxFailures,
+    last_error: lastError,
+    last_error_at: lastErrorAt,
+    updated_at: new Date().toISOString(),
+  });
+
+  try {
+    writeState(db, "meta/system-health", "consolidation", content, ["system_alert", "consolidation"], "consolidation-worker");
+    lastWrittenStatus = status;
+  } catch (err) {
+    console.error("consolidation: failed to write health alert entry:", err instanceof Error ? err.message : String(err));
+  }
 }
 
 // --- Lifecycle exports ---
@@ -220,6 +287,16 @@ export function getConsolidationBacklog(db: Database.Database): ConsolidationCan
 export function resetConsolidationCircuitBreaker(): void {
   circuitBreakerFailures = 0;
   circuitBreakerTripped = false;
+  lastError = null;
+  lastErrorAt = null;
+  // Write the healthy-transition alert if we have a db and the status changed
+  if (workerDb) {
+    maybeWriteHealthAlert(workerDb);
+  } else {
+    // Without a db (e.g. after stopConsolidationWorker), just update the tracked
+    // status so the next batch run will write on its first real transition.
+    lastWrittenStatus = "healthy";
+  }
 }
 
 // --- Worker loop ---
@@ -248,15 +325,25 @@ export async function processConsolidationBatch(): Promise<void> {
 
       if (result.error) {
         circuitBreakerFailures++;
+        // Truncate error to 300 chars to avoid storing large blobs in the health entry
+        lastError = result.error.slice(0, 300);
+        lastErrorAt = new Date().toISOString();
         console.error(`Consolidation failed for ${candidate.namespace} (${circuitBreakerFailures}/${config.maxFailures}): ${result.error}`);
 
         if (circuitBreakerFailures >= config.maxFailures) {
           circuitBreakerTripped = true;
           console.warn("Consolidation circuit breaker tripped — consolidation disabled until reset");
+          maybeWriteHealthAlert(db);
           break;
+        } else {
+          maybeWriteHealthAlert(db);
         }
       } else {
         circuitBreakerFailures = 0;
+        // On recovery within a batch, clear error state and transition to healthy
+        lastError = null;
+        lastErrorAt = null;
+        maybeWriteHealthAlert(db);
         if (result.orphans_discovered > 0) {
           console.log(
             `Consolidated ${candidate.namespace}: ${result.logs_processed} logs, ${result.cross_references_found} cross-refs (${result.orphans_discovered} scanner-discovered orphans)`,
@@ -969,6 +1056,13 @@ export function _setApiKey(key: string | null): void {
 
 export function _setWorkerDb(d: Database.Database | null): void {
   workerDb = d;
+}
+
+/** Reset the health-tracking state (lastError, lastErrorAt, lastWrittenStatus) for tests. */
+export function _resetHealthState(): void {
+  lastError = null;
+  lastErrorAt = null;
+  lastWrittenStatus = null;
 }
 
 export { config as _consolidationConfig };

--- a/src/security.ts
+++ b/src/security.ts
@@ -73,6 +73,24 @@ export function scanForSecrets(content: string): SecurityResult {
 }
 
 /**
+ * Replace all secret-pattern matches in `message` with "[REDACTED]".
+ * Used to sanitize error strings before storing or exposing them.
+ * Unlike {@link scanForSecrets} (which rejects on first match), this
+ * applies every pattern as a global replacement so multi-secret strings
+ * are fully scrubbed.
+ */
+export function redactSecrets(message: string): string {
+  let result = message;
+  for (const { pattern } of SECRET_PATTERNS) {
+    // Build a global-flagged copy so replaceAll behaviour works regardless
+    // of whether the pattern already has the /g flag.
+    const global = new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g");
+    result = result.replace(global, "[REDACTED]");
+  }
+  return result;
+}
+
+/**
  * Scan content for instruction-shaped phrasing (see {@link INJECTION_PATTERNS}).
  * Returns the de-duplicated labels of every matched signature, or an empty array.
  * Advisory only — callers surface this as a warning and still store the entry.

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,6 +1,7 @@
 import type { SecurityResult } from "./types.js";
 
 const SECRET_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /sk-or-v1-[a-zA-Z0-9_-]{20,}/, label: "OpenRouter API key" },
   { pattern: /sk-[a-zA-Z0-9]{20,}/, label: "API key (sk-...)" },
   { pattern: /sk-proj-[a-zA-Z0-9]{20,}/, label: "OpenAI project API key (sk-proj-...)" },
   { pattern: /ghp_[a-zA-Z0-9]{36,}/, label: "GitHub personal access token" },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -106,6 +106,7 @@ import {
   consolidateNamespace,
   isConsolidationAvailable,
   getConsolidationBacklog,
+  getConsolidationHealth,
 } from "./consolidation.js";
 import type {
   WriteParams,
@@ -3899,24 +3900,45 @@ export function registerTools(
                 }
               }
 
-              // Consolidation pressure (owner-only). Only meaningful when the
-              // worker is actually available — otherwise a backlog is noise
-              // nothing will drain. A persistent backlog while consolidation is
-              // available means the worker is stalled or rate-limited. Tracked
-              // namespaces are owner-readable, so no per-namespace canRead pass is
-              // needed here (the whole signal is gated on owner). Distilled from
-              // the Letta memory-design harvest (see decisions/letta-harvest).
-              if (ctx.principalType === "owner" && isConsolidationAvailable()) {
-                for (const candidate of getConsolidationBacklog(db)) {
-                  const backlogItem: MaintenanceItem = {
-                    namespace: candidate.namespace,
-                    issue: "consolidation_backlog",
-                    suggestion: `${candidate.unincorporated_log_count} unincorporated log${candidate.unincorporated_log_count === 1 ? "" : "s"} awaiting consolidation. The worker drains these on its next run; a persistent backlog suggests it is stalled or rate-limited.`,
+              // Consolidation pressure and failure signal (owner-only).
+              // Two cases:
+              //   1. Worker available + backlog → surface consolidation_backlog items.
+              //   2. Worker enabled but circuit breaker tripped (or failing) →
+              //      surface consolidation_circuit_breaker warning. This MUST fire
+              //      even though isConsolidationAvailable() is false when tripped —
+              //      that was the silent-failure bug: the old guard suppressed the
+              //      warning exactly when the worker needed attention most.
+              // Tracked namespaces are owner-readable, so no per-namespace canRead
+              // pass is needed here (the whole signal is gated on owner).
+              // Distilled from the Letta memory-design harvest (see decisions/letta-harvest).
+              if (ctx.principalType === "owner") {
+                const health = getConsolidationHealth();
+                if (health.enabled && isConsolidationAvailable()) {
+                  for (const candidate of getConsolidationBacklog(db)) {
+                    const backlogItem: MaintenanceItem = {
+                      namespace: candidate.namespace,
+                      issue: "consolidation_backlog",
+                      suggestion: `${candidate.unincorporated_log_count} unincorporated log${candidate.unincorporated_log_count === 1 ? "" : "s"} awaiting consolidation. The worker drains these on its next run; a persistent backlog suggests it is stalled or rate-limited.`,
+                    };
+                    // Oldest-first: never-consolidated namespaces (null) sort ahead
+                    // of those with an older last-consolidated timestamp.
+                    maintenanceSortKey.set(backlogItem, candidate.last_consolidated_at ?? "");
+                    maintenanceNeeded.push(backlogItem);
+                  }
+                } else if (health.enabled && (health.circuit_breaker_tripped || health.failures > 0)) {
+                  // Circuit breaker has tripped (or is accumulating failures).
+                  // Surface a loud maintenance item — the worker is not draining
+                  // the backlog and needs operator attention.
+                  const failureSummary = health.last_error
+                    ? `${health.failures}/${health.max_failures} failures, last error: ${health.last_error.slice(0, 120)}`
+                    : `${health.failures}/${health.max_failures} failures`;
+                  const cbItem: MaintenanceItem = {
+                    namespace: null,
+                    issue: "consolidation_circuit_breaker",
+                    suggestion: `Consolidation worker is failing: ${failureSummary}. It will not drain backlog until fixed. Check memory_status / journalctl -u munin-memory.`,
                   };
-                  // Oldest-first: never-consolidated namespaces (null) sort ahead
-                  // of those with an older last-consolidated timestamp.
-                  maintenanceSortKey.set(backlogItem, candidate.last_consolidated_at ?? "");
-                  maintenanceNeeded.push(backlogItem);
+                  maintenanceSortKey.set(cbItem, "");
+                  maintenanceNeeded.push(cbItem);
                 }
               }
 
@@ -5969,8 +5991,9 @@ export function registerTools(
                   if (item.issue === "missing_lifecycle" && !includeMissingLifecycle) continue;
                   if (item.issue === "missing_status") continue;
 
+                  // namespace is always a string here (derived from assessment.row.namespace)
                   attentionItems.push(buildAttentionItem(
-                    item.namespace,
+                    item.namespace ?? assessment.row.namespace,
                     item.issue,
                     assessment.row.updated_at,
                     assessment.row.content_preview.slice(0, 150),
@@ -6525,6 +6548,7 @@ export function registerTools(
                   embeddings: isEmbeddingAvailable(),
                   semantic_search: isSemanticEnabled(),
                   hybrid_search: isHybridEnabled(),
+                  // Keep this boolean for backward compatibility (Heimdall reads it)
                   consolidation: isConsolidationAvailable(),
                 },
                 tools: {
@@ -6539,6 +6563,9 @@ export function registerTools(
               };
               if (ctx.principalType === "owner") {
                 statusResponse.telemetry = getToolCallAggregates(db, 7);
+                // Detailed health breakdown (owner-only) — includes circuit breaker
+                // state, failure count, and last error so failures are never silent.
+                statusResponse.consolidation_health = getConsolidationHealth();
               }
               return okResult("status", statusResponse);
             };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3913,7 +3913,12 @@ export function registerTools(
               // Distilled from the Letta memory-design harvest (see decisions/letta-harvest).
               if (ctx.principalType === "owner") {
                 const health = getConsolidationHealth();
-                if (health.enabled && isConsolidationAvailable()) {
+                // Block 1: Worker available + backlog → surface consolidation_backlog items.
+                // When the breaker is tripped, isConsolidationAvailable() returns false so
+                // no backlog is shown (nothing will drain it). When failures > 0 but the
+                // breaker is not yet tripped, the worker IS still available — show both
+                // the backlog AND the circuit_breaker warning (Block 2 below).
+                if (health.enabled && health.available) {
                   for (const candidate of getConsolidationBacklog(db)) {
                     const backlogItem: MaintenanceItem = {
                       namespace: candidate.namespace,
@@ -3925,7 +3930,12 @@ export function registerTools(
                     maintenanceSortKey.set(backlogItem, candidate.last_consolidated_at ?? "");
                     maintenanceNeeded.push(backlogItem);
                   }
-                } else if (health.enabled && (health.circuit_breaker_tripped || health.failures > 0)) {
+                }
+                // Block 2: Circuit breaker tripped OR accumulating failures → surface warning.
+                // INDEPENDENT of Block 1: fires whenever failures > 0, even when the breaker
+                // is not yet tripped and the worker is still available. This is the pre-trip
+                // warning that was previously suppressed by the else-if relationship.
+                if (health.enabled && (health.circuit_breaker_tripped || health.failures > 0)) {
                   // Circuit breaker has tripped (or is accumulating failures).
                   // Surface a loud maintenance item — the worker is not draining
                   // the backlog and needs operator attention.

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,8 +258,8 @@ export interface DashboardEntry {
 }
 
 export interface MaintenanceItem {
-  namespace: string;
-  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "expiring_soon" | "expired" | "consolidation_backlog";
+  namespace: string | null;
+  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "expiring_soon" | "expired" | "consolidation_backlog" | "consolidation_circuit_breaker";
   suggestion: string;
 }
 

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -1764,6 +1764,70 @@ describe("meta/system-health alert entry — transition-only writes", () => {
     expect(parsed.last_error).toContain("[REDACTED]");
     expect(parsed.last_error).not.toContain(fakeKey);
   });
+
+  it("sanitizes ALL occurrences of the API key when it appears twice in the error body", async () => {
+    const fakeKey = "sk-or-v1-supersecretkey12345678";
+    _setApiKey(fakeKey);
+    _setWorkerDb(db);
+
+    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+      appendLog(db, "projects/doublekey", `Log ${i}`, []);
+    }
+
+    const originalFetch = globalThis.fetch;
+    // Error body contains the key TWICE (bare, no Bearer prefix)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(`${fakeKey} is invalid. Retry with a valid key: ${fakeKey}`),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
+
+    // In-memory health must have ZERO occurrences of the raw key
+    const health = getConsolidationHealth();
+    expect(health.last_error).not.toBeNull();
+    expect(health.last_error).not.toContain(fakeKey);
+    expect(health.last_error).toContain("[REDACTED]");
+
+    // Persisted entry must also have ZERO occurrences
+    const alertEntry = readState(db, "meta/system-health", "consolidation");
+    expect(alertEntry).not.toBeNull();
+    const parsed = JSON.parse(alertEntry!.content) as { last_error: string };
+    expect(parsed.last_error).not.toContain(fakeKey);
+  });
+
+  it("sanitizes bare OpenRouter key in error body (no Bearer prefix)", async () => {
+    const fakeKey = "sk-or-v1-supersecretkey12345678";
+    _setApiKey(fakeKey);
+    _setWorkerDb(db);
+
+    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+      appendLog(db, "projects/barekey", `Log ${i}`, []);
+    }
+
+    const originalFetch = globalThis.fetch;
+    // Error body: bare key, NO "Bearer " prefix — must be caught by the new sk-or-v1-... pattern
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(`API key ${fakeKey} is not authorized`),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
+
+    const health = getConsolidationHealth();
+    expect(health.last_error).not.toBeNull();
+    expect(health.last_error).not.toContain(fakeKey);
+    expect(health.last_error).toContain("[REDACTED]");
+
+    const alertEntry = readState(db, "meta/system-health", "consolidation");
+    expect(alertEntry).not.toBeNull();
+    const parsedBare = JSON.parse(alertEntry!.content) as { last_error: string };
+    expect(parsedBare.last_error).not.toContain(fakeKey);
+  });
 });
 
 describe("startConsolidationWorker reconciliation on startup", () => {

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -25,9 +25,11 @@ import {
   isOrphaned,
   mergeCrossReferences,
   discoverOrphanedReferences,
+  getConsolidationHealth,
   _consolidationConfig,
   _setApiKey,
   _setWorkerDb,
+  _resetHealthState,
   type ChatCompletionResponse,
 } from "../src/consolidation.js";
 import type { Entry } from "../src/types.js";
@@ -1449,6 +1451,235 @@ describe("isConsolidationAvailable — edge conditions", () => {
   it("returns false when apiKey is null even if config.enabled were true", () => {
     _setApiKey(null);
     expect(isConsolidationAvailable()).toBe(false);
+  });
+});
+
+// ─── getConsolidationHealth + alert entry (loud failure signal) ──────────────
+
+describe("getConsolidationHealth — reflects circuit breaker state", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+    _setApiKey(null);
+    _setWorkerDb(null);
+  });
+
+  afterEach(async () => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    _setApiKey(null);
+    _setWorkerDb(null);
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+  });
+
+  it("returns healthy state when no failures have occurred and api key is set", () => {
+    _setApiKey("test-key");
+    const health = getConsolidationHealth();
+    expect(health.available).toBe(false); // config.enabled is false in test env
+    expect(health.api_key_present).toBe(true);
+    expect(health.circuit_breaker_tripped).toBe(false);
+    expect(health.failures).toBe(0);
+    expect(health.max_failures).toBe(_consolidationConfig.maxFailures);
+    expect(health.last_error).toBeNull();
+    expect(health.last_error_at).toBeNull();
+  });
+
+  it("reflects failure count and last_error after simulated failures via consolidateNamespace", async () => {
+    _setApiKey("test-key");
+    // Seed enough logs
+    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+      appendLog(db, "projects/healthtest", `Log ${i}`, []);
+    }
+    const failingApi = vi.fn().mockRejectedValue(new Error("OpenRouter API error 401: invalid key"));
+
+    // Run one failure through processConsolidationBatch internals (via consolidateNamespace)
+    _setWorkerDb(db);
+    // Inject failure directly via consolidateNamespace to increment the counter
+    // (processConsolidationBatch reads circuitBreakerFailures via its internal path)
+    const result = await consolidateNamespace(db, "projects/healthtest", failingApi);
+    expect(result.error).toContain("invalid key");
+
+    // Now drive processConsolidationBatch to pick it up — but that would need real fetch.
+    // Instead, test the health state after we simulate the counter increments directly.
+    // Use the batch path with workerDb set so the counter is incremented.
+    // Because consolidateNamespace only returns an error (doesn't increment cb itself),
+    // processConsolidationBatch is the one incrementing. Let's test that path via a
+    // stub fetch approach.
+    _setWorkerDb(null);
+  });
+
+  it("reflects circuit_breaker_tripped: true and last_error after batch failures", async () => {
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/health${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key-for-test");
+    _setWorkerDb(db);
+
+    // Stub global fetch so failures are controlled and don't make network calls
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+
+    globalThis.fetch = originalFetch;
+
+    const health = getConsolidationHealth();
+    expect(health.circuit_breaker_tripped).toBe(true);
+    expect(health.last_error).not.toBeNull();
+    expect(health.last_error).toContain("401");
+    expect(health.last_error_at).not.toBeNull();
+    expect(health.failures).toBeGreaterThanOrEqual(failCount);
+  });
+});
+
+describe("meta/system-health alert entry — transition-only writes", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+    _setApiKey(null);
+    _setWorkerDb(null);
+  });
+
+  afterEach(async () => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    _setApiKey(null);
+    _setWorkerDb(null);
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+  });
+
+  it("writes a meta/system-health:consolidation entry with status:tripped after circuit trips", async () => {
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/alert${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key");
+    _setWorkerDb(db);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized: invalid API key"),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+
+    globalThis.fetch = originalFetch;
+
+    // Assert the alert state entry was written
+    const alertEntry = readState(db, "meta/system-health", "consolidation");
+    expect(alertEntry).not.toBeNull();
+    const parsed = JSON.parse(alertEntry!.content) as {
+      status: string;
+      failures: number;
+      last_error: string;
+      last_error_at: string;
+      updated_at: string;
+    };
+    expect(parsed.status).toBe("tripped");
+    expect(parsed.failures).toBeGreaterThanOrEqual(failCount);
+    expect(parsed.last_error).toContain("401");
+    expect(parsed.last_error_at).toBeTruthy();
+    expect(parsed.updated_at).toBeTruthy();
+
+    // Tags should include system_alert and consolidation
+    const tags = JSON.parse(alertEntry!.tags) as string[];
+    expect(tags).toContain("system_alert");
+    expect(tags).toContain("consolidation");
+  });
+
+  it("does NOT rewrite the alert entry on a subsequent failure at the same tripped status (transition-only)", async () => {
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount + 2; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/transtest${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key");
+    _setWorkerDb(db);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as unknown as Response);
+
+    // First batch run — should write the alert entry (transition healthy→tripped)
+    await processConsolidationBatch();
+    const firstEntry = readState(db, "meta/system-health", "consolidation");
+    expect(firstEntry).not.toBeNull();
+    const firstUpdatedAt = firstEntry!.updated_at;
+
+    // Reset the circuit to untripped (but keep lastWrittenStatus as "tripped")
+    // so we can simulate a second failure that SHOULD NOT re-write
+    // (status is still tripped, no transition)
+    // We check that if processConsolidationBatch is called again while already tripped,
+    // it exits early without modifying the entry (tripped guard)
+    await processConsolidationBatch();
+    const secondEntry = readState(db, "meta/system-health", "consolidation");
+    // Since breaker is tripped, the second call is a no-op; entry unchanged
+    expect(secondEntry!.updated_at).toBe(firstUpdatedAt);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("transitions to healthy status on resetConsolidationCircuitBreaker", async () => {
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/recovery${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key");
+    _setWorkerDb(db);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as unknown as Response);
+
+    // Trip the breaker and write the tripped alert
+    await processConsolidationBatch();
+    const trippedEntry = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(trippedEntry!.content).status).toBe("tripped");
+
+    globalThis.fetch = originalFetch;
+
+    // Reset and write the healthy transition
+    resetConsolidationCircuitBreaker();
+
+    const healthyEntry = readState(db, "meta/system-health", "consolidation");
+    expect(healthyEntry).not.toBeNull();
+    expect(JSON.parse(healthyEntry!.content).status).toBe("healthy");
   });
 });
 

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -1490,28 +1490,37 @@ describe("getConsolidationHealth — reflects circuit breaker state", () => {
     expect(health.last_error_at).toBeNull();
   });
 
-  it("reflects failure count and last_error after simulated failures via consolidateNamespace", async () => {
-    _setApiKey("test-key");
-    // Seed enough logs
+  it("reflects failure count and last_error after one processConsolidationBatch failure (pre-trip)", async () => {
+    _setApiKey("fake-key-for-test");
+    _setWorkerDb(db);
+
     for (let i = 0; i < _consolidationConfig.minLogs; i++) {
       appendLog(db, "projects/healthtest", `Log ${i}`, []);
     }
-    const failingApi = vi.fn().mockRejectedValue(new Error("OpenRouter API error 401: invalid key"));
 
-    // Run one failure through processConsolidationBatch internals (via consolidateNamespace)
-    _setWorkerDb(db);
-    // Inject failure directly via consolidateNamespace to increment the counter
-    // (processConsolidationBatch reads circuitBreakerFailures via its internal path)
-    const result = await consolidateNamespace(db, "projects/healthtest", failingApi);
-    expect(result.error).toContain("invalid key");
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized: fake error"),
+    } as unknown as Response);
 
-    // Now drive processConsolidationBatch to pick it up — but that would need real fetch.
-    // Instead, test the health state after we simulate the counter increments directly.
-    // Use the batch path with workerDb set so the counter is incremented.
-    // Because consolidateNamespace only returns an error (doesn't increment cb itself),
-    // processConsolidationBatch is the one incrementing. Let's test that path via a
-    // stub fetch approach.
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
     _setWorkerDb(null);
+
+    const health = getConsolidationHealth();
+    // One failure: failures === 1, breaker NOT tripped (maxFailures is 3)
+    expect(health.failures).toBe(1);
+    expect(health.last_error).not.toBeNull();
+    expect(health.last_error).toContain("401");
+    expect(health.circuit_breaker_tripped).toBe(false);
+
+    // Persisted entry should have status "failing" (not "tripped", not "healthy")
+    const alertEntry = readState(db, "meta/system-health", "consolidation");
+    expect(alertEntry).not.toBeNull();
+    const parsed = JSON.parse(alertEntry!.content) as { status: string };
+    expect(parsed.status).toBe("failing");
   });
 
   it("reflects circuit_breaker_tripped: true and last_error after batch failures", async () => {
@@ -1680,6 +1689,147 @@ describe("meta/system-health alert entry — transition-only writes", () => {
     const healthyEntry = readState(db, "meta/system-health", "consolidation");
     expect(healthyEntry).not.toBeNull();
     expect(JSON.parse(healthyEntry!.content).status).toBe("healthy");
+  });
+
+  it("reset without workerDb does NOT advance lastWrittenStatus to healthy", async () => {
+    // Trip the breaker first with a workerDb present so the tripped status is persisted.
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/resetnodbtest${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key");
+    _setWorkerDb(db);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
+
+    // Verify the persisted entry says tripped
+    const trippedEntry = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(trippedEntry!.content).status).toBe("tripped");
+
+    // Now stop the worker (sets workerDb = null) and reset the breaker WITHOUT a db.
+    await stopConsolidationWorker();
+    resetConsolidationCircuitBreaker();
+
+    // The persisted entry MUST still say tripped (we couldn't write healthy without a db).
+    const afterNoDbReset = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(afterNoDbReset!.content).status).toBe("tripped");
+
+    // Now set workerDb back and reset again — this time it SHOULD write healthy.
+    _setWorkerDb(db);
+    resetConsolidationCircuitBreaker();
+    const afterWithDbReset = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(afterWithDbReset!.content).status).toBe("healthy");
+  });
+
+  it("sanitizes API key and Bearer token from last_error before storing", async () => {
+    const fakeKey = "sk-or-v1-supersecretkey12345678";
+    _setApiKey(fakeKey);
+    _setWorkerDb(db);
+
+    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+      appendLog(db, "projects/sanitizetest", `Log ${i}`, []);
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve(`Error: Bearer ${fakeKey} is invalid`),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
+
+    // In-memory health must not contain the raw key
+    const health = getConsolidationHealth();
+    expect(health.last_error).not.toBeNull();
+    expect(health.last_error).toContain("[REDACTED]");
+    expect(health.last_error).not.toContain(fakeKey);
+
+    // Persisted entry must also be sanitized
+    const alertEntry = readState(db, "meta/system-health", "consolidation");
+    expect(alertEntry).not.toBeNull();
+    const parsed = JSON.parse(alertEntry!.content) as { last_error: string };
+    expect(parsed.last_error).toContain("[REDACTED]");
+    expect(parsed.last_error).not.toContain(fakeKey);
+  });
+});
+
+describe("startConsolidationWorker reconciliation on startup", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+    _setApiKey(null);
+    _setWorkerDb(null);
+  });
+
+  afterEach(async () => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+    _setApiKey(null);
+    await stopConsolidationWorker();
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+  });
+
+  it("startConsolidationWorker reconciles stale tripped alert on startup when health is already healthy", async () => {
+    // Step 1: Trip the breaker with a workerDb present.
+    const failCount = _consolidationConfig.maxFailures;
+    for (let ns = 0; ns < failCount; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/reconcile${ns}`, `Log ${i}`, []);
+      }
+    }
+
+    _setApiKey("fake-key");
+    _setWorkerDb(db);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve("Unauthorized"),
+    } as unknown as Response);
+
+    await processConsolidationBatch();
+    globalThis.fetch = originalFetch;
+
+    // Verify persisted entry says tripped
+    const trippedEntry = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(trippedEntry!.content).status).toBe("tripped");
+
+    // Step 2: Stop worker (sets workerDb = null) then reset WITHOUT db.
+    await stopConsolidationWorker();
+    resetConsolidationCircuitBreaker(); // in-memory: healthy; persisted: still tripped (Fix A)
+
+    // Verify persisted entry is still tripped after no-db reset (Fix A must be in place)
+    const afterNoDbReset = readState(db, "meta/system-health", "consolidation");
+    expect(JSON.parse(afterNoDbReset!.content).status).toBe("tripped");
+
+    // Step 3: Start the worker again with the db — reconciliation should write healthy.
+    startConsolidationWorker(db);
+    await stopConsolidationWorker();
+
+    // Persisted entry should now be healthy (Fix B reconciliation).
+    const reconciledEntry = readState(db, "meta/system-health", "consolidation");
+    expect(reconciledEntry).not.toBeNull();
+    expect(JSON.parse(reconciledEntry!.content).status).toBe("healthy");
   });
 });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   scanForSecrets,
+  redactSecrets,
   scanForInjection,
   injectionWarning,
   validateNamespace,
@@ -109,6 +110,37 @@ describe("scanForSecrets", () => {
       "API keys should never be stored in memory. The security module rejects them.",
     );
     expect(result.valid).toBe(true);
+  });
+
+  it("rejects bare OpenRouter API key (sk-or-v1-... without Bearer prefix)", () => {
+    const result = scanForSecrets("key is sk-or-v1-abcdefghijklmnopqrstuv");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("OpenRouter API key");
+  });
+
+  it("rejects bare OpenRouter key embedded in an error message", () => {
+    const result = scanForSecrets("OpenRouter API error 401: sk-or-v1-abcdefghijklmnopqrstuv is invalid");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("redactSecrets", () => {
+  it("redacts a bare OpenRouter API key (no Bearer prefix)", () => {
+    const raw = "error: sk-or-v1-abcdefghijklmnopqrstuv is invalid";
+    const redacted = redactSecrets(raw);
+    expect(redacted).not.toMatch(/sk-or-v1-[a-zA-Z0-9_-]{20,}/);
+    expect(redacted).toContain("[REDACTED]");
+  });
+
+  it("redacts all occurrences of a literal string that appears twice", () => {
+    // Simulates the consolidation chokepoint with a double-occurrence literal key
+    const key = "sk-or-v1-supersecretkey12345678";
+    const errorBody = `OpenRouter error 401: ${key} is invalid. Please check ${key} again.`;
+    // First do the literal-key split/join (as the new chokepoint code does), then redactSecrets
+    const afterLiteral = errorBody.split(key).join("[REDACTED]");
+    const afterRedact = redactSecrets(afterLiteral);
+    expect(afterRedact).not.toContain(key);
+    expect(afterRedact.match(/\[REDACTED\]/g)?.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -6,7 +6,7 @@ import { initDatabase, upsertConsolidationMetadata, writeState } from "../src/db
 import { registerTools, computeCommitmentConfidence } from "../src/tools.js";
 import { ownerContext } from "../src/access.js";
 import type { AccessContext } from "../src/access.js";
-import { _setApiKey, _consolidationConfig, resetConsolidationCircuitBreaker } from "../src/consolidation.js";
+import { _setApiKey, _consolidationConfig, resetConsolidationCircuitBreaker, getConsolidationHealth, _resetHealthState } from "../src/consolidation.js";
 import type { LibrarianRuntimeConfig } from "../src/librarian.js";
 
 const TEST_DB_PATH = "/tmp/munin-memory-tools-test.db";
@@ -2721,6 +2721,68 @@ describe("memory_orient", () => {
       const raw = await familyCall("memory_orient", {});
       const result = parseToolResponse(raw) as { maintenance_needed?: Array<{ issue: string }> };
       expect(result.maintenance_needed?.some((m) => m.issue === "consolidation_backlog") ?? false).toBe(false);
+    });
+
+    it("surfaces consolidation_circuit_breaker maintenance item when the breaker is tripped (regression guard for disappearing-warning bug)", async () => {
+      // This test is the regression guard: previously the orient code was gated on
+      // isConsolidationAvailable(), so a tripped breaker silently suppressed the warning.
+      _consolidationConfig.enabled = true;
+      _setApiKey("test-key");
+      // Manually trip the breaker (don't reset it)
+      // Simulate by setting the state via the module-level config
+      // Force the circuit breaker to tripped via repeated failures
+      // We use _consolidationConfig directly since we can't easily inject into processConsolidationBatch here
+      // Instead: set apiKey, mark breaker as tripped via _setApiKey + manual state change
+      // The test seam: we'll drive the state by calling _resetHealthState and then directly
+      // manipulating via _consolidationConfig. Since circuitBreakerTripped is not exported,
+      // we need processConsolidationBatch to trip it — use the stub fetch approach.
+
+      // Reset to clean state
+      resetConsolidationCircuitBreaker();
+      _resetHealthState();
+
+      const failCount = _consolidationConfig.maxFailures;
+      for (let ns = 0; ns < failCount; ns++) {
+        for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+          await callTool("memory_log", {
+            namespace: `projects/cbtest${ns}`,
+            content: `Log entry ${i}`,
+            tags: ["test"],
+          });
+        }
+      }
+
+      // Trip the breaker via processConsolidationBatch with stubbed failing fetch
+      const { processConsolidationBatch: runBatch } = await import("../src/consolidation.js");
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = async () => ({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized: bad key",
+      } as unknown as Response);
+
+      const { _setWorkerDb } = await import("../src/consolidation.js");
+      _setWorkerDb(db);
+      await runBatch();
+      globalThis.fetch = origFetch;
+      _setWorkerDb(null);
+
+      // Now call memory_orient — the circuit breaker is tripped, so isConsolidationAvailable()
+      // returns false, but we MUST still see a maintenance item.
+      const raw = await callTool("memory_orient", {});
+      const result = parseToolResponse(raw) as {
+        maintenance_needed?: Array<{ issue: string; suggestion: string }>;
+      };
+
+      const cbItem = result.maintenance_needed?.find((m) => m.issue === "consolidation_circuit_breaker");
+      expect(cbItem).toBeDefined();
+      expect(cbItem!.suggestion).toContain("failing");
+
+      // Clean up
+      resetConsolidationCircuitBreaker();
+      _resetHealthState();
+      _consolidationConfig.enabled = false;
+      _setApiKey(null);
     });
   });
 
@@ -6053,6 +6115,60 @@ describe("memory_status", () => {
     const writeRow = result.telemetry.find((r) => r.tool_name === "memory_write");
     expect(writeRow).toBeDefined();
     expect(writeRow!.error_count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("features.consolidation remains a boolean (backward compat)", async () => {
+    const raw = await callTool("memory_status", {});
+    const result = parseToolResponse(raw) as {
+      features: { consolidation: boolean };
+    };
+    expect(typeof result.features.consolidation).toBe("boolean");
+  });
+
+  it("includes consolidation_health for owner with all expected fields", async () => {
+    _setApiKey("test-key");
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+
+    const raw = await callTool("memory_status", {});
+    const result = parseToolResponse(raw) as {
+      consolidation_health: {
+        enabled: boolean;
+        api_key_present: boolean;
+        available: boolean;
+        circuit_breaker_tripped: boolean;
+        failures: number;
+        max_failures: number;
+        last_error: string | null;
+        last_error_at: string | null;
+      };
+    };
+
+    expect(result.consolidation_health).toBeDefined();
+    expect(typeof result.consolidation_health.enabled).toBe("boolean");
+    expect(result.consolidation_health.api_key_present).toBe(true);
+    expect(typeof result.consolidation_health.available).toBe("boolean");
+    expect(result.consolidation_health.circuit_breaker_tripped).toBe(false);
+    expect(typeof result.consolidation_health.failures).toBe("number");
+    expect(typeof result.consolidation_health.max_failures).toBe("number");
+    expect(result.consolidation_health.last_error).toBeNull();
+    expect(result.consolidation_health.last_error_at).toBeNull();
+
+    _setApiKey(null);
+    _resetHealthState();
+  });
+
+  it("does not expose consolidation_health to non-owner callers", async () => {
+    const agentCtx: AccessContext = {
+      principalId: "agent:test",
+      principalType: "agent",
+      namespaceRules: [],
+    };
+    const agentCall = makeContextCallTool(agentCtx);
+
+    const raw = await agentCall("memory_status", {});
+    const result = parseToolResponse(raw) as { consolidation_health?: unknown };
+    expect(result.consolidation_health).toBeUndefined();
   });
 });
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2784,6 +2784,56 @@ describe("memory_orient", () => {
       _consolidationConfig.enabled = false;
       _setApiKey(null);
     });
+
+    it("surfaces consolidation_circuit_breaker when failures > 0 but breaker not yet tripped (pre-trip warning)", async () => {
+      _consolidationConfig.enabled = true;
+      _setApiKey("test-key");
+      resetConsolidationCircuitBreaker();
+      _resetHealthState();
+
+      // Seed enough logs for ONE namespace only (causes 1 failure, breaker at 1/3)
+      const { _setWorkerDb } = await import("../src/consolidation.js");
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        await callTool("memory_log", {
+          namespace: "projects/pretrip0",
+          content: `Log entry ${i}`,
+          tags: ["test"],
+        });
+      }
+
+      const { processConsolidationBatch: runBatch } = await import("../src/consolidation.js");
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = async () => ({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized: bad key",
+      } as unknown as Response);
+
+      _setWorkerDb(db);
+      await runBatch(); // causes failures === 1, breaker NOT tripped (maxFailures is 3)
+      globalThis.fetch = origFetch;
+      _setWorkerDb(null);
+
+      // memory_orient must show BOTH consolidation_circuit_breaker AND consolidation_backlog
+      // (worker is still available since breaker not tripped)
+      const raw = await callTool("memory_orient", {});
+      const result = parseToolResponse(raw) as {
+        maintenance_needed?: Array<{ issue: string; suggestion: string }>;
+      };
+
+      const cbItem = result.maintenance_needed?.find((m) => m.issue === "consolidation_circuit_breaker");
+      expect(cbItem).toBeDefined();
+      expect(cbItem!.suggestion).toContain("failing");
+
+      const backlogItem = result.maintenance_needed?.find((m) => m.issue === "consolidation_backlog");
+      expect(backlogItem).toBeDefined();
+
+      // Clean up
+      resetConsolidationCircuitBreaker();
+      _resetHealthState();
+      _consolidationConfig.enabled = false;
+      _setApiKey(null);
+    });
   });
 
   it("excludes demo namespaces by default", async () => {
@@ -6155,6 +6205,51 @@ describe("memory_status", () => {
     expect(result.consolidation_health.last_error_at).toBeNull();
 
     _setApiKey(null);
+    _resetHealthState();
+  });
+
+  it("sanitizes last_error in consolidation_health exposed by memory_status", async () => {
+    const fakeKey = "sk-or-v1-supersecretkey12345678";
+    _setApiKey(fakeKey);
+    _consolidationConfig.enabled = true;
+    resetConsolidationCircuitBreaker();
+    _resetHealthState();
+
+    const { _setWorkerDb, processConsolidationBatch: runBatch } = await import("../src/consolidation.js");
+
+    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+      await callTool("memory_log", {
+        namespace: "projects/statusapikey",
+        content: `Log entry ${i}`,
+        tags: ["test"],
+      });
+    }
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 401,
+      text: async () => `Error: Bearer ${fakeKey} is invalid`,
+    } as unknown as Response);
+
+    _setWorkerDb(db);
+    await runBatch();
+    globalThis.fetch = origFetch;
+    _setWorkerDb(null);
+
+    const raw = await callTool("memory_status", {});
+    const result = parseToolResponse(raw) as {
+      consolidation_health: { last_error: string | null };
+    };
+
+    expect(result.consolidation_health.last_error).not.toBeNull();
+    expect(result.consolidation_health.last_error).toContain("[REDACTED]");
+    expect(result.consolidation_health.last_error).not.toContain(fakeKey);
+
+    // Clean up
+    _consolidationConfig.enabled = false;
+    _setApiKey(null);
+    resetConsolidationCircuitBreaker();
     _resetHealthState();
   });
 


### PR DESCRIPTION
## Why

The consolidation worker failed **silently**. On an OpenRouter error (e.g. an invalid API key → `401`), `processConsolidationBatch` caught the error, bumped a circuit-breaker counter, and logged to **stderr only**. Worse — the one in-band warning surface (`memory_orient`) was guarded by `isConsolidationAvailable()`, which returns `false` once the breaker trips. So the warning **disappeared exactly when the worker died**. This was discovered live: the Pi's OpenRouter key went invalid and consolidation was dead with no signal anywhere.

## What

Make the failure **loud** and **pollable**:

1. **`src/consolidation.ts`** — track `last_error` + timestamp; add `getConsolidationHealth()`; write a pollable **state entry** `meta/system-health:consolidation` **only on status transitions** (`healthy` → `failing` → `tripped` and back), via the existing `writeState()` helper, wrapped so a write failure never escapes the worker. Startup **reconciles** a stale persisted alert back to `healthy` after recovery.
2. **`src/tools.ts` `memory_status`** — keep the `features.consolidation` boolean (Heimdall depends on it) and add an owner-gated `consolidation_health` object.
3. **`src/tools.ts` `memory_orient`** — surface a `consolidation_circuit_breaker` maintenance item whenever the worker is failing **or** tripped (independent of `isConsolidationAvailable()`). **Fixes the disappearing-warning bug.**
4. **Secret-safety** — `last_error` is sanitized through `redactSecrets()` (new `security.ts` export reusing `SECRET_PATTERNS`) plus a literal global replace of the configured key, before it is ever stored or exposed. Added a specific `sk-or-v1-...` OpenRouter-key pattern (the generic `sk-...` pattern stopped at the hyphens).

### Alert entry contract (for the Ratatoskr Telegram poller)
`meta/system-health:consolidation`, tags `["system_alert","consolidation"]`:
```json
{ "status": "tripped", "failures": 3, "max_failures": 3,
  "last_error": "OpenRouter API error 401: ... [REDACTED] ...",
  "last_error_at": "2026-06-15T...Z", "updated_at": "2026-06-15T...Z" }
```
Written only on transitions, so a poller can alert once per incident and clear on `healthy`.

## Review
Cross-model **Codex review (gpt-5.5, xhigh)** over 2 rounds: round 1 found the pre-trip orient gap, a stale-alert-on-recovery bug, and an incomplete `last_error` sanitization; round 2 found the sanitizer missed a **bare/repeated** OpenRouter key. All fixed. The disappearing-warning fix has a dedicated regression test (fails against the old guarded code).

## Tests
TDD throughout. Full suite **1901 passing / 4 skipped**; lint, typecheck, typecheck:tools, build all clean; coverage above ratchet floors.

## Follow-up (separate)
The **Ratatoskr** poller that reads this entry and sends the Telegram alert (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)