### PR TITLE
feat(attention): temporal_stale signal for elapsed forward-looking dated statements (#114)

### DIFF
--- a/src/internal/reranker.ts
+++ b/src/internal/reranker.ts
@@ -20,6 +20,7 @@ import {
   getDaysUntil,
   isEntryExpiringSoon,
   findUpcomingEventDate,
+  findPassedForwardDate,
   isTrackedNamespace,
   RELAXED_QUERY_STOPWORDS,
 } from "./retrieval-shared.js";
@@ -254,6 +255,17 @@ function applyActiveLifecycleAttention(
     return "upcoming_event_stale";
   }
 
+  const passedDate = findPassedForwardDate(row.content);
+  if (passedDate) {
+    const daysSince = Math.floor((Date.now() - new Date(passedDate + "T23:59:59Z").getTime()) / 86400000);
+    maintenanceItems.push({
+      namespace: row.namespace,
+      issue: "temporal_stale",
+      suggestion: `Content references ${passedDate} (${daysSince} day${daysSince === 1 ? "" : "s"} ago) with forward-looking phrasing. Restate what actually happened or remove the forward-looking reference.`,
+    });
+    return "temporal_stale";
+  }
+
   return undefined;
 }
 
@@ -367,6 +379,7 @@ function scoreTriageTrackedStatus(trackedStatus: TrackedStatusAssessment): numbe
     let s = 28;
     if (trackedStatus.attentionReason === "upcoming_event_stale") s += 4;
     if (trackedStatus.attentionReason === "active_but_stale") s += 2;
+    if (trackedStatus.attentionReason === "temporal_stale") s += 3;
     return s;
   }
   if (trackedStatus.lifecycle === "active") return -8;

--- a/src/internal/retrieval-shared.ts
+++ b/src/internal/retrieval-shared.ts
@@ -18,6 +18,9 @@ export const EXPIRES_SOON_DAYS = 7;
 // Date pattern: YYYY-MM-DD (standalone or in ISO timestamp)
 export const DATE_PATTERN = /\b(20\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))\b/g;
 
+// Forward-looking phrasing that, when appearing near a past date, signals a stale statement.
+export const FORWARD_LOOKING_PATTERN = /\b(?:going\s+to|will(?:\s+be)?|plan(?:n?ing)?(?:\s+to)?|scheduled\s+(?:for|to)|upcoming|attend(?:ing)?|presenting\s+at|speaking\s+at|travel(?:l?ing)?(?:\s+to)?|join(?:ing)?)\b/i;
+
 // --- Lifecycle tag management ---
 
 export const LIFECYCLE_TAGS = new Set(["active", "blocked", "completed", "stopped", "maintenance", "archived"]);
@@ -80,6 +83,25 @@ export function findUpcomingEventDate(content: string, updatedAt: string): strin
     }
   }
   return soonest;
+}
+
+/**
+ * Detect a YYYY-MM-DD date that has already passed while forward-looking
+ * phrasing appears within 200 chars of it. Returns the first such past date
+ * string, or null. Advisory signal for stale forward-looking statements like
+ * "going to conference 2026-03-10" after that date elapsed.
+ */
+export function findPassedForwardDate(content: string): string | null {
+  const now = Date.now();
+  for (const match of content.matchAll(DATE_PATTERN)) {
+    const dateStr = match[1];
+    const dateMs = new Date(dateStr + "T23:59:59Z").getTime();
+    if (dateMs >= now) continue; // future/today — handled by findUpcomingEventDate
+    const start = Math.max(0, (match.index ?? 0) - 200);
+    const end = Math.min(content.length, (match.index ?? 0) + match[0].length + 200);
+    if (FORWARD_LOOKING_PATTERN.test(content.slice(start, end))) return dateStr;
+  }
+  return null;
 }
 
 export function isTrackedNamespace(namespace: string): boolean {

--- a/src/internal/retrieval-shared.ts
+++ b/src/internal/retrieval-shared.ts
@@ -18,8 +18,10 @@ export const EXPIRES_SOON_DAYS = 7;
 // Date pattern: YYYY-MM-DD (standalone or in ISO timestamp)
 export const DATE_PATTERN = /\b(20\d{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]))\b/g;
 
-// Forward-looking phrasing that, when appearing near a past date, signals a stale statement.
-export const FORWARD_LOOKING_PATTERN = /\b(?:going\s+to|will(?:\s+be)?|plan(?:n?ing)?(?:\s+to)?|scheduled\s+(?:for|to)|upcoming|attend(?:ing)?|presenting\s+at|speaking\s+at|travel(?:l?ing)?(?:\s+to)?|join(?:ing)?)\b/i;
+// Forward-looking phrasing that, when appearing in the same sentence as a past date, signals a
+// stale statement. "will" is intentionally excluded — it fires on retrospective uses like
+// "shipped 2026-03-10, will continue" and on proper names like "follow-up with Will".
+export const FORWARD_LOOKING_PATTERN = /\b(?:going\s+to|plan(?:n?ing)?(?:\s+to)?|scheduled\s+(?:for|to)|upcoming|attend(?:ing)?|presenting\s+at|speaking\s+at|travel(?:l?ing)?(?:\s+to)?|join(?:ing)?)\b/i;
 
 // --- Lifecycle tag management ---
 
@@ -87,19 +89,38 @@ export function findUpcomingEventDate(content: string, updatedAt: string): strin
 
 /**
  * Detect a YYYY-MM-DD date that has already passed while forward-looking
- * phrasing appears within 200 chars of it. Returns the first such past date
- * string, or null. Advisory signal for stale forward-looking statements like
- * "going to conference 2026-03-10" after that date elapsed.
+ * phrasing appears in the SAME sentence/line as the date. Returns the first
+ * such past date string, or null. Advisory signal for stale statements like
+ * "planning to attend conference 2026-03-10" after that date elapsed.
+ *
+ * Precision choices:
+ * - Sentence/line scoping (not a 200-char window) prevents adjacent clauses
+ *   from triggering (e.g. "Conference was 2026-03-10. Next we are planning…").
+ * - Round-trip date validation rejects calendar overflows like 2026-02-31.
  */
 export function findPassedForwardDate(content: string): string | null {
   const now = Date.now();
   for (const match of content.matchAll(DATE_PATTERN)) {
     const dateStr = match[1];
-    const dateMs = new Date(dateStr + "T23:59:59Z").getTime();
-    if (dateMs >= now) continue; // future/today — handled by findUpcomingEventDate
-    const start = Math.max(0, (match.index ?? 0) - 200);
-    const end = Math.min(content.length, (match.index ?? 0) + match[0].length + 200);
-    if (FORWARD_LOOKING_PATTERN.test(content.slice(start, end))) return dateStr;
+    const parsed = new Date(dateStr + "T23:59:59Z");
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== dateStr) continue;
+    if (parsed.getTime() >= now) continue; // future/today — handled by findUpcomingEventDate
+
+    // Scope to the sentence/line containing the date match.
+    const idx = match.index ?? 0;
+    const before = Math.max(
+      content.lastIndexOf(".", idx - 1),
+      content.lastIndexOf("!", idx - 1),
+      content.lastIndexOf("?", idx - 1),
+      content.lastIndexOf("\n", idx - 1),
+    );
+    let after = content.length;
+    for (const ch of [".", "!", "?", "\n"]) {
+      const p = content.indexOf(ch, idx + match[0].length);
+      if (p !== -1 && p < after) after = p;
+    }
+    const sentence = content.slice(before + 1, after);
+    if (FORWARD_LOOKING_PATTERN.test(sentence)) return dateStr;
   }
   return null;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1128,6 +1128,7 @@ function getAttentionSeverity(category: AttentionItem["category"]): AttentionIte
     case "conflicting_lifecycle":
       return "high";
     case "active_but_stale":
+    case "temporal_stale":
     case "expiring_soon":
     case "missing_status":
     case "missing_lifecycle":
@@ -1154,6 +1155,9 @@ function buildAttentionItem(
       break;
     case "upcoming_event_stale":
       reason = "Upcoming event is close and the status is stale.";
+      break;
+    case "temporal_stale":
+      reason = "Content references a past date with forward-looking phrasing.";
       break;
     case "missing_status":
       reason = "Tracked namespace has entries but no status key.";
@@ -3375,6 +3379,10 @@ const TOOL_DEFINITIONS = [
         include_upcoming_events: {
           type: "boolean",
           description: "Optional. Include stale statuses with near-term event dates. Default: true.",
+        },
+        include_temporal_stale: {
+          type: "boolean",
+          description: "Optional. Include statuses that reference a past date with forward-looking phrasing. Default: true.",
         },
         include_expiring: {
           type: "boolean",
@@ -5969,6 +5977,7 @@ export function registerTools(
               const includeBlocked = attentionArgs.include_blocked !== false;
               const includeStale = attentionArgs.include_stale !== false;
               const includeUpcomingEvents = attentionArgs.include_upcoming_events !== false;
+              const includeTemporalStale = attentionArgs.include_temporal_stale !== false;
               const includeExpiring = attentionArgs.include_expiring !== false;
               const includeMissingStatus = attentionArgs.include_missing_status !== false;
               const includeConflictingLifecycle = attentionArgs.include_conflicting_lifecycle !== false;
@@ -5996,6 +6005,7 @@ export function registerTools(
                 for (const item of assessment.maintenanceItems) {
                   if (item.issue === "active_but_stale" && !includeStale) continue;
                   if (item.issue === "upcoming_event_stale" && !includeUpcomingEvents) continue;
+                  if (item.issue === "temporal_stale" && !includeTemporalStale) continue;
                   if ((item.issue === "expiring_soon" || item.issue === "expired") && !includeExpiring) continue;
                   if (item.issue === "conflicting_lifecycle" && !includeConflictingLifecycle) continue;
                   if (item.issue === "missing_lifecycle" && !includeMissingLifecycle) continue;

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,7 @@ export interface AttentionParams {
   include_blocked?: boolean;
   include_stale?: boolean;
   include_upcoming_events?: boolean;
+  include_temporal_stale?: boolean;
   include_expiring?: boolean;
   include_missing_status?: boolean;
   include_conflicting_lifecycle?: boolean;
@@ -259,7 +260,7 @@ export interface DashboardEntry {
 
 export interface MaintenanceItem {
   namespace: string | null;
-  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "expiring_soon" | "expired" | "consolidation_backlog" | "consolidation_circuit_breaker";
+  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "temporal_stale" | "expiring_soon" | "expired" | "consolidation_backlog" | "consolidation_circuit_breaker";
   suggestion: string;
 }
 

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -387,6 +387,61 @@ describe("assessTrackedStatus", () => {
     expect(result.needsAttention).toBe(true);
     expect(result.attentionReason).toBe("active_but_stale");
   });
+
+  it("flags temporal_stale when a past date appears near forward-looking phrasing", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Planning to attend the conference on ${pastDate}. Very excited!`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.attentionReason).toBe("temporal_stale");
+    const item = result.maintenanceItems.find(m => m.issue === "temporal_stale");
+    expect(item).toBeDefined();
+    expect(item!.suggestion).toContain(pastDate);
+    expect(item!.suggestion).toMatch(/\d+ day/);
+  });
+
+  it("does NOT flag temporal_stale for retrospective phrasing near a past date", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Completed the conference on ${pastDate}. It went great.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.attentionReason).not.toBe("temporal_stale");
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
+
+  it("does NOT flag temporal_stale when entry is already caught by active_but_stale (>14d)", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const staleDate = new Date(Date.now() - 20 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Planning to attend the conference on ${pastDate}.`,
+      updated_at: staleDate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.attentionReason).toBe("active_but_stale");
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
+
+  it("does NOT flag temporal_stale for a future date with forward-looking phrasing (caught by upcoming_event_stale)", () => {
+    const futureDate = new Date(Date.now() + 3 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdateButStaleEnough = new Date(Date.now() - 5 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Planning to attend the workshop on ${futureDate}.`,
+      updated_at: recentUpdateButStaleEnough,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.attentionReason).toBe("upcoming_event_stale");
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
 });
 
 // --- getQueryHeuristicScore ---

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -442,6 +442,67 @@ describe("assessTrackedStatus", () => {
     expect(result.attentionReason).toBe("upcoming_event_stale");
     expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
   });
+
+  // --- Codex-review regression tests (#140 fixes) ---
+
+  it("does NOT flag temporal_stale for 'will continue' after a past date (bare 'will' removed from pattern)", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Shipped ${pastDate}; will continue with follow-up work.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
+
+  it("does NOT flag temporal_stale for a proper name 'Will' near a past date", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `${pastDate} follow-up with Will.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
+
+  it("still flags temporal_stale for strong forward-looking cue (positive control after fix)", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Planning to attend the conference on ${pastDate}.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.attentionReason).toBe("temporal_stale");
+  });
+
+  it("does NOT flag temporal_stale for an invalid date (2026-02-31 rolls over — rejected by round-trip check)", () => {
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Planning around 2026-02-31.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
+
+  it("does NOT flag temporal_stale when forward-looking cue is in a different sentence (cross-sentence)", () => {
+    const pastDate = new Date(Date.now() - 10 * 86400 * 1000).toISOString().slice(0, 10);
+    const recentUpdate = new Date(Date.now() - 2 * 86400 * 1000).toISOString();
+    const row = makeRow({
+      content: `Conference was ${pastDate}. Next quarter we are planning to expand.`,
+      updated_at: recentUpdate,
+      tags: JSON.stringify(["active"]),
+    });
+    const result = assessTrackedStatus(row);
+    expect(result.maintenanceItems.find(m => m.issue === "temporal_stale")).toBeUndefined();
+  });
 });
 
 // --- getQueryHeuristicScore ---

--- a/tests/tools-coverage.test.ts
+++ b/tests/tools-coverage.test.ts
@@ -1761,6 +1761,28 @@ describe("memory_attention categories", () => {
     expect(byCategory.get("active_but_stale")?.severity).toBe("medium");
     expect(byCategory.get("upcoming_event_stale")?.severity).toBe("high");
   });
+
+  it("builds reason and severity for temporal_stale category", async () => {
+    const pastDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const temporal = parseToolResponse(await callTool("memory_write", {
+      namespace: "projects/att-temporal",
+      key: "status",
+      content: `## Phase\nActive\n## Notes\nScheduled to attend the summit on ${pastDate}.`,
+      tags: ["active"],
+    }));
+    backdateEntry(temporal.id, 2);
+
+    const res = parseToolResponse(await callTool("memory_attention", {}));
+    expect(res.ok).toBe(true);
+    const byCategory = new Map<string, ToolResponse>(
+      res.items.map((item: ToolResponse) => [item.category as string, item]),
+    );
+
+    expect(byCategory.get("temporal_stale")?.reason).toBe(
+      "Content references a past date with forward-looking phrasing.",
+    );
+    expect(byCategory.get("temporal_stale")?.severity).toBe("medium");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -5824,6 +5824,37 @@ describe("maintenance suggestions (memory_orient)", () => {
     expect(eventStale).toBeUndefined();
   });
 
+  it("flags temporal_stale when a past date appears near forward-looking phrasing", async () => {
+    const pastDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const content = `**Phase:** Active\n**Current work:** Planning to present at the summit on ${pastDate}.`;
+    await callTool("memory_write", { namespace: "projects/temporal-test", key: "status", content, tags: ["active"] });
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("UPDATE entries SET updated_at = ? WHERE namespace = 'projects/temporal-test' AND key = 'status'").run(twoDaysAgo);
+
+    const raw = await callTool("memory_orient", {});
+    const result = parseToolResponse(raw) as {
+      maintenance_needed: Array<{ namespace: string; issue: string; suggestion: string }>;
+    };
+    const item = result.maintenance_needed?.find(m => m.issue === "temporal_stale" && m.namespace === "projects/temporal-test");
+    expect(item).toBeDefined();
+    expect(item!.suggestion).toContain(pastDate);
+  });
+
+  it("does NOT flag temporal_stale for retrospective phrasing near a past date", async () => {
+    const pastDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const content = `**Phase:** Completed\n**Notes:** Wrapped up the summit on ${pastDate}. It went well.`;
+    await callTool("memory_write", { namespace: "projects/temporal-retro", key: "status", content, tags: ["active"] });
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("UPDATE entries SET updated_at = ? WHERE namespace = 'projects/temporal-retro' AND key = 'status'").run(twoDaysAgo);
+
+    const raw = await callTool("memory_orient", {});
+    const result = parseToolResponse(raw) as {
+      maintenance_needed?: Array<{ namespace: string; issue: string }>;
+    };
+    const item = (result.maintenance_needed ?? []).find(m => m.issue === "temporal_stale" && m.namespace === "projects/temporal-retro");
+    expect(item).toBeUndefined();
+  });
+
   it("does not flag non-tracked namespaces", async () => {
     await callTool("memory_write", { namespace: "people/alice", key: "prefs", content: "vim" });
 


### PR DESCRIPTION
## What & why

Closes #114. State/status entries phrased in the future ("going to X on `2026-03-10`", "planning to ship by `<date>`") go **stale-but-silent** once the date passes — still written as upcoming, with no signal to restate. Munin had `valid_until`, expiring/expired, and `upcoming_event_stale` (date *approaching*), but nothing for "this dated statement has elapsed and is still written as future."

## Change
- Add a **`temporal_stale`** advisory maintenance item (surfaced by `memory_orient` + `memory_attention`) when a tracked `projects/*`|`clients/*` **active** status references a `YYYY-MM-DD` date that has now passed while forward-looking phrasing appears within 200 chars of it.
- **Advisory only** — it flags for the owner to restate; it never auto-rewrites content. (Silent restatement is explicitly rejected — auditable owner-authored truth is the point; this is the deliberate counter-design to "Dreaming"-style hidden self-rewriting.)
- New `findPassedForwardDate` + `FORWARD_LOOKING_PATTERN` in `retrieval-shared.ts`, reusing the existing `DATE_PATTERN`.
- Wired into `applyActiveLifecycleAttention` **after** the `active_but_stale` and `upcoming_event_stale` checks, so it only fires when neither does (no double-flagging). Triage score slots between them (+3).
- `memory_attention`: "medium" severity, reason string, and an `include_temporal_stale` filter (default true).

## Tests (TDD)
- 4 reranker unit tests: past+forward → fires; retrospective phrasing → no; >14d-stale entry → `active_but_stale` wins; future date → `upcoming_event_stale` wins.
- 2 `memory_orient` integration tests + 1 `memory_attention` category test.
- typecheck / typecheck:tools / lint clean.

Harvested from the "Dreaming V3" temporal-self-rewriting idea, but deliberately propose-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)