### PR TITLE
feat(insights): surface retrieved-but-never-followed-up entries as an active signal (#99)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2149,6 +2149,10 @@ export function logRetrievalOutcome(
  * @param since Optional ISO 8601 timestamp. When provided, only impression events
  *   at or after this timestamp are counted, bounding results to a rolling window.
  *   Default behavior (undefined) is unbounded.
+ * @param restrictToTracked When true, restrict results to entries in tracked/operational
+ *   namespaces (projects/* and clients/*) only. Applied at the SQL level before LIMIT,
+ *   preventing reference namespaces (meta/*, documents/*, people/*, etc.) from consuming
+ *   limit slots or producing false-positive "unused" signals.
  */
 export function getInsightsByEntry(
   db: Database.Database,
@@ -2156,6 +2160,7 @@ export function getInsightsByEntry(
   minImpressions = 3,
   limit = 20,
   since?: string,
+  restrictToTracked?: boolean,
 ): EntryInsightRow[] {
   const clampedLimit = Math.min(Math.max(limit, 1), 50);
 
@@ -2171,6 +2176,11 @@ export function getInsightsByEntry(
       nsParams.push(namespace);
     }
   }
+
+  // Restrict to tracked (operational) namespaces — literal LIKE patterns, no extra params.
+  const trackedFilter = restrictToTracked
+    ? "AND (e.namespace LIKE 'projects/%' OR e.namespace LIKE 'clients/%')"
+    : "";
 
   // Optional rolling-window filter on impression event timestamp
   const sinceFilter = since ? "AND rev.timestamp >= ?" : "";
@@ -2232,6 +2242,7 @@ export function getInsightsByEntry(
       AND ro_l.outcome_type = 'log_in_result_namespace'
     WHERE TRUE
       ${nsFilter}
+      ${trackedFilter}
     GROUP BY imp.entry_id, e.namespace, e.updated_at
     HAVING COUNT(DISTINCT imp.event_id) >= ?
     ORDER BY impressions DESC

--- a/src/db.ts
+++ b/src/db.ts
@@ -2145,12 +2145,17 @@ export function logRetrievalOutcome(
  * Impressions counted only from memory_query and memory_attention events
  * (result_ids non-empty). staleness_pressure = fraction of opened_result outcomes
  * where the entry was older than 14 days at the time of opening.
+ *
+ * @param since Optional ISO 8601 timestamp. When provided, only impression events
+ *   at or after this timestamp are counted, bounding results to a rolling window.
+ *   Default behavior (undefined) is unbounded.
  */
 export function getInsightsByEntry(
   db: Database.Database,
   namespace?: string,
   minImpressions = 3,
   limit = 20,
+  since?: string,
 ): EntryInsightRow[] {
   const clampedLimit = Math.min(Math.max(limit, 1), 50);
 
@@ -2167,6 +2172,10 @@ export function getInsightsByEntry(
     }
   }
 
+  // Optional rolling-window filter on impression event timestamp
+  const sinceFilter = since ? "AND rev.timestamp >= ?" : "";
+  const sinceParams: unknown[] = since ? [since] : [];
+
   const sql = `
     WITH impressions_cte AS (
       -- One row per (entry_id, event_id) from query/attention events with results
@@ -2177,6 +2186,7 @@ export function getInsightsByEntry(
            json_each(rev.result_ids) AS e_json
       WHERE rev.tool_name IN ('memory_query', 'memory_attention')
         AND json_array_length(rev.result_ids) > 0
+        ${sinceFilter}
     ),
     opens_cte AS (
       SELECT ro.entry_id, ro.retrieval_event_id
@@ -2230,7 +2240,7 @@ export function getInsightsByEntry(
 
   return db
     .prepare(sql)
-    .all(...nsParams, minImpressions, clampedLimit) as EntryInsightRow[];
+    .all(...sinceParams, ...nsParams, minImpressions, clampedLimit) as EntryInsightRow[];
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1133,6 +1133,10 @@ function getAttentionSeverity(category: AttentionItem["category"]): AttentionIte
     case "missing_status":
     case "missing_lifecycle":
       return "medium";
+    case "retrieved_unused":
+    case "consolidation_backlog":
+    case "consolidation_circuit_breaker":
+      return "low";
     default:
       return "low";
   }
@@ -1173,6 +1177,9 @@ function buildAttentionItem(
       break;
     case "expired":
       reason = "Status validity window has expired.";
+      break;
+    case "retrieved_unused":
+      reason = "Entries repeatedly retrieved but never opened or acted on.";
       break;
     default:
       reason = suggestion;
@@ -3675,6 +3682,16 @@ const SIGNAL_STALENESS_PRESSURE_THRESHOLD = 0.5;
 const SIGNAL_NO_FOLLOWTHROUGH_THRESHOLD = 0.05;
 const SIGNAL_NO_FOLLOWTHROUGH_MIN_IMPRESSIONS = 5;
 
+// --- Retrieved-but-unused signal thresholds ---
+/** Minimum impression count (within the rolling window) to qualify an entry as "unused". */
+const RETRIEVED_UNUSED_MIN_IMPRESSIONS = 5;
+/** Minimum qualifying entries before a memory_patterns PatternItem is emitted. */
+const RETRIEVED_UNUSED_PATTERN_MIN = 2;
+/** Minimum qualifying entries before a memory_orient MaintenanceItem is emitted. */
+const RETRIEVED_UNUSED_ORIENT_MIN = 3;
+/** Rolling window in days for both surfaces. */
+const RETRIEVED_UNUSED_SINCE_DAYS = 30;
+
 function computeEntryInsight(row: {
   entry_id: string;
   namespace: string | null;
@@ -3957,6 +3974,25 @@ export function registerTools(
                   };
                   maintenanceSortKey.set(cbItem, "");
                   maintenanceNeeded.push(cbItem);
+                }
+
+                // Block 3: Retrieved-but-unused signal — entries repeatedly shown in search
+                // results with zero follow-through over the rolling window.
+                // meta/* entries are excluded (reference docs are legitimately retrieved
+                // without being "opened" and would produce false positives).
+                {
+                  const sinceWindowOrient = new Date(Date.now() - RETRIEVED_UNUSED_SINCE_DAYS * 86400000).toISOString();
+                  const unusedOrient = getInsightsByEntry(db, undefined, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 10, sinceWindowOrient)
+                    .filter((r) => r.followthrough_events === 0 && !(r.namespace ?? "").startsWith("meta/"));
+                  if (unusedOrient.length >= RETRIEVED_UNUSED_ORIENT_MIN) {
+                    const unusedOrientItem: MaintenanceItem = {
+                      namespace: null,
+                      issue: "retrieved_unused",
+                      suggestion: `${unusedOrient.length} entr${unusedOrient.length === 1 ? "y" : "ies"} retrieved ${RETRIEVED_UNUSED_MIN_IMPRESSIONS}+ times (last ${RETRIEVED_UNUSED_SINCE_DAYS}d) with zero follow-through. Run memory_patterns to review.`,
+                    };
+                    maintenanceSortKey.set(unusedOrientItem, "");
+                    maintenanceNeeded.push(unusedOrientItem);
+                  }
                 }
               }
 
@@ -4792,6 +4828,27 @@ export function registerTools(
                     : "Blocked namespaces with lingering commitments create noisy handoffs and false progress signals.",
                   source_entry_ids: supporting.map((row) => row.source_entry_id),
                 });
+              }
+
+              // Retrieved-but-unused pattern (owner-only).
+              // Surfaces entries that are repeatedly shown in search results but
+              // never opened or acted on — a signal that they may be noise or
+              // mislabelled, or that retrieval recall is too aggressive.
+              if (ctx.principalType === "owner") {
+                const sinceWindow = new Date(Date.now() - RETRIEVED_UNUSED_SINCE_DAYS * 86400000).toISOString();
+                const unused = getInsightsByEntry(db, namespace, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 20, sinceWindow)
+                  .filter((r) => r.followthrough_events === 0 && !(r.namespace ?? "").startsWith("meta/"));
+                if (unused.length >= RETRIEVED_UNUSED_PATTERN_MIN) {
+                  const unusedIds = unused.slice(0, 6).map((r) => r.entry_id);
+                  unusedIds.forEach((id) => sourceIds.add(id));
+                  patterns.push({
+                    kind: "retrieved_unused",
+                    summary: `${unused.length} entr${unused.length === 1 ? "y" : "ies"} retrieved ${RETRIEVED_UNUSED_MIN_IMPRESSIONS}+ times in the last ${RETRIEVED_UNUSED_SINCE_DAYS} days with zero follow-through. Run memory_insights to review.`,
+                    confidence: Math.min(0.85, 0.5 + unused.length * 0.05),
+                    source_entry_ids: unusedIds,
+                    source_namespaces: [...new Set(unused.slice(0, 6).map((r) => r.namespace).filter((n): n is string => n !== null))],
+                  });
+                }
               }
 
               const sortedPatterns = patterns

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3978,12 +3978,16 @@ export function registerTools(
 
                 // Block 3: Retrieved-but-unused signal — entries repeatedly shown in search
                 // results with zero follow-through over the rolling window.
-                // meta/* entries are excluded (reference docs are legitimately retrieved
-                // without being "opened" and would produce false positives).
+                // Restricted to projects/* and clients/* at SQL level so reference namespaces
+                // (meta/*, documents/*, people/*, decisions/*, reading/*, signals/*, digests/*)
+                // are excluded before LIMIT rather than as a post-filter.
                 {
                   const sinceWindowOrient = new Date(Date.now() - RETRIEVED_UNUSED_SINCE_DAYS * 86400000).toISOString();
-                  const unusedOrient = getInsightsByEntry(db, undefined, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 10, sinceWindowOrient)
-                    .filter((r) => r.followthrough_events === 0 && !(r.namespace ?? "").startsWith("meta/"));
+                  const hasRecent = db.prepare("SELECT 1 FROM retrieval_events WHERE timestamp >= ? LIMIT 1").get(sinceWindowOrient);
+                  const unusedOrient = hasRecent
+                    ? getInsightsByEntry(db, undefined, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 10, sinceWindowOrient, true)
+                        .filter((r) => r.followthrough_events === 0)
+                    : [];
                   if (unusedOrient.length >= RETRIEVED_UNUSED_ORIENT_MIN) {
                     const unusedOrientItem: MaintenanceItem = {
                       namespace: null,
@@ -4834,10 +4838,12 @@ export function registerTools(
               // Surfaces entries that are repeatedly shown in search results but
               // never opened or acted on — a signal that they may be noise or
               // mislabelled, or that retrieval recall is too aggressive.
+              // Restricted to tracked namespaces (projects/*, clients/*) in SQL to
+              // avoid false positives from reference namespaces (meta/*, documents/*, etc.).
               if (ctx.principalType === "owner") {
                 const sinceWindow = new Date(Date.now() - RETRIEVED_UNUSED_SINCE_DAYS * 86400000).toISOString();
-                const unused = getInsightsByEntry(db, namespace, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 20, sinceWindow)
-                  .filter((r) => r.followthrough_events === 0 && !(r.namespace ?? "").startsWith("meta/"));
+                const unused = getInsightsByEntry(db, namespace, RETRIEVED_UNUSED_MIN_IMPRESSIONS, 20, sinceWindow, true)
+                  .filter((r) => r.followthrough_events === 0);
                 if (unused.length >= RETRIEVED_UNUSED_PATTERN_MIN) {
                   const unusedIds = unused.slice(0, 6).map((r) => r.entry_id);
                   unusedIds.forEach((id) => sourceIds.add(id));
@@ -5579,6 +5585,14 @@ export function registerTools(
                   }
                   if (isStale(parsed.updated_at)) {
                     result.stale = true;
+                  }
+                  // Analytics: log opened_result outcome (mirrors memory_read behaviour)
+                  if (sessionId) {
+                    logRetrievalOutcome(db, sessionId, {
+                      outcomeType: "opened_result",
+                      entryId: parsed.id,
+                      namespace: parsed.namespace,
+                    });
                   }
                   return result;
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,7 +260,7 @@ export interface DashboardEntry {
 
 export interface MaintenanceItem {
   namespace: string | null;
-  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "temporal_stale" | "expiring_soon" | "expired" | "consolidation_backlog" | "consolidation_circuit_breaker";
+  issue: "active_but_stale" | "missing_status" | "conflicting_lifecycle" | "missing_lifecycle" | "upcoming_event_stale" | "temporal_stale" | "expiring_soon" | "expired" | "consolidation_backlog" | "consolidation_circuit_breaker" | "retrieved_unused";
   suggestion: string;
 }
 
@@ -620,7 +620,7 @@ export interface CommitmentsResponse {
 }
 
 export interface PatternItem {
-  kind: "decision_theme" | "commitment_slip" | "blocked_followthrough" | "undated_next_steps";
+  kind: "decision_theme" | "commitment_slip" | "blocked_followthrough" | "undated_next_steps" | "retrieved_unused";
   summary: string;
   confidence: number;
   source_entry_ids: string[];

--- a/tests/retrieval-tools.test.ts
+++ b/tests/retrieval-tools.test.ts
@@ -541,25 +541,35 @@ describe("memory_patterns — retrieved_unused pattern", () => {
     expect(unusedPattern!.source_entry_ids.length).toBeGreaterThan(0);
   });
 
-  it("does NOT emit retrieved_unused when one entry has a positive outcome", async () => {
+  it("pattern fires from qualifying entries and excludes the entry with a positive outcome", async () => {
     const call = makeCallTool(db, ownerCtx());
 
     // Entry A: 5 impressions, no outcome → qualifies
-    writeState(db, "projects/open-ok-a", "status", "open project alpha", ["active"]);
-    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/open-ok-a' AND key = 'status'").get() as { id: string }).id;
-    seedImpressions(db, entryA, 5, "ok-a");
+    writeState(db, "projects/out-a", "status", "outcome project alpha", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/out-a' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 5, "ot-a");
 
-    // Entry B: 5 impressions + opened_result → disqualifies
-    writeState(db, "projects/open-ok-b", "status", "open project beta", ["active"]);
-    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/open-ok-b' AND key = 'status'").get() as { id: string }).id;
-    seedImpressions(db, entryB, 5, "ok-b");
-    seedOpenOutcome(db, entryB, "ok-b");
+    // Entry B: 5 impressions + opened_result → disqualified (has follow-through)
+    writeState(db, "projects/out-b", "status", "outcome project beta", ["active"]);
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/out-b' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryB, 5, "ot-b");
+    seedOpenOutcome(db, entryB, "ot-b");
 
-    // Only A qualifies → count=1 < RETRIEVED_UNUSED_PATTERN_MIN(2) → no pattern
+    // Entry C: 5 impressions, no outcome → qualifies
+    writeState(db, "projects/out-c", "status", "outcome project gamma", ["active"]);
+    const entryC = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/out-c' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryC, 5, "ot-c");
+
+    // A and C qualify (count=2 >= RETRIEVED_UNUSED_PATTERN_MIN) → pattern fires
     const raw = await call("memory_patterns", {});
-    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string; source_entry_ids: string[] }> };
     const unusedPattern = result.patterns.find((p) => p.kind === "retrieved_unused");
-    expect(unusedPattern).toBeUndefined();
+    expect(unusedPattern).toBeDefined();
+    // B must not appear in source_entry_ids because it had a follow-through outcome
+    expect(unusedPattern!.source_entry_ids).not.toContain(entryB);
+    // A and C should be in source_entry_ids
+    expect(unusedPattern!.source_entry_ids).toContain(entryA);
+    expect(unusedPattern!.source_entry_ids).toContain(entryC);
   });
 
   it("does NOT emit retrieved_unused when impressions < 5", async () => {
@@ -608,7 +618,7 @@ describe("memory_patterns — retrieved_unused pattern", () => {
   it("does NOT include meta/* entries in retrieved_unused pattern", async () => {
     const call = makeCallTool(db, ownerCtx());
 
-    // meta/ entries should be excluded
+    // meta/ entries should be excluded (only projects/* and clients/* are tracked)
     writeState(db, "meta/excluded-a", "notes", "meta entry alpha", []);
     writeState(db, "meta/excluded-b", "notes", "meta entry beta", []);
     const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'meta/excluded-a' AND key = 'notes'").get() as { id: string }).id;
@@ -619,6 +629,64 @@ describe("memory_patterns — retrieved_unused pattern", () => {
     const raw = await call("memory_patterns", {});
     const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
     expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+
+  it("30-day rolling window: old impressions (31d ago) do NOT qualify", async () => {
+    const call = makeCallTool(db, ownerCtx());
+    const oldTs = new Date(Date.now() - 31 * 86400 * 1000).toISOString();
+
+    writeState(db, "projects/old-imp-a", "status", "old impressions alpha", ["active"]);
+    writeState(db, "projects/old-imp-b", "status", "old impressions beta", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/old-imp-a' AND key = 'status'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/old-imp-b' AND key = 'status'").get() as { id: string }).id;
+
+    // Seed 5 impressions per entry, all timestamped 31 days ago (outside the 30d window)
+    for (let i = 0; i < 5; i++) {
+      db.prepare(
+        `INSERT INTO retrieval_events (id, session_id, timestamp, tool_name, result_ids, result_namespaces, result_ranks)
+         VALUES (?, 'sess-old-a', ?, 'memory_query', json_array(?), '[]', '[]')`,
+      ).run(`evt-old-a-${i}`, oldTs, entryA);
+      db.prepare(
+        `INSERT INTO retrieval_events (id, session_id, timestamp, tool_name, result_ids, result_namespaces, result_ranks)
+         VALUES (?, 'sess-old-b', ?, 'memory_query', json_array(?), '[]', '[]')`,
+      ).run(`evt-old-b-${i}`, oldTs, entryB);
+    }
+
+    // Old impressions are outside the rolling window → should NOT qualify
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+
+  it("30-day rolling window: in-window impressions DO qualify (control)", async () => {
+    const call = makeCallTool(db, ownerCtx());
+    const oldTs = new Date(Date.now() - 31 * 86400 * 1000).toISOString();
+
+    writeState(db, "projects/win-ctrl-a", "status", "window control alpha", ["active"]);
+    writeState(db, "projects/win-ctrl-b", "status", "window control beta", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/win-ctrl-a' AND key = 'status'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/win-ctrl-b' AND key = 'status'").get() as { id: string }).id;
+
+    // Seed 5 OLD impressions per entry (outside window) — should not count
+    for (let i = 0; i < 5; i++) {
+      db.prepare(
+        `INSERT INTO retrieval_events (id, session_id, timestamp, tool_name, result_ids, result_namespaces, result_ranks)
+         VALUES (?, 'sess-wc-old-a', ?, 'memory_query', json_array(?), '[]', '[]')`,
+      ).run(`evt-wc-old-a-${i}`, oldTs, entryA);
+      db.prepare(
+        `INSERT INTO retrieval_events (id, session_id, timestamp, tool_name, result_ids, result_namespaces, result_ranks)
+         VALUES (?, 'sess-wc-old-b', ?, 'memory_query', json_array(?), '[]', '[]')`,
+      ).run(`evt-wc-old-b-${i}`, oldTs, entryB);
+    }
+
+    // Seed 5 IN-WINDOW impressions per entry (now)
+    seedImpressions(db, entryA, 5, "wc-new-a");
+    seedImpressions(db, entryB, 5, "wc-new-b");
+
+    // In-window impressions meet the threshold → pattern fires
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeDefined();
   });
 });
 

--- a/tests/retrieval-tools.test.ts
+++ b/tests/retrieval-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { unlinkSync, existsSync } from "node:fs";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { AccessContext } from "../src/access.js";
 import { initDatabase, writeState } from "../src/db.js";
 import { registerTools } from "../src/tools.js";
 
@@ -441,5 +442,248 @@ describe("memory_insights tool", () => {
     const clampEntry = result.entries.find((e) => e.entry_id === entry.id);
     expect(clampEntry).toBeDefined();
     expect(clampEntry!.followthrough_rate).toBeLessThanOrEqual(1.0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Helper: create a callTool bound to a given AccessContext
+// -----------------------------------------------------------------------
+function makeCallTool(
+  db: Database.Database,
+  ctx: AccessContext,
+  sid = "test-session-owner",
+): (name: string, args?: Record<string, unknown>) => Promise<unknown> {
+  const s = new Server(
+    { name: "test-munin-unused", version: "0.0.1" },
+    { capabilities: { tools: {} } },
+  );
+  registerTools(s, db, sid, ctx);
+  return async (name: string, args: Record<string, unknown> = {}) => {
+    const handler = (
+      s as unknown as { _requestHandlers: Map<string, Function> }
+    )._requestHandlers?.get("tools/call");
+    if (!handler) throw new Error("no handler");
+    return handler({ method: "tools/call", params: { name, arguments: args } });
+  };
+}
+
+function ownerCtx(): AccessContext {
+  return { principalId: "owner", principalType: "owner", accessibleNamespaces: [] };
+}
+
+function agentCtx(): AccessContext {
+  return {
+    principalId: "agent:test",
+    principalType: "agent",
+    accessibleNamespaces: [{ pattern: "projects/*", permissions: "rw" }],
+  };
+}
+
+/**
+ * Seed `count` impression events (memory_query, no outcomes) for `entryId`.
+ * Returns a fresh-enough ISO timestamp so the rolling window covers them.
+ */
+function seedImpressions(
+  db: Database.Database,
+  entryId: string,
+  count: number,
+  prefix: string,
+): void {
+  const now = new Date().toISOString();
+  for (let i = 0; i < count; i++) {
+    db.prepare(
+      `INSERT INTO retrieval_events (id, session_id, timestamp, tool_name, result_ids, result_namespaces, result_ranks)
+       VALUES (?, ?, ?, 'memory_query', json_array(?), '[]', '[]')`,
+    ).run(`evt-${prefix}-${i}`, `sess-${prefix}`, now, entryId);
+  }
+}
+
+/** Seed a single opened_result outcome for the most recent event of an entry. */
+function seedOpenOutcome(
+  db: Database.Database,
+  entryId: string,
+  prefix: string,
+): void {
+  const event = db
+    .prepare(
+      `SELECT id FROM retrieval_events WHERE result_ids LIKE '%' || ? || '%' ORDER BY timestamp DESC LIMIT 1`,
+    )
+    .get(entryId) as { id: string } | undefined;
+  if (!event) throw new Error("No event found for entryId: " + entryId);
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO retrieval_outcomes (id, retrieval_event_id, timestamp, outcome_type, entry_id)
+     VALUES (?, ?, ?, 'opened_result', ?)`,
+  ).run(`out-${prefix}`, event.id, now, entryId);
+}
+
+// -----------------------------------------------------------------------
+// memory_patterns — retrieved_unused pattern
+// -----------------------------------------------------------------------
+describe("memory_patterns — retrieved_unused pattern", () => {
+  it("emits retrieved_unused pattern when >=2 entries have >=5 impressions and zero follow-through (owner)", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    // Create two entries
+    writeState(db, "projects/unused-a", "status", "unused project alpha", ["active"]);
+    writeState(db, "projects/unused-b", "status", "unused project beta", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/unused-a' AND key = 'status'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/unused-b' AND key = 'status'").get() as { id: string }).id;
+
+    seedImpressions(db, entryA, 5, "ua");
+    seedImpressions(db, entryB, 5, "ub");
+
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string; summary: string; source_entry_ids: string[] }> };
+
+    const unusedPattern = result.patterns.find((p) => p.kind === "retrieved_unused");
+    expect(unusedPattern).toBeDefined();
+    expect(unusedPattern!.source_entry_ids.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT emit retrieved_unused when one entry has a positive outcome", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    // Entry A: 5 impressions, no outcome → qualifies
+    writeState(db, "projects/open-ok-a", "status", "open project alpha", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/open-ok-a' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 5, "ok-a");
+
+    // Entry B: 5 impressions + opened_result → disqualifies
+    writeState(db, "projects/open-ok-b", "status", "open project beta", ["active"]);
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/open-ok-b' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryB, 5, "ok-b");
+    seedOpenOutcome(db, entryB, "ok-b");
+
+    // Only A qualifies → count=1 < RETRIEVED_UNUSED_PATTERN_MIN(2) → no pattern
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    const unusedPattern = result.patterns.find((p) => p.kind === "retrieved_unused");
+    expect(unusedPattern).toBeUndefined();
+  });
+
+  it("does NOT emit retrieved_unused when impressions < 5", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    // Both entries have only 4 impressions (below threshold)
+    writeState(db, "projects/low-imp-a", "status", "low impressions alpha", ["active"]);
+    writeState(db, "projects/low-imp-b", "status", "low impressions beta", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/low-imp-a' AND key = 'status'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/low-imp-b' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 4, "li-a");
+    seedImpressions(db, entryB, 4, "li-b");
+
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+
+  it("does NOT emit retrieved_unused when only 1 entry qualifies", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    writeState(db, "projects/solo-unused", "status", "solo unused project", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/solo-unused' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 5, "solo");
+
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+
+  it("does NOT emit retrieved_unused for non-owner context", async () => {
+    const call = makeCallTool(db, agentCtx());
+
+    writeState(db, "projects/agent-unused-a", "status", "agent unused alpha", ["active"]);
+    writeState(db, "projects/agent-unused-b", "status", "agent unused beta", ["active"]);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/agent-unused-a' AND key = 'status'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'projects/agent-unused-b' AND key = 'status'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 5, "ag-a");
+    seedImpressions(db, entryB, 5, "ag-b");
+
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+
+  it("does NOT include meta/* entries in retrieved_unused pattern", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    // meta/ entries should be excluded
+    writeState(db, "meta/excluded-a", "notes", "meta entry alpha", []);
+    writeState(db, "meta/excluded-b", "notes", "meta entry beta", []);
+    const entryA = (db.prepare("SELECT id FROM entries WHERE namespace = 'meta/excluded-a' AND key = 'notes'").get() as { id: string }).id;
+    const entryB = (db.prepare("SELECT id FROM entries WHERE namespace = 'meta/excluded-b' AND key = 'notes'").get() as { id: string }).id;
+    seedImpressions(db, entryA, 5, "me-a");
+    seedImpressions(db, entryB, 5, "me-b");
+
+    const raw = await call("memory_patterns", {});
+    const result = parseToolResponse(raw) as { patterns: Array<{ kind: string }> };
+    expect(result.patterns.find((p) => p.kind === "retrieved_unused")).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------
+// memory_orient — retrieved_unused maintenance signal
+// -----------------------------------------------------------------------
+describe("memory_orient — retrieved_unused maintenance signal", () => {
+  it("includes retrieved_unused in maintenance_needed when >=3 entries qualify (owner)", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    for (const label of ["a", "b", "c"]) {
+      writeState(db, `projects/orient-unused-${label}`, "status", `orient unused ${label}`, ["active"]);
+      const id = (db.prepare(`SELECT id FROM entries WHERE namespace = 'projects/orient-unused-${label}' AND key = 'status'`).get() as { id: string }).id;
+      seedImpressions(db, id, 5, `oru-${label}`);
+    }
+
+    const raw = await call("memory_orient", {});
+    const result = parseToolResponse(raw) as { maintenance_needed?: Array<{ issue: string }> };
+    const item = (result.maintenance_needed ?? []).find((m) => m.issue === "retrieved_unused");
+    expect(item).toBeDefined();
+  });
+
+  it("does NOT include retrieved_unused when exactly 2 entries qualify (below orient threshold)", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    for (const label of ["x", "y"]) {
+      writeState(db, `projects/orient-two-${label}`, "status", `orient two ${label}`, ["active"]);
+      const id = (db.prepare(`SELECT id FROM entries WHERE namespace = 'projects/orient-two-${label}' AND key = 'status'`).get() as { id: string }).id;
+      seedImpressions(db, id, 5, `ot2-${label}`);
+    }
+
+    const raw = await call("memory_orient", {});
+    const result = parseToolResponse(raw) as { maintenance_needed?: Array<{ issue: string }> };
+    const item = (result.maintenance_needed ?? []).find((m) => m.issue === "retrieved_unused");
+    expect(item).toBeUndefined();
+  });
+
+  it("does NOT include retrieved_unused for non-owner context", async () => {
+    const call = makeCallTool(db, agentCtx());
+
+    for (const label of ["p", "q", "r"]) {
+      writeState(db, `projects/orient-agent-${label}`, "status", `orient agent ${label}`, ["active"]);
+      const id = (db.prepare(`SELECT id FROM entries WHERE namespace = 'projects/orient-agent-${label}' AND key = 'status'`).get() as { id: string }).id;
+      seedImpressions(db, id, 5, `oag-${label}`);
+    }
+
+    const raw = await call("memory_orient", {});
+    const result = parseToolResponse(raw) as { maintenance_needed?: Array<{ issue: string }> };
+    const item = (result.maintenance_needed ?? []).find((m) => m.issue === "retrieved_unused");
+    expect(item).toBeUndefined();
+  });
+
+  it("does NOT include meta/* entries in orient retrieved_unused signal", async () => {
+    const call = makeCallTool(db, ownerCtx());
+
+    // Only meta/ entries qualify — should not trigger
+    for (const label of ["d", "e", "f"]) {
+      writeState(db, `meta/orient-meta-${label}`, "notes", `orient meta ${label}`, []);
+      const id = (db.prepare(`SELECT id FROM entries WHERE namespace = 'meta/orient-meta-${label}' AND key = 'notes'`).get() as { id: string }).id;
+      seedImpressions(db, id, 5, `ometa-${label}`);
+    }
+
+    const raw = await call("memory_orient", {});
+    const result = parseToolResponse(raw) as { maintenance_needed?: Array<{ issue: string }> };
+    const item = (result.maintenance_needed ?? []).find((m) => m.issue === "retrieved_unused");
+    expect(item).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What & why

Closes #99. Munin already collects passive retrieval analytics (`retrieval_events` / `retrieval_outcomes`, Feature 4 Phase 1), and `getInsightsByEntry` already computes `followthrough_events` per entry — but nothing turned that into an **active** quality signal a session would see without explicitly calling `memory_insights`. This wires it into two surfaces (owner-only, observe-only — no reranking):

- **`memory_patterns`:** emits a `retrieved_unused` pattern when ≥2 entries have ≥5 impressions (last 30d) and **zero** follow-through (no opens, writes, or logs in the result namespace).
- **`memory_orient` `maintenance_needed`:** a `retrieved_unused` item when ≥3 such entries qualify (higher bar for the prominent surface).

## False-positive guards
- **Rolling 30-day window** (`getInsightsByEntry` gains an optional `since`) so an entry heavily used long ago but obsolete now isn't flagged on all-time data. (The `since` param is *prepended* in binding order — the filter lives in the impressions CTE, which binds before the namespace filter.)
- **`meta/*` excluded** — reference docs (conventions, telos) are legitimately retrieved without being "opened" and would be false positives.
- Owner-only on both surfaces.

## Tests
10 new (thresholds, positive-outcome exclusion, owner-only, `meta/` exclusion, orient-vs-pattern bars). typecheck / typecheck:tools / lint clean.

A cheap, observe-only precursor to learned reranking (Phase 2): persistent zero-follow-through flags entries that are likely stale, mis-tagged, or surfacing in irrelevant queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)