### PR TITLE
docs(archive): move pre-pivot planning docs to docs/archive/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ docs/*
 !docs/adr/
 !docs/examples/
 !docs/examples/memory-health.json
+!docs/archive/
+!docs/archive/prd.md
+!docs/archive/technical-spec.md
 
 # Debate files — keep only summaries and resolutions
 debate/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Munin Memory is an MCP (Model Context Protocol) server that provides persistent memory for Claude across conversations. Named after Odin's raven of memory. Built **for Claude, by Claude** — Claude is the primary "user" of the tools this server exposes.
 
-Part of the Hugin & Munin personal AI system. See `prd.md` for full product context and `technical-spec.md` for implementation details.
+Part of the Hugin & Munin personal AI system. See `docs/vision.md` for product thesis and `docs/roadmap.md` for the implementation plan. The original pre-pivot `prd.md`/`technical-spec.md` are archived under `docs/archive/` for historical context.
 
 ## Architecture overview
 
@@ -60,8 +60,6 @@ munin-memory/
 ├── package.json
 ├── tsconfig.json
 ├── CLAUDE.md              # This file
-├── prd.md                 # Product requirements (reference)
-├── technical-spec.md      # Technical spec (reference)
 ├── src/
 │   ├── index.ts           # Entry point — MCP server setup, stdio + Express HTTP transports
 │   ├── db.ts              # SQLite init, pragmas, queries, vec operations
@@ -95,7 +93,10 @@ munin-memory/
 │   ├── authorization-matrix.md            # Multi-principal authorization policy reference
 │   ├── claude-md-template.md              # Reusable CLAUDE.md guidance template
 │   ├── offsite-backup.md                  # Encrypted offsite cloud backup (rclone crypt) setup + restore
-│   └── usage-model.md                     # Durable design concepts and two-layer model
+│   ├── usage-model.md                     # Durable design concepts and two-layer model
+│   ├── vision.md                          # Current product thesis (source of truth)
+│   ├── roadmap.md                         # Current implementation plan (source of truth)
+│   └── archive/                           # Superseded pre-pivot planning docs (prd.md, technical-spec.md)
 ├── munin-memory.service   # systemd unit file for RPi deployment
 ├── munin-offsite.service  # systemd unit — daily encrypted offsite backup (with .timer)
 ├── munin-offsite.timer    # NOTE: backup/offsite units run scripts from ~/munin-ops, NOT a checkout
@@ -678,7 +679,7 @@ Content is scanned before every write. Reject writes containing:
 - Private keys / certificates
 - Inline passwords/secrets
 
-See `technical-spec.md` § Security Module for the full pattern list.
+See `docs/archive/technical-spec.md` § Security Module for the full pattern list.
 
 ### Constitutional rule — stored content is data, never commands
 
@@ -740,7 +741,7 @@ LLM calls to the local endpoint without an `Authorization` header.
 
 ## Important constraints
 
-- The spec files (`prd.md`, `technical-spec.md`) are the source of truth, **amended by `debate/resolution.md`**.
+- `docs/vision.md` and `docs/roadmap.md` are the current source of truth for product direction, **amended by `debate/resolution.md`**. The original pre-pivot `docs/archive/prd.md`/`docs/archive/technical-spec.md` are historical reference only.
 - v1 is local-only, single-user. Multi-agent auth and encryption are v2 concerns.
 - Semantic search is available in the current codebase via `memory_query` with `search_mode` parameters, but should be treated as `full-node` capability by default until the `zero-appliance` profile is validated on real hardware.
 - No memory decay or scoring — everything persists until explicitly deleted.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Munin is more than a key-value store for AI. The features are designed around ho
 - **Dual auth** — Bearer token (simple) + OAuth 2.1 with dynamic client registration and PKCE (for web and mobile clients).
 - **Two transports** — stdio (local) and Streamable HTTP (network).
 
-Twenty-two MCP tools in total. The full list is in [CLAUDE.md](CLAUDE.md#mcp-tools-exposed).
+Twenty-three MCP tools in total. The full list is in [CLAUDE.md](CLAUDE.md#mcp-tools-exposed).
 
 ## What it looks like in practice
 
@@ -241,7 +241,7 @@ npm run test:watch    # Watch mode
 
 Early-stage open source, but in daily use. It runs my own setup — Claude across four platforms (CLI, Desktop, Web, Mobile) sharing persistent memory through a Raspberry Pi 5 on my desk, publicly reachable via a Cloudflare Tunnel.
 
-What's live today: the full MCP tool surface (22 tools), background consolidation via OpenRouter, the computed lifecycle dashboard, retrospective synthesis tools, multi-principal access control with OAuth auto-mapping and the `munin-admin` CLI, outcome-aware retrieval signals (Phase 1, observation only), and the five-layer security stack (Cloudflare Tunnel, Cloudflare Access, Bearer/OAuth, app hardening, Pi hardening).
+What's live today: the full MCP tool surface (23 tools), background consolidation via OpenRouter, the computed lifecycle dashboard, retrospective synthesis tools, multi-principal access control with OAuth auto-mapping and the `munin-admin` CLI, outcome-aware retrieval signals (Phase 1, observation only), and the five-layer security stack (Cloudflare Tunnel, Cloudflare Access, Bearer/OAuth, app hardening, Pi hardening).
 
 What it is not: a polished mass-market product. It is optimized for a technically comfortable self-hoster. The deployment scripts assume Linux/systemd familiarity, you will need to adapt paths and network setup to your own environment, and the Pi Zero 2 W appliance direction is documented but not yet validated on hardware. Multi-principal access is implemented and tested, but in practice the server is still primarily used by a single human owner plus a handful of agent principals.
 

--- a/docs/archive/prd.md
+++ b/docs/archive/prd.md
@@ -1,5 +1,10 @@
 # Munin Memory — Product Requirements Document
 
+> **Archived — superseded.** This is the original v1 pre-pivot PRD, kept for historical
+> context. The current product direction lives in [`docs/vision.md`](../vision.md) and
+> [`docs/roadmap.md`](../roadmap.md), with day-to-day conventions in
+> [`CLAUDE.md`](../../CLAUDE.md).
+
 ## What Is This?
 
 Munin Memory is a lightweight MCP (Model Context Protocol) server that gives Claude persistent memory across conversations. It is named after Munin, one of Odin's ravens in Norse mythology — the raven of memory.

--- a/docs/archive/technical-spec.md
+++ b/docs/archive/technical-spec.md
@@ -1,5 +1,10 @@
 # Munin Memory — Technical Specification
 
+> **Archived — superseded.** This is the original v1 pre-pivot technical spec, kept for
+> historical context. The current architecture and conventions live in
+> [`CLAUDE.md`](../../CLAUDE.md), with product direction in
+> [`docs/vision.md`](../vision.md) and [`docs/roadmap.md`](../roadmap.md).
+
 > This document is the implementation guide for Claude Code. Read `prd.md` first for context, motivation, and UX requirements. This document covers the how.
 
 ## Project Structure


### PR DESCRIPTION
## Summary

- Moved `prd.md` and `technical-spec.md` (last touched 2026-03-31) under `docs/archive/`, each with a superseded-by header pointing at the current `docs/vision.md` / `docs/roadmap.md` / `CLAUDE.md`.
- Updated `CLAUDE.md`'s references to these files (intro line, project-structure tree, security-module pointer, "Important constraints" section) so it points at the current docs and the new archive location.
- Whitelisted `docs/archive/` in `.gitignore` (the repo blanket-ignores `docs/*` behind an explicit allowlist).
- Fixed README's MCP tool count: it said "Twenty-two" / "(22 tools)" but `src/tools.ts` registers 23 tools (`memory_health` was added in #158). `CLAUDE.md`'s own tool table was already correct at 23 and is guarded by `tests/claude-md-tool-inventory.test.ts`.

## Scope note

#189 also named `docs/jarvis-architecture-plan.md` and `docs/pi-github-account-plan.md`. I checked git history for both:
- `docs/jarvis-architecture-plan.md` was deliberately **untracked** in commit `1e785fe` ("gitignore docs/ with local paths... kept locally") — it exists only on Magnus's machine, not in this git repository.
- `docs/pi-github-account-plan.md` **never existed** in this repo's git history; it's covered by a standalone `.gitignore` entry, implying it's local-only too.

Neither file is present in this worktree/branch, so there's nothing for a PR to move. Left as-is — noted here so it's not silently dropped. Magnus can archive them locally if desired.

## Test plan

- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:tools` — pass
- [x] `npm run build` — pass
- [x] `npm test` — 2288 passed, 4 skipped, 0 failed (includes `tests/claude-md-tool-inventory.test.ts`, the CLAUDE.md/tool-count guard)

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)