### PR TITLE
Cover tenant HTTP principal attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ claude mcp add --transport http \
   -s user munin-memory http://localhost:3030/mcp
 ```
 
+The HTTP bearer token configured as `MUNIN_API_KEY` is a shared owner
+credential: requests authenticated with it are intentionally attributed to
+`owner`. For tenant or service clients that need distinct attribution, provision
+an agent principal and use its one-time service token instead. Grant only the
+namespaces that client needs; this example covers both direct state entries in
+`traces/codex-tenant` and optional child namespaces below it:
+
+```bash
+npx munin-admin principals add codex-cli \
+  --type agent \
+  --rules '[{"pattern":"traces/codex-tenant","permissions":"rw"},{"pattern":"traces/codex-tenant/*","permissions":"rw"}]'
+```
+
+The command prints the raw token once. Configure the client with that token as
+`Authorization: Bearer ...`; writes and `memory_history.agent_id` will then use
+`codex-cli` rather than `owner`. If the client only writes child namespaces, omit
+the exact rule; if it only writes state keys directly in one namespace, omit the
+`/*` rule.
+
 ### Connect from Claude Web / Mobile (OAuth)
 
 When running in HTTP mode, the server exposes OAuth 2.1 endpoints. Configure your MCP client with the server URL and the OAuth flow handles authentication automatically. For public deployments, OAuth consent is now fail-closed: you must configure a trusted proxy-authenticated header/value pair for `/authorize` and `/authorize/approve`, or the server will refuse to serve public consent. See the [OAuth section in CLAUDE.md](CLAUDE.md#oauth-21-feature-3) for endpoint details.

--- a/docs/authorization-matrix.md
+++ b/docs/authorization-matrix.md
@@ -202,6 +202,38 @@ interface NamespaceRule {
 | OAuth token | → lookup `client_id` in token table → map to principal via `principals` table. |
 | Agent service token | → lookup hashed token in `principals` table → scoped AccessContext. |
 
+For HTTP tenants and service agents, do not share the HTTP bearer credentials
+configured as `MUNIN_API_KEY`, `MUNIN_API_KEY_DPA`, or
+`MUNIN_API_KEY_CONSUMER`: those credentials all resolve to the owner principal
+and only differ by transport ceiling. Use a principal service token instead.
+Grant only the namespaces the client needs; this example covers both direct
+state entries in `traces/codex-tenant` and optional child namespaces below it:
+
+```bash
+npx munin-admin principals add codex-cli \
+  --type agent \
+  --rules '[{"pattern":"traces/codex-tenant","permissions":"rw"},{"pattern":"traces/codex-tenant/*","permissions":"rw"}]'
+```
+
+The token is displayed once and stored only as `SHA-256` in
+`principals.token_hash`. Rotate it with:
+
+```bash
+npx munin-admin principals rotate-token codex-cli
+```
+
+Revoke by revoking the principal:
+
+```bash
+npx munin-admin principals revoke codex-cli
+```
+
+Use an exact namespace rule when the tenant writes state entries directly in a
+namespace (`namespace=traces/codex-tenant`, `key=...`). A `prefix/*` rule only
+covers child namespaces such as `traces/codex-tenant/runs`, not the prefix
+namespace itself. Omit either rule when the tenant does not need that shape of
+access.
+
 **New table:** `principals`
 
 ```sql

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync, unlinkSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
 import type Database from "better-sqlite3";
 import supertest from "supertest";
 import { initDatabase } from "../src/db.js";
@@ -57,6 +58,17 @@ function parseJsonRpcResponse(body: string): Record<string, unknown> {
     return JSON.parse(sseMatch[1]) as Record<string, unknown>;
   }
   return JSON.parse(body) as Record<string, unknown>;
+}
+
+function parseToolContent<T>(body: string): T {
+  const payload = parseJsonRpcResponse(body);
+  const result = payload.result as Record<string, unknown>;
+  const content = result.content as Array<{ text: string }>;
+  return JSON.parse(content[0].text) as T;
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
 }
 
 let db: Database.Database;
@@ -426,5 +438,115 @@ describe("transport-aware HTTP access context", () => {
         process.env.MUNIN_API_KEY_CONSUMER = originalConsumer;
       }
     }
+  });
+});
+
+describe("HTTP tenant service-token attribution", () => {
+  it("attributes bearer-token writes and history rows to the resolved principal", async () => {
+    const tenantToken = "codex-cli-test-service-token";
+    // DPA-covered transport gives this remote agent the same classification
+    // ceiling a dedicated DPA bearer would have; attribution still comes from
+    // the token_hash -> principal_id mapping.
+    db.prepare(
+      `INSERT INTO principals
+       (id, principal_id, principal_type, token_hash, namespace_rules, transport_type, created_at)
+       VALUES (?, ?, 'agent', ?, ?, 'dpa_covered', ?)`,
+    ).run(
+      randomUUID(),
+      "codex-cli",
+      hashToken(tenantToken),
+      JSON.stringify([
+        { pattern: "traces/codex-tenant", permissions: "rw" },
+        { pattern: "traces/codex-tenant/*", permissions: "rw" },
+      ]),
+      new Date().toISOString(),
+    );
+
+    await initializeClient(app, tenantToken);
+
+    const writeResponse = await supertest(app)
+      .post("/mcp")
+      .set({
+        ...jsonRpcHeaders(tenantToken),
+        "mcp-protocol-version": "2025-03-26",
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "memory_write",
+          arguments: {
+            namespace: "traces/codex-tenant",
+            key: "run-2026-07-04",
+            content: "tenant write attribution regression",
+            tags: ["tenant-validation"],
+          },
+        },
+      })
+      .expect(200);
+
+    const writePayload = parseToolContent<{
+      ok: boolean;
+      status: string;
+      provenance: { principal_id: string; owner_principal_id: string };
+    }>(writeResponse.text);
+    expect(writePayload.ok).toBe(true);
+    expect(writePayload.status).toBe("created");
+    expect(writePayload.provenance).toEqual({
+      principal_id: "codex-cli",
+      owner_principal_id: "codex-cli",
+    });
+
+    const stored = db
+      .prepare("SELECT agent_id, owner_principal_id FROM entries WHERE namespace = ? AND key = ?")
+      .get("traces/codex-tenant", "run-2026-07-04") as
+      | { agent_id: string; owner_principal_id: string | null }
+      | undefined;
+    expect(stored).toEqual({
+      agent_id: "codex-cli",
+      owner_principal_id: "codex-cli",
+    });
+
+    const historyResponse = await supertest(app)
+      .post("/mcp")
+      .set({
+        ...jsonRpcHeaders(tenantToken),
+        "mcp-protocol-version": "2025-03-26",
+      })
+      .send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "memory_history",
+          arguments: {
+            namespace: "traces/codex-tenant",
+            limit: 5,
+          },
+        },
+      })
+      .expect(200);
+
+    const historyPayload = parseToolContent<{
+      ok: boolean;
+      count: number;
+      entries: Array<{
+        agent_id: string;
+        provenance: { principal_id: string };
+      }>;
+    }>(historyResponse.text);
+    expect(historyPayload.ok).toBe(true);
+    expect(historyPayload.count).toBeGreaterThan(0);
+    expect(historyPayload.entries[0]).toMatchObject({
+      agent_id: "codex-cli",
+      provenance: { principal_id: "codex-cli" },
+    });
+    expect(requestLogs.at(-1)).toMatchObject({
+      authType: "bearer",
+      clientId: "principal:codex-cli",
+      toolName: "memory_history",
+      status: 200,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add an HTTP MCP regression proving a principal service-token write is attributed to `codex-cli`, not `owner`
- verify stored `entries.agent_id` / `owner_principal_id`, `memory_history.agent_id`, provenance, and request logging all carry the resolved principal
- document the tenant provisioning path and exact-vs-prefix namespace rule distinction

Closes #191.

## Validation
- npm test -- tests/http-transport.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run typecheck:tools
- npm run build
- git diff --check

## Review
- M5 advisory review via qwen3-coder-next-80b; accepted least-privilege/doc clarity feedback, rejected incorrect claim that `MUNIN_API_KEY*` are not HTTP bearer credentials after checking `MuninOAuthProvider.verifyStaticBearerToken`.
