### PR TITLE
[codex] suppress transient consolidation alerts

### DIFF
--- a/scripts/deploy-rpi.sh
+++ b/scripts/deploy-rpi.sh
@@ -45,9 +45,14 @@ rsync -avz \
   --exclude node_modules \
   --exclude .env \
   --exclude .git \
+  --exclude .codex \
+  --exclude .claude \
+  --exclude AGENTS.md \
+  --exclude STATUS.md \
   --exclude 'benchmark/data/raw/' \
   --exclude 'benchmark/data/cache/' \
   --exclude 'benchmark/generated/' \
+  --exclude 'benchmark/footprint-calculator/' \
   --exclude 'benchmark/reports/' \
   ./ "${USER}@${HOST}:${REMOTE_DIR}/"
 

--- a/src/consolidation.ts
+++ b/src/consolidation.ts
@@ -210,6 +210,18 @@ function currentAlertStatus(): "healthy" | "failing" | "tripped" {
  */
 function maybeWriteHealthAlert(db: Database.Database): void {
   const status = currentAlertStatus();
+
+  // The polled state entry is for user-facing alerts, not complete telemetry.
+  // Keep pre-trip failures visible through getConsolidationHealth()/memory_health
+  // but do not persist a "failing" transition for a single transient timeout:
+  // Ratatoskr turns this entry into chat messages, so one 524 followed by a
+  // successful next run would otherwise produce noisy fail/recovered pairs.
+  if (status === "failing") return;
+
+  if (status === "healthy" && lastWrittenStatus !== "failing" && lastWrittenStatus !== "tripped") {
+    return;
+  }
+
   if (status === lastWrittenStatus) return;
 
   const content = JSON.stringify({
@@ -289,9 +301,9 @@ export function startConsolidationWorker(db: Database.Database): void {
           // malformed entry — skip reconciliation
         }
         if (persistedStatus && persistedStatus !== "healthy") {
-          // Force a write: clear lastWrittenStatus so maybeWriteHealthAlert
-          // sees a transition from the stale status to healthy.
-          lastWrittenStatus = null;
+          // Force a write by restoring the persisted non-healthy status in
+          // memory, so maybeWriteHealthAlert sees a real transition to healthy.
+          lastWrittenStatus = persistedStatus === "tripped" ? "tripped" : "failing";
           maybeWriteHealthAlert(db);
         }
       }

--- a/src/internal/openrouter.ts
+++ b/src/internal/openrouter.ts
@@ -44,6 +44,27 @@ const DEFAULT_MAX_TOKENS = 4096;
 const DEFAULT_TITLE = "Munin Memory";
 const HTTP_REFERER = "https://munin-memory.gille.ai";
 
+function getHeader(response: Response, name: string): string | null {
+  return response.headers?.get(name) ?? null;
+}
+
+function summarizeErrorBody(response: Response, text: string): string {
+  const contentType = getHeader(response, "content-type") ?? "";
+  const trimmed = text.trim();
+  const looksHtml =
+    contentType.toLowerCase().includes("text/html") ||
+    /^<!doctype\s+html/i.test(trimmed) ||
+    /^<html[\s>]/i.test(trimmed);
+
+  if (!looksHtml) {
+    return trimmed.slice(0, 200);
+  }
+
+  const titleMatch = trimmed.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch?.[1]?.replace(/\s+/g, " ").trim();
+  return title ? `HTML error page: ${title}` : "HTML error page";
+}
+
 // --- Base-URL resolution ---
 
 /**
@@ -120,7 +141,8 @@ export async function callOpenRouter(opts: OpenRouterCallOptions): Promise<ChatC
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`OpenRouter API error ${response.status}: ${text.slice(0, 200)}`);
+    const detail = summarizeErrorBody(response, text);
+    throw new Error(`LLM API error ${response.status}${detail ? `: ${detail}` : ""}`);
   }
 
   return response.json() as Promise<ChatCompletionResponse>;

--- a/tests/consolidation.test.ts
+++ b/tests/consolidation.test.ts
@@ -1772,7 +1772,7 @@ describe("getConsolidationHealth — reflects circuit breaker state", () => {
     expect(health.last_error_at).toBeNull();
   });
 
-  it("reflects failure count and last_error after one processConsolidationBatch failure (pre-trip)", async () => {
+  it("reflects a pre-trip failure in health without persisting a chat-alert entry", async () => {
     _setApiKey("fake-key-for-test");
     _setWorkerDb(db);
 
@@ -1798,11 +1798,11 @@ describe("getConsolidationHealth — reflects circuit breaker state", () => {
     expect(health.last_error).toContain("401");
     expect(health.circuit_breaker_tripped).toBe(false);
 
-    // Persisted entry should have status "failing" (not "tripped", not "healthy")
+    // Pre-trip failures remain visible in memory_status/memory_health, but do
+    // not write the polled system-health alert entry. One transient gateway
+    // timeout should not produce a chat alert followed by a recovery alert.
     const alertEntry = readState(db, "meta/system-health", "consolidation");
-    expect(alertEntry).not.toBeNull();
-    const parsed = JSON.parse(alertEntry!.content) as { status: string };
-    expect(parsed.status).toBe("failing");
+    expect(alertEntry).toBeNull();
   });
 
   it("reflects circuit_breaker_tripped: true and last_error after batch failures", async () => {
@@ -2019,8 +2019,10 @@ describe("meta/system-health alert entry — transition-only writes", () => {
     _setApiKey(fakeKey);
     _setWorkerDb(db);
 
-    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
-      appendLog(db, "projects/sanitizetest", `Log ${i}`, []);
+    for (let ns = 0; ns < _consolidationConfig.maxFailures; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/sanitizetest${ns}`, `Log ${i}`, []);
+      }
     }
 
     const originalFetch = globalThis.fetch;
@@ -2052,8 +2054,10 @@ describe("meta/system-health alert entry — transition-only writes", () => {
     _setApiKey(fakeKey);
     _setWorkerDb(db);
 
-    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
-      appendLog(db, "projects/doublekey", `Log ${i}`, []);
+    for (let ns = 0; ns < _consolidationConfig.maxFailures; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/doublekey${ns}`, `Log ${i}`, []);
+      }
     }
 
     const originalFetch = globalThis.fetch;
@@ -2085,8 +2089,10 @@ describe("meta/system-health alert entry — transition-only writes", () => {
     _setApiKey(fakeKey);
     _setWorkerDb(db);
 
-    for (let i = 0; i < _consolidationConfig.minLogs; i++) {
-      appendLog(db, "projects/barekey", `Log ${i}`, []);
+    for (let ns = 0; ns < _consolidationConfig.maxFailures; ns++) {
+      for (let i = 0; i < _consolidationConfig.minLogs; i++) {
+        appendLog(db, `projects/barekey${ns}`, `Log ${i}`, []);
+      }
     }
 
     const originalFetch = globalThis.fetch;

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -430,7 +430,7 @@ describe("callOpenRouter — full-endpoint URL normalization (FIX 4)", () => {
 // ---------------------------------------------------------------------------
 
 describe("callOpenRouter — error handling", () => {
-  it("throws with 'OpenRouter API error <status>:' message on non-ok response", async () => {
+  it("throws with 'LLM API error <status>:' message on non-ok response", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
@@ -444,7 +444,28 @@ describe("callOpenRouter — error handling", () => {
         messages: [{ role: "user", content: "hi" }],
         apiKey: "sk-test",
       }),
-    ).rejects.toThrow("OpenRouter API error 401:");
+    ).rejects.toThrow("LLM API error 401:");
+  });
+
+  it("summarizes HTML error bodies instead of exposing page markup", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 524,
+      headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? "text/html; charset=UTF-8" : null) },
+      text: () =>
+        Promise.resolve(
+          '<!DOCTYPE html><!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]--><title>A timeout occurred</title><body>cloudflare</body>',
+        ),
+    } as unknown as Response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      callOpenRouter({
+        model: "test-model",
+        messages: [{ role: "user", content: "hi" }],
+        apiKey: "sk-test",
+      }),
+    ).rejects.toThrow("LLM API error 524: HTML error page: A timeout occurred");
   });
 });
 


### PR DESCRIPTION
## Summary
- suppress pre-trip consolidation failure chat alerts while keeping health telemetry
- summarize HTML LLM error bodies instead of dumping markup
- exclude local-only artifacts from Pi deploy rsync

## Root Cause
A single transient LLM gateway timeout (HTTP 524) could return an HTML error page. The consolidation worker persisted the pre-trip `failing` state to `meta/system-health:consolidation`, which Ratatoskr polls for chat alerts, producing noisy fail/recovered pairs even though the breaker never tripped.

## Validation
- `npm test -- tests/openrouter.test.ts tests/consolidation.test.ts`
- `npm test` (2290 passed / 4 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `bash -n scripts/deploy-rpi.sh`
- deployed to `huginmunin` with `./scripts/deploy-rpi.sh huginmunin --server-only`; `/health` returned `{"status":"ok"}`

## Review
- Native Codex review against `main...HEAD`: no findings.
