### PR TITLE
fix: keep Heimdall descriptor version current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The public Heimdall service descriptor now reports the runtime package version.** `/heimdall.json` previously carried a manually maintained `0.4.0` string after v0.5.0 shipped, so operator dashboards displayed the wrong release even though MCP initialize and `memory_status` were correct. It now uses the same `SERVER_VERSION` source as the other runtime surfaces, with a regression test tying it to `package.json`.
+
 ## [0.5.0] — 2026-07-10
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,6 @@ export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 // --- Heimdall self-descriptor ---
 // Served at GET /heimdall.json for Tier-1 discovery by the Heimdall dashboard.
 // Shape must satisfy Heimdall's validateDescriptor (schema/service/v1).
-// Keep version in sync with package.json when bumping.
 export const HEIMDALL_DESCRIPTOR = {
   _schema: 'https://heimdall.gille.ai/schema/service/v1',
   service: {
@@ -70,7 +69,7 @@ export const HEIMDALL_DESCRIPTOR = {
   },
   kind: 'mcp',
   status: 'pass',
-  version: '0.4.0',
+  version: SERVER_VERSION,
   deploy: {
     host: 'huginmunin',
     systemd_unit: 'munin-memory',

--- a/tests/index-coverage.test.ts
+++ b/tests/index-coverage.test.ts
@@ -47,6 +47,7 @@ import {
   type RequestLogEntry,
 } from "../src/index.js";
 import type { ExtendedAuthInfo } from "../src/oauth.js";
+import { SERVER_VERSION } from "../src/version.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -550,6 +551,8 @@ describe("createHttpApp — HTTP app endpoints", () => {
         repo: "https://github.com/Magnus-Gille/munin-memory",
       },
     });
+    expect(res.body.version).toBe(SERVER_VERSION);
+    expect(HEIMDALL_DESCRIPTOR.version).toBe(SERVER_VERSION);
   });
 
   it("sets X-Content-Type-Options and Cache-Control security headers", async () => {


### PR DESCRIPTION
## Summary
- source /heimdall.json version from the shared package-backed SERVER_VERSION
- add a regression tying the descriptor to the runtime version
- record the fix under Unreleased

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm run test:coverage (2,295 passed, 4 skipped)