### PR TITLE
fix: align redaction audit retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changelog is the canonical record of what moved.
 ### Fixed
 
 - **The public Heimdall service descriptor now reports the runtime package version.** `/heimdall.json` previously carried a manually maintained `0.4.0` string after v0.5.0 shipped, so operator dashboards displayed the wrong release even though MCP initialize and `memory_status` were correct. It now uses the same `SERVER_VERSION` source as the other runtime surfaces, with a regression test tying it to `package.json`.
+- **Librarian redaction audit logs now retain 365 days by default, matching the documented compliance contract.** The pruning path previously fell back to 90 days when `MUNIN_REDACTION_LOG_RETENTION_DAYS` was unset or invalid, silently discarding audit evidence earlier than documented. Explicit positive retention values remain unchanged.
 
 ## [0.5.0] — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ changelog is the canonical record of what moved.
 ### Fixed
 
 - **The public Heimdall service descriptor now reports the runtime package version.** `/heimdall.json` previously carried a manually maintained `0.4.0` string after v0.5.0 shipped, so operator dashboards displayed the wrong release even though MCP initialize and `memory_status` were correct. It now uses the same `SERVER_VERSION` source as the other runtime surfaces, with a regression test tying it to `package.json`.
-- **Librarian redaction audit logs now retain 365 days by default, matching the documented compliance contract.** The pruning path previously fell back to 90 days when `MUNIN_REDACTION_LOG_RETENTION_DAYS` was unset or invalid, silently discarding audit evidence earlier than documented. Explicit positive retention values remain unchanged.
+- **Librarian redaction audit logs now retain 365 days by default, matching the documented compliance contract.** The pruning path previously fell back to 90 days when `MUNIN_REDACTION_LOG_RETENTION_DAYS` was unset or invalid, silently discarding audit evidence earlier than documented. Configuration is now accepted only when its trimmed, complete value is a positive safe integer in decimal digits; malformed, fractional, zero, negative, and unsafe values fall back to 365 days.
 
 ## [0.5.0] — 2026-07-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -725,7 +725,7 @@ Enforcement is three-layered (#150 added the third):
 | `MUNIN_OAUTH_REFRESH_TOKEN_TTL` | `2592000` | Refresh token lifetime (30 days, seconds) |
 | `MUNIN_OAUTH_IDENTITY_HEADER` | — | Header with authenticated user's email for multi-user consent (e.g. `cf-access-authenticated-user-email`) |
 | `MUNIN_ANALYTICS_RETENTION_DAYS` | `90` | Retention for retrieval_events/outcomes. Sessions pruned at 7 days. |
-| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for Librarian redaction audit records. Invalid or non-positive values fall back to 365 days. |
+| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for Librarian redaction audit records. Surrounding whitespace is ignored; otherwise the whole value must be a positive safe integer in decimal digits, or it falls back to 365 days. |
 | `MUNIN_ALLOW_NAMESPACE_DELETE` | `false` | Enable namespace-wide bulk deletes (`memory_delete` with namespace but no key). Default `false` — namespace-wide deletes are disabled to prevent stored-content prompt-injection payloads from driving the full preview→token→confirm flow in a single agent loop. Set to `true` to re-enable. Single-entry deletes (namespace+key) are always allowed. (#150) |
 | `MUNIN_DISPLAY_TIMEZONE` | `Europe/Stockholm` | IANA timezone for display timestamps (storage stays UTC) |
 | `MUNIN_LLM_BASE_URL` | `https://openrouter.ai/api/v1` | OpenAI-compatible chat-completions base URL used by the answer-quality eval and the consolidation worker. Point at a local llama.cpp / Ollama / vLLM server to run without calling OpenRouter. `OPENROUTER_API_KEY` becomes optional when this is set to a non-default URL. Trailing slashes are trimmed automatically. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -725,6 +725,7 @@ Enforcement is three-layered (#150 added the third):
 | `MUNIN_OAUTH_REFRESH_TOKEN_TTL` | `2592000` | Refresh token lifetime (30 days, seconds) |
 | `MUNIN_OAUTH_IDENTITY_HEADER` | — | Header with authenticated user's email for multi-user consent (e.g. `cf-access-authenticated-user-email`) |
 | `MUNIN_ANALYTICS_RETENTION_DAYS` | `90` | Retention for retrieval_events/outcomes. Sessions pruned at 7 days. |
+| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for Librarian redaction audit records. Invalid or non-positive values fall back to 365 days. |
 | `MUNIN_ALLOW_NAMESPACE_DELETE` | `false` | Enable namespace-wide bulk deletes (`memory_delete` with namespace but no key). Default `false` — namespace-wide deletes are disabled to prevent stored-content prompt-injection payloads from driving the full preview→token→confirm flow in a single agent loop. Set to `true` to re-enable. Single-entry deletes (namespace+key) are always allowed. (#150) |
 | `MUNIN_DISPLAY_TIMEZONE` | `Europe/Stockholm` | IANA timezone for display timestamps (storage stays UTC) |
 | `MUNIN_LLM_BASE_URL` | `https://openrouter.ai/api/v1` | OpenAI-compatible chat-completions base URL used by the answer-quality eval and the consolidation worker. Point at a local llama.cpp / Ollama / vLLM server to run without calling OpenRouter. `OPENROUTER_API_KEY` becomes optional when this is set to a non-default URL. Trailing slashes are trimmed automatically. |

--- a/docs/librarian-architecture.md
+++ b/docs/librarian-architecture.md
@@ -822,7 +822,7 @@ CREATE INDEX IF NOT EXISTS idx_entries_ns_classification
 | `MUNIN_BEARER_TRANSPORT_TYPE` | `dpa_covered` | Transport type for legacy `MUNIN_API_KEY` connections (deprecated — use dedicated keys) |
 | `MUNIN_OAUTH_TRANSPORT_TYPE` | `consumer` | Transport type for OAuth connections |
 | `MUNIN_REDACTION_LOG_ENABLED` | `true` | Log redaction events (disable for performance if needed) |
-| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for redaction audit logs. Invalid or non-positive values fall back to 365 days. |
+| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for redaction audit logs. Surrounding whitespace is ignored; otherwise the whole value must be a positive safe integer in decimal digits, or it falls back to 365 days. |
 
 **Credential priority:** If both `MUNIN_API_KEY_DPA` and `MUNIN_API_KEY` are set, the server checks DPA key first, then consumer key, then legacy key. A request matching the legacy key is logged with a deprecation warning.
 

--- a/docs/librarian-architecture.md
+++ b/docs/librarian-architecture.md
@@ -822,7 +822,7 @@ CREATE INDEX IF NOT EXISTS idx_entries_ns_classification
 | `MUNIN_BEARER_TRANSPORT_TYPE` | `dpa_covered` | Transport type for legacy `MUNIN_API_KEY` connections (deprecated — use dedicated keys) |
 | `MUNIN_OAUTH_TRANSPORT_TYPE` | `consumer` | Transport type for OAuth connections |
 | `MUNIN_REDACTION_LOG_ENABLED` | `true` | Log redaction events (disable for performance if needed) |
-| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for redaction audit log |
+| `MUNIN_REDACTION_LOG_RETENTION_DAYS` | `365` | Retention for redaction audit logs. Invalid or non-positive values fall back to 365 days. |
 
 **Credential priority:** If both `MUNIN_API_KEY_DPA` and `MUNIN_API_KEY` are set, the server checks DPA key first, then consumer key, then legacy key. A request matching the legacy key is logged with a deprecation warning.
 
@@ -1096,14 +1096,13 @@ docs/
 2. **~~How should transport be attested?~~** → Dedicated credentials per transport class (§5.2). Codex critique C01: auth method alone is not a trustworthy signal.
 3. **~~Should derived tools redact output or filter input?~~** → Filter input before synthesis (§7.1.1). Codex critique C02: post-synthesis redaction is insufficient.
 4. **~~What metadata should redacted entries expose?~~** → Tiered by principal type (§6.2). Codex critique C03: full metadata leaks relationships for non-owner.
+7. **~~How long should redaction logs be retained?~~** → 365 days. Compliance evidence needs a longer window than retrieval analytics, which default to 90 days.
 
 ### Still open
 
 5. **Should `memory_query` return redacted entries in search results, or omit them entirely?** Current proposal: include them (with metadata only) so the user knows relevant results exist. Alternative: omit and add a `redacted_count` field. The tiered metadata policy (§6.2) mitigates the leakage concern for non-owner principals.
 
 6. **Should classification be settable as a tool parameter on `memory_write`, or only via tags?** A dedicated parameter is cleaner but adds schema complexity. A tag-only approach uses existing infrastructure but is easier to accidentally omit.
-
-7. **Redaction log retention.** 365 days proposed for compliance evidence. This is intentionally longer than `MUNIN_ANALYTICS_RETENTION_DAYS` (90 days) because redaction logs serve a legal purpose.
 
 8. **Should `client-restricted` entries be completely invisible (like namespace denial) rather than redacted?** The tiered metadata policy reduces this concern — non-owner principals already get minimal metadata. For owner on downgraded transport, visibility is desired.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,14 @@ function getAnalyticsRetentionDays(): number {
 const DEFAULT_REDACTION_LOG_RETENTION_DAYS = 365;
 
 function getRedactionLogRetentionDays(): number {
-  const val = parseInt(
-    process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS
-      ?? String(DEFAULT_REDACTION_LOG_RETENTION_DAYS),
-    10,
-  );
-  return Number.isFinite(val) && val > 0
-    ? val
-    : DEFAULT_REDACTION_LOG_RETENTION_DAYS;
+  const configured = process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+  if (configured === undefined) return DEFAULT_REDACTION_LOG_RETENTION_DAYS;
+
+  const normalized = configured.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) return DEFAULT_REDACTION_LOG_RETENTION_DAYS;
+
+  const val = Number(normalized);
+  return Number.isSafeInteger(val) ? val : DEFAULT_REDACTION_LOG_RETENTION_DAYS;
 }
 
 export function runMaintenancePrune(database: Database.Database): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,17 @@ function getAnalyticsRetentionDays(): number {
   return Number.isFinite(val) && val > 0 ? val : 90;
 }
 
+const DEFAULT_REDACTION_LOG_RETENTION_DAYS = 365;
+
 function getRedactionLogRetentionDays(): number {
-  const val = parseInt(process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS ?? "90", 10);
-  return Number.isFinite(val) && val > 0 ? val : 90;
+  const val = parseInt(
+    process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS
+      ?? String(DEFAULT_REDACTION_LOG_RETENTION_DAYS),
+    10,
+  );
+  return Number.isFinite(val) && val > 0
+    ? val
+    : DEFAULT_REDACTION_LOG_RETENTION_DAYS;
 }
 
 export function runMaintenancePrune(database: Database.Database): void {

--- a/tests/index-maintenance.test.ts
+++ b/tests/index-maintenance.test.ts
@@ -81,7 +81,12 @@ describe("runMaintenancePrune", () => {
 
   it.each([
     ["unset", undefined],
-    ["invalid", "not-a-number"],
+    ["non-numeric", "not-a-number"],
+    ["partially numeric", "30oops"],
+    ["fractional", "30.5"],
+    ["zero", "0"],
+    ["negative", "-30"],
+    ["unsafe integer", "9007199254740992"],
   ])("defaults redaction audit retention to 365 days when configuration is %s", (_label, configuredValue) => {
     const db = initDatabase(":memory:");
     const originalRetention = process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
@@ -110,6 +115,42 @@ describe("runMaintenancePrune", () => {
         .prepare("SELECT id FROM redaction_log ORDER BY id")
         .all() as Array<{ id: string }>;
       expect(rows).toEqual([{ id: "within-default-retention" }]);
+    } finally {
+      if (originalRetention === undefined) {
+        delete process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+      } else {
+        process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS = originalRetention;
+      }
+      db.close();
+    }
+  });
+
+  it.each([
+    ["plain decimal", "180"],
+    ["surrounding whitespace", "  180  "],
+  ])("honors an explicit positive safe integer with %s", (_label, configuredValue) => {
+    const db = initDatabase(":memory:");
+    const originalRetention = process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+    process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS = configuredValue;
+
+    try {
+      insertRedactionLog(
+        db,
+        "within-explicit-retention",
+        new Date(Date.now() - (100 * DAY_MS)).toISOString(),
+      );
+      insertRedactionLog(
+        db,
+        "outside-explicit-retention",
+        new Date(Date.now() - (200 * DAY_MS)).toISOString(),
+      );
+
+      runMaintenancePrune(db);
+
+      const rows = db
+        .prepare("SELECT id FROM redaction_log ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(rows).toEqual([{ id: "within-explicit-retention" }]);
     } finally {
       if (originalRetention === undefined) {
         delete process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;

--- a/tests/index-maintenance.test.ts
+++ b/tests/index-maintenance.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect } from "vitest";
 import { initDatabase } from "../src/db.js";
 import { runMaintenancePrune } from "../src/index.js";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function insertRedactionLog(db: ReturnType<typeof initDatabase>, id: string, createdAt: string): void {
+  db.prepare(
+    `INSERT INTO redaction_log
+       (id, session_id, principal_id, transport_type, entry_id, entry_namespace, entry_classification, connection_max_classification, tool_name, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    `session-${id}`,
+    "owner",
+    "consumer",
+    `entry-${id}`,
+    "clients/lofalk",
+    "client-confidential",
+    "internal",
+    "memory_read",
+    createdAt,
+  );
+}
+
 describe("runMaintenancePrune", () => {
   it("prunes expired redaction log rows", () => {
     const db = initDatabase(":memory:");
@@ -48,6 +69,47 @@ describe("runMaintenancePrune", () => {
         .prepare("SELECT id FROM redaction_log ORDER BY id")
         .all() as Array<{ id: string }>;
       expect(rows).toEqual([{ id: "fresh-redaction" }]);
+    } finally {
+      if (originalRetention === undefined) {
+        delete process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+      } else {
+        process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS = originalRetention;
+      }
+      db.close();
+    }
+  });
+
+  it.each([
+    ["unset", undefined],
+    ["invalid", "not-a-number"],
+  ])("defaults redaction audit retention to 365 days when configuration is %s", (_label, configuredValue) => {
+    const db = initDatabase(":memory:");
+    const originalRetention = process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+
+    if (configuredValue === undefined) {
+      delete process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;
+    } else {
+      process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS = configuredValue;
+    }
+
+    try {
+      insertRedactionLog(
+        db,
+        "within-default-retention",
+        new Date(Date.now() - (200 * DAY_MS)).toISOString(),
+      );
+      insertRedactionLog(
+        db,
+        "outside-default-retention",
+        new Date(Date.now() - (400 * DAY_MS)).toISOString(),
+      );
+
+      runMaintenancePrune(db);
+
+      const rows = db
+        .prepare("SELECT id FROM redaction_log ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(rows).toEqual([{ id: "within-default-retention" }]);
     } finally {
       if (originalRetention === undefined) {
         delete process.env.MUNIN_REDACTION_LOG_RETENTION_DAYS;


### PR DESCRIPTION
## What changed

- align the Librarian redaction-audit retention fallback with the documented 365-day compliance contract
- accept only complete positive safe-integer day values (surrounding whitespace allowed); malformed, fractional, zero, negative, and unsafe values fall back to 365
- document the environment variable and close the architecture decision
- add regressions for unset, malformed, boundary, and valid explicit configuration

## Why

Runtime previously defaulted to 90 days while the Librarian architecture promised 365. That could silently prune compliance evidence earlier than operators expected. Parent review also caught that `parseInt` would have accepted partially numeric garbage; the final parser now enforces the documented full-value contract.

## Impact

The default retains redaction audit rows longer and may increase database size modestly. Explicit valid positive retention values are unchanged.

## Validation

- lint
- source/test and tooling typechecks
- build
- full tests: 2,297 passed, 4 skipped
- coverage ratchets: statements 89.41%, branches 84.32%, functions 92.41%, lines 90.58%
- production audit: 0 vulnerabilities
- full audit: one pre-existing low dev-only esbuild advisory
- focused configuration tests: 10 passed
- `git diff --check`

## Deploy / rollback

Deploy server-only after merge and verify loopback health plus active service. Roll back by redeploying the prior commit or temporarily setting `MUNIN_REDACTION_LOG_RETENTION_DAYS=90`; snapshot first because the shorter setting will prune older rows on the next maintenance run.