### PR TITLE
chore(deps): pin Dependabot below the typescript-eslint peer bound

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # typescript-eslint 8.x declares `peer typescript@">=4.8.4 <6.1.0"`, so any
+      # typescript above 6.0.x fails `npm ci` with ERESOLVE — which breaks install
+      # for the whole grouped PR, not just the linter (see #209, where a bump to
+      # typescript 7.0.2 took all 8 dev-dependency updates down with it).
+      # Revisit once typescript-eslint supports TypeScript 7 and lift both entries.
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       dev-dependencies:
         dependency-type: development


### PR DESCRIPTION
## Summary

Closes the recurring failure behind #209.

`typescript-eslint@8.x` declares `peer typescript@">=4.8.4 <6.1.0"`. Dependabot's grouped dev-dependency PR bumped `typescript` to 7.0.2, so `npm ci` died with `ERESOLVE` before a single test executed — and because the eight updates ship as one group, the incompatible one blocked the other seven.

## Why minor is ignored too, not just major

`package.json` declares `typescript: ^6.0.3` against a peer ceiling of `<6.1.0`. A routine 6.1.x minor bump would break install in precisely the same way as the 7.x major did, so ignoring majors alone would leave the hole open. Both entries lift together once typescript-eslint supports TypeScript 7.

## Verification

- `.github/dependabot.yml` parses as valid YAML; the `ignore` block resolves under the npm ecosystem entry.
- Config-only change — no source, schema, or auth surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)