### PR TITLE
fix: reject trailing/doubled slashes in write-target namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ changelog is the canonical record of what moved.
   models, aborts before touching anything (including `sudo`), and names what each
   model requires. Override with `MUNIN_OPS_ALLOW_MODEL_CHANGE=true` after the
   host's `.env` has been updated to match.
+- **Write targets now reject a trailing or doubled slash in the namespace.**
+  `memory_write` and `memory_log` previously accepted `"maintenance/"` and stored
+  it as a namespace distinct from `"maintenance"`, silently forking history in
+  two. Two production writers hardcoded the trailing form and accumulated 61 log
+  entries in phantom namespaces before it was noticed. The error names the
+  intended namespace (`Did you mean "maintenance"?`). Namespace *prefix filters*
+  are unaffected — `memory_query` still accepts `projects/` to mean the whole
+  subtree, which is why the rule lives in a separate `validateWriteNamespace`
+  rather than in `validateNamespace`.
 - **`scripts/deploy-rpi.sh` now fails before rsync when the deploy target contains
   `.git`.** Earlier releases stripped `.git` from the artifact directory after
   syncing. The deploy target must now already be a pure, git-free artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,14 +51,17 @@ changelog is the canonical record of what moved.
   model requires. Override with `MUNIN_OPS_ALLOW_MODEL_CHANGE=true` after the
   host's `.env` has been updated to match.
 - **Write targets now reject a trailing or doubled slash in the namespace.**
-  `memory_write` and `memory_log` previously accepted `"maintenance/"` and stored
+  `memory_write`, `memory_log`, targeted consolidation, admin profile seeding,
+  and the state persistence backstop now reject `"maintenance/"` instead of storing
   it as a namespace distinct from `"maintenance"`, silently forking history in
   two. Two production writers hardcoded the trailing form and accumulated 61 log
   entries in phantom namespaces before it was noticed. The error names the
   intended namespace (`Did you mean "maintenance"?`). Namespace *prefix filters*
   are unaffected — `memory_query` still accepts `projects/` to mean the whole
   subtree, which is why the rule lives in a separate `validateWriteNamespace`
-  rather than in `validateNamespace`.
+  rather than in `validateNamespace`. Consolidation candidate discovery skips
+  legacy malformed namespaces without recording worker failures, and namespace
+  access rules reject empty path segments before a home can be derived from them.
 - **`scripts/deploy-rpi.sh` now fails before rsync when the deploy target contains
   `.git`.** Earlier releases stripped `.git` from the artifact directory after
   syncing. The deploy target must now already be a pure, git-free artifact

--- a/src/access.ts
+++ b/src/access.ts
@@ -216,6 +216,16 @@ export function validateNamespaceRules(rules: NamespaceRule[]): void {
       }
     }
 
+    const namespacePortion = pattern.endsWith("/*")
+      ? pattern.slice(0, -2)
+      : pattern;
+    if (namespacePortion.split("/").some((segment) => segment.length === 0)) {
+      throw new Error(
+        `Invalid namespace pattern "${pattern}". Namespace segments cannot be empty; ` +
+          `use a single "/" between segments (the final "/*" suffix is allowed).`,
+      );
+    }
+
     // Exact patterns: no further validation needed beyond the * checks above
   }
 }

--- a/src/admin-cli.ts
+++ b/src/admin-cli.ts
@@ -58,6 +58,7 @@ import {
   validateClassificationPattern,
 } from "./librarian.js";
 import type { ClassificationLevel } from "./types.js";
+import { validateWriteNamespace } from "./security.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -472,6 +473,7 @@ export function addPrincipal(
 
   // Validate --profile up front so we never create a principal we cannot seed.
   let profileHome: string | null = null;
+  let profileMetaNamespace: string | null = null;
   if (opts.profile) {
     if (!getTaxonomyProfile(opts.profile)) {
       throw new Error(
@@ -486,6 +488,21 @@ export function addPrincipal(
       );
     }
 
+    profileMetaNamespace = `${profileHome}/meta`;
+    const metaNamespaceCheck = validateWriteNamespace(profileMetaNamespace);
+    if (!metaNamespaceCheck.valid) {
+      const homeRule = opts.rules.find(
+        (rule) =>
+          rule.permissions === "rw" &&
+          rule.pattern.endsWith("/*") &&
+          rule.pattern.slice(0, -2) === profileHome,
+      );
+      throw new Error(
+        `--profile cannot seed: rule "${homeRule?.pattern ?? "(unknown)"}" derives invalid ` +
+          `meta namespace "${profileMetaNamespace}". ${metaNamespaceCheck.error}`,
+      );
+    }
+
     // Shared-home guard (#164 part 2): the profile seeds personal conventions +
     // config under "<home>/meta". If that namespace is also readable by another
     // active non-owner principal (e.g. the home derived to a SHARED prefix
@@ -493,7 +510,7 @@ export function addPrincipal(
     // "users/<id>/*" rule), seeding would leak the principal's personal taxonomy.
     const sharedWith = findPrincipalSharingNamespace(
       db,
-      `${profileHome}/meta`,
+      profileMetaNamespace,
       opts.principalId,
     );
     if (sharedWith !== null) {
@@ -552,7 +569,7 @@ export function addPrincipal(
   let seeded: AddPrincipalResult["seeded"];
   if (opts.profile && profileHome !== null) {
     const profile = getTaxonomyProfile(opts.profile)!;
-    const metaNs = `${profileHome}/meta`;
+    const metaNs = profileMetaNamespace!;
     const { conventions, trackedPatterns } = materializeProfile(profile, profileHome);
     // Classification floor vs principal max (#164 part 3): with the Librarian
     // enabled, the home's namespace floor (default "internal") can exceed a

--- a/src/db.ts
+++ b/src/db.ts
@@ -22,7 +22,7 @@ import {
 } from "./internal/retrieval-shared.js";
 import { runMigrations } from "./migrations.js";
 import { resolveKnob } from "./profiles.js";
-import { scanForSecrets } from "./security.js";
+import { scanForSecrets, validateWriteNamespace } from "./security.js";
 import {
   CLASSIFICATION_LEVELS,
   compareClassificationLevels,
@@ -368,6 +368,11 @@ export function writeState(
   validUntil?: string | null,
   writeOptions?: WriteStateOptions,
 ): WriteStateResult {
+  const namespaceCheck = validateWriteNamespace(namespace);
+  if (!namespaceCheck.valid) {
+    throw new Error(namespaceCheck.error);
+  }
+
   if (writeOptions?.createIfAbsent === true && expectedUpdatedAt !== undefined) {
     throw new Error("createIfAbsent and expectedUpdatedAt are mutually exclusive write preconditions");
   }
@@ -507,6 +512,11 @@ export function patchState(
   expectedUpdatedAt?: string,
   classificationOptions?: ClassificationWriteOptions,
 ): PatchStateResult {
+  const namespaceCheck = validateWriteNamespace(namespace);
+  if (!namespaceCheck.valid) {
+    throw new Error(namespaceCheck.error);
+  }
+
   const existing = db.prepare(
     "SELECT id, content, tags, updated_at, classification FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state'",
   ).get(namespace, key) as {
@@ -3052,7 +3062,24 @@ export function getNamespacesNeedingConsolidation(
         OR (COALESCE(cm.drain_in_progress, 0) = 1 AND COUNT(*) >= 1)
     ORDER BY unincorporated_log_count DESC
   `;
-  return db.prepare(sql).all(...trackedParams, minLogs) as ConsolidationCandidate[];
+  const candidates = db.prepare(sql).all(...trackedParams, minLogs) as ConsolidationCandidate[];
+  const validCandidates: ConsolidationCandidate[] = [];
+  const skippedNamespaces: string[] = [];
+  for (const candidate of candidates) {
+    if (validateWriteNamespace(candidate.namespace).valid) {
+      validCandidates.push(candidate);
+    } else {
+      skippedNamespaces.push(candidate.namespace);
+    }
+  }
+  if (skippedNamespaces.length > 0) {
+    console.warn(
+      `consolidation: skipped malformed write-target namespace(s): ${skippedNamespaces
+        .map((namespace) => JSON.stringify(namespace))
+        .join(", ")}`,
+    );
+  }
+  return validCandidates;
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -3025,6 +3025,11 @@ export function getNamespaceTagVocabulary(
 
 // --- Consolidation operations ---
 
+// Backlog discovery is polled by health checks and consolidation entry points.
+// Remember malformed legacy namespaces for the process lifetime so persistent
+// phantom rows remain visible without producing an unbounded stream of warnings.
+const warnedMalformedConsolidationNamespaces = new Set<string>();
+
 /**
  * Return namespaces (projects/*, clients/*) that have at least minLogs unincorporated
  * log entries — i.e., logs created after the last consolidation checkpoint.
@@ -3064,17 +3069,18 @@ export function getNamespacesNeedingConsolidation(
   `;
   const candidates = db.prepare(sql).all(...trackedParams, minLogs) as ConsolidationCandidate[];
   const validCandidates: ConsolidationCandidate[] = [];
-  const skippedNamespaces: string[] = [];
+  const newlySkippedNamespaces: string[] = [];
   for (const candidate of candidates) {
     if (validateWriteNamespace(candidate.namespace).valid) {
       validCandidates.push(candidate);
-    } else {
-      skippedNamespaces.push(candidate.namespace);
+    } else if (!warnedMalformedConsolidationNamespaces.has(candidate.namespace)) {
+      warnedMalformedConsolidationNamespaces.add(candidate.namespace);
+      newlySkippedNamespaces.push(candidate.namespace);
     }
   }
-  if (skippedNamespaces.length > 0) {
+  if (newlySkippedNamespaces.length > 0) {
     console.warn(
-      `consolidation: skipped malformed write-target namespace(s): ${skippedNamespaces
+      `consolidation: skipped malformed write-target namespace(s): ${newlySkippedNamespaces
         .map((namespace) => JSON.stringify(namespace))
         .join(", ")}`,
     );

--- a/src/security.ts
+++ b/src/security.ts
@@ -238,6 +238,39 @@ export function validateNamespace(namespace: string): SecurityResult {
 }
 
 /**
+ * Validate a namespace used as a WRITE TARGET.
+ *
+ * Stricter than `validateNamespace`, which also guards namespace *prefix
+ * filters* where a trailing slash is meaningful (`memory_query` uses
+ * `projects/` to mean "everything beneath projects"). As a write target a
+ * trailing or doubled slash is always a caller bug: it stores a namespace that
+ * reads as identical to its trimmed form but lives separately, silently forking
+ * history in two. Two production writers hardcoded `"maintenance/"` and
+ * `"security/"` and accumulated 61 log entries in phantom namespaces before it
+ * was noticed.
+ *
+ * Segments are otherwise unconstrained beyond the character rule — namespaces
+ * such as `tasks/_heartbeat` intentionally begin a segment with an underscore.
+ */
+export function validateWriteNamespace(namespace: string): SecurityResult {
+  const base = validateNamespace(namespace);
+  if (!base.valid) return base;
+
+  if (namespace.split("/").some((segment) => segment.length === 0)) {
+    const trimmed = namespace.replace(/\/+$/, "");
+    const hint = trimmed.length > 0 && !trimmed.includes("//") ? ` Did you mean "${trimmed}"?` : "";
+    return {
+      valid: false,
+      error:
+        `Invalid namespace "${namespace}". Namespace segments cannot be empty, so a ` +
+        `trailing or doubled slash is not allowed as a write target — it would create a ` +
+        `second namespace separate from the one you meant.${hint}`,
+    };
+  }
+  return { valid: true };
+}
+
+/**
  * Return the first character (and its index) that is not in the allowed set.
  * Used to give actionable validation errors that name the offending character.
  */
@@ -305,7 +338,7 @@ export function validateWriteInput(
   maxContentSize: number,
 ): SecurityResult {
   const checks = [
-    validateNamespace(namespace),
+    validateWriteNamespace(namespace),
     validateKey(key),
     validateContent(content, maxContentSize),
     validateTags(tags),
@@ -324,7 +357,7 @@ export function validateLogInput(
   maxContentSize: number,
 ): SecurityResult {
   const checks = [
-    validateNamespace(namespace),
+    validateWriteNamespace(namespace),
     validateContent(content, maxContentSize),
     validateTags(tags),
     scanForSecrets(content),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -106,6 +106,7 @@ import {
   validateWriteInput,
   validateLogInput,
   validateNamespace,
+  validateWriteNamespace,
   validateKey,
   validateTags,
   injectionWarning,
@@ -3781,7 +3782,7 @@ const TOOL_DEFINITIONS = [
         namespace: {
           type: "string",
           description:
-            "Hierarchical namespace using / separator. E.g. 'projects/hugin-munin', 'people/owner', 'decisions/tech-stack'. Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens instead, e.g. 'testing/foo-bar' not 'testing/foo.bar').",
+            "Hierarchical namespace using / separator. E.g. 'projects/hugin-munin', 'people/owner', 'decisions/tech-stack'. Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens instead, e.g. 'testing/foo-bar' not 'testing/foo.bar'). Write targets reject trailing slashes and empty segments: use 'maintenance', not 'maintenance/'. Prefix-filter tools such as memory_query deliberately accept forms like 'projects/'.",
         },
         key: {
           type: "string",
@@ -4084,7 +4085,7 @@ const TOOL_DEFINITIONS = [
         namespace: {
           type: "string",
           description:
-            "The namespace to log to (hierarchical, '/' separator). Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens, e.g. 'testing/foo-bar' not 'testing/foo.bar').",
+            "The namespace to log to (hierarchical, '/' separator). Grammar: must start with a letter or digit, then only letters, digits, '_', '-', and '/'. Dots and spaces are INVALID (use hyphens, e.g. 'testing/foo-bar' not 'testing/foo.bar'). Write targets reject trailing slashes and empty segments: use 'maintenance', not 'maintenance/'. Prefix-filter tools such as memory_query deliberately accept forms like 'projects/'.",
         },
         content: {
           type: "string",
@@ -6018,7 +6019,7 @@ export function registerTools(
                 args as unknown as WriteParams & { patch?: PatchParams };
 
               // Validate namespace and key (always required)
-              const nsCheck = validateNamespace(namespace);
+              const nsCheck = validateWriteNamespace(namespace);
               if (!nsCheck.valid) {
                 return errResult("write", "validation_error", nsCheck.error!);
               }
@@ -7671,7 +7672,7 @@ export function registerTools(
               const { namespace: consolidateNs } = (args ?? {}) as { namespace?: string };
 
               if (consolidateNs) {
-                const nsCheck = validateNamespace(consolidateNs);
+                const nsCheck = validateWriteNamespace(consolidateNs);
                 if (!nsCheck.valid) {
                   return errResult("consolidate", "validation_error", nsCheck.error!);
                 }

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -149,6 +149,12 @@ describe("validateNamespaceRules", () => {
     ).toThrow();
   });
 
+  it("rejects empty segments inside a namespace rule prefix", () => {
+    expect(() =>
+      validateNamespaceRules([{ pattern: "users/alice//*", permissions: "rw" }])
+    ).toThrow(/users\/alice\/\/\*/);
+  });
+
   it("rejects invalid permissions", () => {
     expect(() =>
       validateNamespaceRules([

--- a/tests/admin-cli.test.ts
+++ b/tests/admin-cli.test.ts
@@ -192,6 +192,23 @@ describe("addPrincipal", () => {
     ).toThrow("Ambiguous patterns");
   });
 
+  it("rejects a doubled-slash home rule before creating or seeding a profiled principal", () => {
+    expect(() =>
+      addPrincipal(db, {
+        principalId: "alice-double-slash",
+        principalType: "family",
+        rules: [{ pattern: "users/alice//*", permissions: "rw" }],
+        profile: "freelancer",
+      }),
+    ).toThrow(/users\/alice\/\/\*/);
+
+    expect(showPrincipal(db, "alice-double-slash")).toBeNull();
+    const seeded = db.prepare(
+      "SELECT COUNT(*) AS count FROM entries WHERE owner_principal_id = ?",
+    ).get("alice-double-slash") as { count: number };
+    expect(seeded.count).toBe(0);
+  });
+
   it("rejects duplicate principal-id", () => {
     addPrincipal(db, {
       principalId: "alice",

--- a/tests/admin-cli.test.ts
+++ b/tests/admin-cli.test.ts
@@ -209,6 +209,23 @@ describe("addPrincipal", () => {
     expect(seeded.count).toBe(0);
   });
 
+  it("rejects a profiled principal when its valid rule derives an invalid seed namespace", () => {
+    expect(() =>
+      addPrincipal(db, {
+        principalId: "alice-invalid-seed",
+        principalType: "family",
+        rules: [{ pattern: "users/alice!/*", permissions: "rw" }],
+        profile: "freelancer",
+      }),
+    ).toThrow(/--profile cannot seed/);
+
+    expect(showPrincipal(db, "alice-invalid-seed")).toBeNull();
+    const seeded = db.prepare(
+      "SELECT COUNT(*) AS count FROM entries WHERE owner_principal_id = ?",
+    ).get("alice-invalid-seed") as { count: number };
+    expect(seeded.count).toBe(0);
+  });
+
   it("rejects duplicate principal-id", () => {
     addPrincipal(db, {
       principalId: "alice",

--- a/tests/consolidation-db.test.ts
+++ b/tests/consolidation-db.test.ts
@@ -114,6 +114,26 @@ describe("getNamespacesNeedingConsolidation", () => {
     expect(candidates[0].namespace).toBe("projects/busy");
     expect(candidates[1].namespace).toBe("clients/quiet");
   });
+
+  it("excludes legacy logs in a malformed trailing-slash namespace", () => {
+    const insertLegacyLog = db.prepare(
+      `INSERT INTO entries
+         (id, namespace, key, entry_type, content, tags, agent_id, owner_principal_id, created_at, updated_at, classification)
+       VALUES (?, ?, NULL, 'log', ?, '[]', 'owner', 'owner', ?, ?, 'internal')`,
+    );
+    for (let i = 0; i < 4; i++) {
+      const timestamp = `2026-07-21T12:00:0${i}.000Z`;
+      insertLegacyLog.run(
+        `legacy-malformed-log-${i}`,
+        "projects/legacy/",
+        `Legacy log ${i}`,
+        timestamp,
+        timestamp,
+      );
+    }
+
+    expect(getNamespacesNeedingConsolidation(db, 3)).toEqual([]);
+  });
 });
 
 describe("getNamespacesNeedingConsolidation — with prior consolidation checkpoint", () => {

--- a/tests/consolidation-db.test.ts
+++ b/tests/consolidation-db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { unlinkSync, existsSync } from "node:fs";
 import {
@@ -133,6 +133,34 @@ describe("getNamespacesNeedingConsolidation", () => {
     }
 
     expect(getNamespacesNeedingConsolidation(db, 3)).toEqual([]);
+  });
+
+  it("warns only once per malformed namespace across consecutive calls", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const insertLegacyLog = db.prepare(
+      `INSERT INTO entries
+         (id, namespace, key, entry_type, content, tags, agent_id, owner_principal_id, created_at, updated_at, classification)
+       VALUES (?, ?, NULL, 'log', ?, '[]', 'owner', 'owner', ?, ?, 'internal')`,
+    );
+    for (let i = 0; i < 3; i++) {
+      const timestamp = `2026-07-21T13:00:0${i}.000Z`;
+      insertLegacyLog.run(
+        `repeated-malformed-log-${i}`,
+        "projects/repeated-malformed/",
+        `Malformed log ${i}`,
+        timestamp,
+        timestamp,
+      );
+    }
+
+    getNamespacesNeedingConsolidation(db, 3);
+    getNamespacesNeedingConsolidation(db, 3);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'consolidation: skipped malformed write-target namespace(s): "projects/repeated-malformed/"',
+    );
+    warnSpy.mockRestore();
   });
 });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -10,6 +10,7 @@ import {
   initDatabase,
   parsePragmaInt,
   writeState,
+  patchState,
   readState,
   getById,
   appendLog,
@@ -95,6 +96,37 @@ describe("initDatabase", () => {
   it("sets WAL journal mode", () => {
     const mode = db.pragma("journal_mode", { simple: true });
     expect(mode).toBe("wal");
+  });
+});
+
+describe("state write-target namespace backstop", () => {
+  it("writeState rejects a malformed namespace", () => {
+    expect(() =>
+      writeState(db, "maintenance/", "status", "must not be stored", []),
+    ).toThrow(/write target/i);
+  });
+
+  it("patchState rejects a malformed namespace before reading a legacy row", () => {
+    const timestamp = "2026-07-21T12:00:00.000Z";
+    db.prepare(
+      `INSERT INTO entries
+         (id, namespace, key, entry_type, content, tags, agent_id, owner_principal_id, created_at, updated_at, classification)
+       VALUES (?, ?, ?, 'state', ?, '[]', 'owner', 'owner', ?, ?, 'internal')`,
+    ).run(
+      "db-legacy-trailing-slash-state",
+      "security/",
+      "status",
+      "legacy content",
+      timestamp,
+      timestamp,
+    );
+
+    expect(() =>
+      patchState(db, "security/", "status", { content_append: "must not be appended" }),
+    ).toThrow(/write target/i);
+    const row = db.prepare("SELECT content FROM entries WHERE id = ?")
+      .get("db-legacy-trailing-slash-state") as { content: string };
+    expect(row.content).toBe("legacy content");
   });
 });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -334,6 +334,7 @@ describe("validateNamespace", () => {
     // on this; tightening must not strand them.
     expect(validateWriteNamespace("tasks/_heartbeat").valid).toBe(true);
     expect(validateWriteNamespace("tasks/_auth_alarm").valid).toBe(true);
+    expect(validateWriteNamespace("tasks/-heartbeat").valid).toBe(true);
     expect(validateNamespace("experiments/hugin/champions/m5-code-edit-28e17").valid).toBe(true);
   });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,6 +5,7 @@ import {
   scanForInjection,
   injectionWarning,
   validateNamespace,
+  validateWriteNamespace,
   validateKey,
   validateContent,
   validateTags,
@@ -307,6 +308,33 @@ describe("validateNamespace", () => {
 
   it("rejects namespace with leading slash", () => {
     expect(validateNamespace("/projects").valid).toBe(false);
+  });
+
+  it("rejects a trailing slash that would fork a namespace in two", () => {
+    // Regression: "maintenance/" and "maintenance" are semantically the same
+    // namespace but were stored separately, silently splitting history. Two
+    // production writers hardcoded the trailing form and accumulated 61 log
+    // entries in phantom namespaces before anyone noticed.
+    for (const namespace of ["maintenance/", "security/", "projects/munin-memory/"]) {
+      const result = validateWriteNamespace(namespace);
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/slash/i);
+    }
+  });
+
+  it("rejects empty path segments", () => {
+    expect(validateWriteNamespace("maintenance//os").valid).toBe(false);
+    expect(validateWriteNamespace("a//b//c").valid).toBe(false);
+    // ...but a prefix FILTER may legitimately end in "/" (memory_query subtree).
+    expect(validateNamespace("projects/").valid).toBe(true);
+  });
+
+  it("still accepts segments that start with underscore or hyphen", () => {
+    // Production namespaces such as tasks/_heartbeat and tasks/_auth_alarm rely
+    // on this; tightening must not strand them.
+    expect(validateWriteNamespace("tasks/_heartbeat").valid).toBe(true);
+    expect(validateWriteNamespace("tasks/_auth_alarm").valid).toBe(true);
+    expect(validateNamespace("experiments/hugin/champions/m5-code-edit-28e17").valid).toBe(true);
   });
 
   it("rejects namespace with special characters", () => {

--- a/tests/tools-coverage.test.ts
+++ b/tests/tools-coverage.test.ts
@@ -1970,6 +1970,13 @@ describe("memory_consolidate", () => {
     expect(res.error).toBe("validation_error");
   });
 
+  it("rejects a targeted consolidation write to a trailing-slash namespace", async () => {
+    const res = parseToolResponse(await callTool("memory_consolidate", { namespace: "maintenance/" }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("validation_error");
+    expect(res.message).toContain('Did you mean "maintenance"?');
+  });
+
   it("completes immediately for a namespace with no unincorporated logs", async () => {
     const res = parseToolResponse(await callTool("memory_consolidate", { namespace: "projects/empty-ns" }));
     expect(res.ok).toBe(true);

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -161,6 +161,17 @@ describe("memory_write", () => {
     expect(result.error).toBe("validation_error");
   });
 
+  it("rejects a trailing slash on the full-write path with an actionable hint", async () => {
+    const raw = await callTool("memory_write", {
+      namespace: "maintenance/",
+      key: "status",
+      content: "must not be stored",
+    });
+    const result = parseToolResponse(raw) as { error: string; message: string };
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toContain('Did you mean "maintenance"?');
+  });
+
   it("rejects content with secrets", async () => {
     const raw = await callTool("memory_write", {
       namespace: "projects/test",
@@ -397,9 +408,53 @@ describe("memory_write patch", () => {
     const result = parseToolResponse(raw) as { error: string };
     expect(result.error).toBe("validation_error");
   });
+
+  it("rejects a patch targeting a legacy row in a trailing-slash namespace without changing it", async () => {
+    const timestamp = "2026-07-21T12:00:00.000Z";
+    db.prepare(
+      `INSERT INTO entries
+         (id, namespace, key, entry_type, content, tags, agent_id, owner_principal_id, created_at, updated_at, classification)
+       VALUES (?, ?, ?, 'state', ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "legacy-trailing-slash-state",
+      "projects/legacy/",
+      "notes",
+      "legacy content",
+      "[]",
+      "owner",
+      "owner",
+      timestamp,
+      timestamp,
+      "internal",
+    );
+
+    const raw = await callTool("memory_write", {
+      namespace: "projects/legacy/",
+      key: "notes",
+      patch: { content_append: "must not be appended" },
+    });
+    const result = parseToolResponse(raw) as { error: string; message: string };
+    expect(result.error).toBe("validation_error");
+    expect(result.message).toMatch(/write target/i);
+
+    const row = db.prepare(
+      "SELECT content, updated_at FROM entries WHERE id = ?",
+    ).get("legacy-trailing-slash-state") as { content: string; updated_at: string };
+    expect(row).toEqual({ content: "legacy content", updated_at: timestamp });
+  });
 });
 
 describe("memory_update_status", () => {
+  it("rejects a trailing slash namespace at the handler boundary", async () => {
+    const raw = await callTool("memory_update_status", {
+      namespace: "projects/status-tool/",
+      phase: "Active",
+      lifecycle: "active",
+    });
+    const result = parseToolResponse(raw) as { error: string };
+    expect(result.error).toBe("validation_error");
+  });
+
   it("creates a canonical tracked status from structured fields", async () => {
     const raw = await callTool("memory_update_status", {
       namespace: "projects/status-tool",
@@ -2717,6 +2772,15 @@ describe("memory_log", () => {
     const raw = await callTool("memory_log", {
       namespace: "",
       content: "test",
+    });
+    const result = parseToolResponse(raw) as { error: string };
+    expect(result.error).toBe("validation_error");
+  });
+
+  it("rejects a trailing slash namespace at the handler boundary", async () => {
+    const raw = await callTool("memory_log", {
+      namespace: "maintenance/",
+      content: "must not be logged",
     });
     const result = parseToolResponse(raw) as { error: string };
     expect(result.error).toBe("validation_error");
@@ -5588,6 +5652,29 @@ describe("staleness flag", () => {
 });
 
 describe("compare-and-swap (memory_write)", () => {
+  it("documents strict write-target namespace grammar for memory_write and memory_log", async () => {
+    const handler = (
+      server as unknown as { _requestHandlers: Map<string, Function> }
+    )._requestHandlers?.get("tools/list");
+    const toolList = await handler!({ method: "tools/list", params: {} });
+    const tools = (toolList as {
+      tools: Array<{
+        name: string;
+        inputSchema: {
+          properties?: Record<string, { description?: string }>;
+        };
+      }>;
+    }).tools;
+
+    for (const name of ["memory_write", "memory_log"]) {
+      const description = tools.find((tool) => tool.name === name)
+        ?.inputSchema.properties?.namespace?.description;
+      expect(description).toContain("trailing slashes");
+      expect(description).toContain("empty segments");
+      expect(description).toContain("maintenance/");
+    }
+  });
+
   it("advertises create_if_absent in the MCP input schema", async () => {
     const handler = (
       server as unknown as { _requestHandlers: Map<string, Function> }


### PR DESCRIPTION
## Problem

`memory_write`/`memory_log` accepted `"maintenance/"` and stored it as a namespace **distinct from** `"maintenance"`. Identical to a human, separate in the database — so writes silently fork history in two.

This is not hypothetical. Two production writers hardcoded the trailing form and accumulated **61 log entries** in phantom namespaces:

| Namespace | Logs | Writer |
|---|---|---|
| `maintenance/` | 44 | `brokkr/scripts/maintenance-report.sh:403,492,520` |
| `security/` | 17 | `grimnir/scripts/security-scan.sh:753` |

The documented grammar — *starts with alphanumeric, then alphanumeric/underscore/hyphen/slash* — admits a trailing slash, so validation passed.

## Why the rule is not in `validateNamespace`

My first attempt tightened `validateNamespace` directly. **It broke five tests**, and they were right to break: that function also guards namespace prefix *filters*, where a trailing slash is meaningful — `memory_query` uses `projects/` to mean the whole subtree.

So the strict rule lives in a new `validateWriteNamespace`, routed in from `validateWriteInput` and `validateLogInput` only. A test pins that `validateNamespace("projects/")` stays valid.

## Scope

- Rejects empty segments generally, so `a//b` is caught too.
- Segments may still start with `_`/`-`: `tasks/_heartbeat` and `tasks/_auth_alarm` exist in production and a test pins them.
- Error is actionable: `Invalid namespace "maintenance/". … Did you mean "maintenance"?`
- Existing phantom namespaces are untouched — disposition is a separate decision.
- Affected writers are best-effort (warn and continue), so they degrade rather than break.

## Verification

- Red/green: both new cases failed before the change.
- lint, typecheck, typecheck:tools — pass
- 2,340 tests pass; coverage 89.58% (ratchet held); benchmark PASS

Cross-repo issues filed for the two callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)