### PR TITLE
fix: stop install-ops.sh silently swapping the backup destination model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ changelog is the canonical record of what moved.
 
 - Deployment, backup, offsite, service-descriptor, and model-evaluation examples now
   use generic, configurable hosts, identities, paths, remotes, and URLs.
+- **`scripts/install-ops.sh` refuses to swap a host's backup destination model.**
+  `backup-to-nas.sh` exists in two incompatible forms — push to a remote host over
+  ssh/rsync, or write to a local mounted volume — and a host is provisioned for
+  exactly one in its ops `.env`. Installing the other did not fail at install
+  time; it failed on the next timer fire, silently, surfacing days later as a
+  missing off-host copy. The installer now compares the deployed and incoming
+  models, aborts before touching anything (including `sudo`), and names what each
+  model requires. Override with `MUNIN_OPS_ALLOW_MODEL_CHANGE=true` after the
+  host's `.env` has been updated to match.
 - **`scripts/deploy-rpi.sh` now fails before rsync when the deploy target contains
   `.git`.** Earlier releases stripped `.git` from the artifact directory after
   syncing. The deploy target must now already be a pure, git-free artifact

--- a/scripts/install-ops.sh
+++ b/scripts/install-ops.sh
@@ -27,9 +27,62 @@ OPS_DIR="${MUNIN_OPS_DIR:-${OPS_HOME}/munin-ops}"
 SCRIPTS=(backup-to-nas.sh offsite-backup.sh offsite-snapshot.sh)
 UNITS=(munin-backup.service munin-backup.timer munin-offsite.service munin-offsite.timer)
 
+# ── Backup destination-model guard ───────────────────────────────────────────
+# backup-to-nas.sh exists in two INCOMPATIBLE destination models: it either
+# pushes to a remote host over ssh/rsync, or writes to a local mounted volume.
+# A host is provisioned for exactly one of them, in its ops .env.
+#
+# Swapping the model on an already-provisioned host does not fail here — it
+# fails on the next timer fire, silently, and the first symptom is a missing
+# off-host copy noticed days later. That is not hypothetical: the repo's script
+# was changed to the local-mount model while the deployed host was provisioned
+# for the remote model, so a reinstall would have replaced a just-repaired
+# backup with one that exits 64 ("MUNIN_BACKUP_DIR is required") every night.
+#
+# Refuse instead, and say exactly what to do. Override deliberately with
+# MUNIN_OPS_ALLOW_MODEL_CHANGE=true once the host's .env matches the new model.
+backup_destination_model() {  # path → remote | local-mount | unknown | absent
+  local f="$1"
+  [[ -f "$f" ]] || { echo "absent"; return; }
+  if grep -qE '^[[:space:]]*NAS_HOST=' "$f"; then
+    echo "remote"
+  elif grep -q 'MUNIN_BACKUP_MOUNT' "$f"; then
+    echo "local-mount"
+  else
+    echo "unknown"
+  fi
+}
+
 echo "==> Installing operational scripts into ${OPS_DIR}/scripts (from ${REPO_DIR})"
 install -d -m 755 "${OPS_DIR}/scripts"
 for s in "${SCRIPTS[@]}"; do
+  if [[ "$s" == "backup-to-nas.sh" ]]; then
+    src_model=$(backup_destination_model "${REPO_DIR}/scripts/${s}")
+    dst_model=$(backup_destination_model "${OPS_DIR}/scripts/${s}")
+    if [[ "$dst_model" != "absent" && "$dst_model" != "unknown" &&
+          "$src_model" != "unknown" && "$src_model" != "$dst_model" ]]; then
+      if [[ "${MUNIN_OPS_ALLOW_MODEL_CHANGE:-}" != "true" ]]; then
+        {
+          echo "ERROR: refusing to change this host's backup destination model."
+          echo "       deployed: ${dst_model}   (${OPS_DIR}/scripts/${s})"
+          echo "       incoming: ${src_model}   (${REPO_DIR}/scripts/${s})"
+          echo
+          echo "       The two models need different configuration, so installing"
+          echo "       the incoming one would leave the nightly backup failing"
+          echo "       silently from its next run:"
+          echo "         remote      needs NAS_HOST/NAS_DIR and ssh access"
+          echo "         local-mount needs MUNIN_BACKUP_MOUNT + MUNIN_BACKUP_DIR"
+          echo "                     on an actively mounted filesystem"
+          echo
+          echo "       Fix the host's ops .env for the incoming model FIRST, then"
+          echo "       re-run with MUNIN_OPS_ALLOW_MODEL_CHANGE=true."
+          echo "       Nothing has been installed; the deployed backup is untouched."
+        } >&2
+        exit 1
+      fi
+      echo "    WARNING: destination model ${dst_model} -> ${src_model} (MUNIN_OPS_ALLOW_MODEL_CHANGE=true)"
+    fi
+  fi
   install -m 755 "${REPO_DIR}/scripts/${s}" "${OPS_DIR}/scripts/${s}"
   echo "    ${s}"
 done

--- a/tests/install-ops-guard.test.ts
+++ b/tests/install-ops-guard.test.ts
@@ -1,0 +1,97 @@
+/**
+ * install-ops.sh must never silently swap a host's backup destination model.
+ *
+ * backup-to-nas.sh exists in two incompatible forms — push to a remote host over
+ * ssh/rsync, or write to a local mounted volume — and a host is provisioned for
+ * exactly one. Installing the other does not fail at install time; it fails on
+ * the next timer fire, silently, and surfaces days later as a missing off-host
+ * copy of the memory database.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const installOps = join(repoRoot, "scripts", "install-ops.sh");
+
+const scratch: string[] = [];
+function makeScratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), "munin-ops-guard-"));
+  scratch.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (scratch.length > 0) {
+    const d = scratch.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+const REMOTE_SCRIPT = `#!/bin/bash\nNAS_HOST="203.0.113.10"\nNAS_DIR="/srv/backups"\nrsync -a "$1" "magnus@\${NAS_HOST}:\${NAS_DIR}/"\n`;
+const LOCAL_SCRIPT = `#!/bin/bash\nBACKUP_MOUNT="\${MUNIN_BACKUP_MOUNT:-}"\ninstall -m 600 "$1" "\$BACKUP_MOUNT/x"\n`;
+
+/** Stage an ops dir with a deployed backup script of the given model. */
+function stageOpsDir(body: string): string {
+  const opsDir = join(makeScratch(), "munin-ops");
+  mkdirSync(join(opsDir, "scripts"), { recursive: true });
+  const p = join(opsDir, "scripts", "backup-to-nas.sh");
+  writeFileSync(p, body);
+  chmodSync(p, 0o755);
+  return opsDir;
+}
+
+function runInstall(opsDir: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync("bash", [installOps], {
+    env: { ...process.env, MUNIN_OPS_DIR: opsDir, ...extraEnv },
+    encoding: "utf8",
+  });
+}
+
+describe("install-ops.sh backup destination-model guard", () => {
+  it("refuses to replace a remote-model deployment with the local-mount model", () => {
+    // The exact production situation: huginmunin runs the remote model, while
+    // the repo's script had been switched to local-mount. A reinstall would have
+    // left the nightly backup exiting 64 every night.
+    const opsDir = stageOpsDir(REMOTE_SCRIPT);
+    const result = runInstall(opsDir);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("refusing to change this host's backup destination model");
+    expect(result.stderr).toMatch(/deployed:\s+remote/);
+    expect(result.stderr).toContain("MUNIN_OPS_ALLOW_MODEL_CHANGE=true");
+  });
+
+  it("aborts before touching sudo or the deployed script", () => {
+    const opsDir = stageOpsDir(REMOTE_SCRIPT);
+    const result = runInstall(opsDir);
+
+    // The guard must run in the scripts loop, ahead of the units loop — otherwise
+    // it would prompt for sudo before refusing.
+    expect(result.stdout).not.toContain("Installing systemd units");
+    expect(result.stderr).toContain("the deployed backup is untouched");
+    // The deployed script must still be the remote-model one.
+    const deployed = spawnSync("cat", [join(opsDir, "scripts", "backup-to-nas.sh")], {
+      encoding: "utf8",
+    }).stdout;
+    expect(deployed).toContain("NAS_HOST=");
+  });
+
+  it("names both models and what each requires, so the error is actionable", () => {
+    const result = runInstall(stageOpsDir(REMOTE_SCRIPT));
+
+    expect(result.stderr).toContain("MUNIN_BACKUP_MOUNT");
+    expect(result.stderr).toContain("NAS_HOST");
+  });
+
+  it("does not fire when the deployed script already uses the incoming model", () => {
+    // Same model on both sides must not trip the guard. Asserted by the absence
+    // of the refusal, not by a successful install — the install proceeds into
+    // sudo territory, which this test deliberately does not reach.
+    const result = runInstall(stageOpsDir(LOCAL_SCRIPT));
+
+    expect(result.stderr).not.toContain("refusing to change");
+  });
+});


### PR DESCRIPTION
## The live footgun

`scripts/backup-to-nas.sh` exists in two **incompatible** destination models, and a host is provisioned for exactly one:

| | remote | local-mount |
|---|---|---|
| Destination | NAS over ssh | local mounted volume |
| Mechanism | `rsync -a` | `install -m 600` |
| Requires | `NAS_HOST`/`NAS_DIR` + ssh | `MUNIN_BACKUP_MOUNT` + `MUNIN_BACKUP_DIR` on an active mountpoint |

Installing the wrong one **does not fail at install time**. It fails on the next timer fire, silently — first symptom is a missing off-host copy noticed days later.

**Not hypothetical.** main's script is now local-mount, while the deployed host runs remote and has *no local mounted backup volume* (only `/` on the SD card and `/boot/firmware`), and its ops `.env` sets neither variable. Simulating main's preflight against that host's real environment:

```
WOULD EXIT 64: MUNIN_BACKUP_DIR is required
rc=64
```

So an `install-ops.sh` run from main would have replaced a **just-repaired** nightly backup (#218) with one failing every night — reproducing the very outage that was fixed.

## The guard

Classify deployed vs incoming; refuse when they differ. Aborts inside the scripts loop, **ahead of the units loop**, so nothing is written and `sudo` is never reached. The error names both models and what each needs. Override with `MUNIN_OPS_ALLOW_MODEL_CHANGE=true` once the host's `.env` matches.

Classification is unambiguous on the two real scripts — verified: remote has `NAS_HOST=` ×1 and `MUNIN_BACKUP_MOUNT` ×0; local-mount is the exact inverse (×0 / ×11).

## Scope

**This is a guard, not the fix.** Reconciling the two models into one script that supports both destinations is separate and larger.

## Verification

- 4 new tests: refusal fires, aborts before sudo, deployed script untouched, error is actionable, and no false positive when models match.
- shellcheck (warning level) clean; lint, typecheck, 2,341 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)