### PR TITLE
fix: unify the two backup destination models into one configurable script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,35 @@ MUNIN_OWNER_ALIASES=
 MUNIN_OWNER_PROFILE_NAMESPACE=people/owner
 
 # === Operational backup (copy these to ~/munin-ops/.env) ===
-# Both are required by munin-backup.service. MUNIN_BACKUP_MOUNT must be the
-# mounted filesystem root; MUNIN_BACKUP_DIR must be an absolute child path.
-# The job verifies the mount before mkdir so a missing mount cannot fall back
-# silently to the system disk.
+# munin-backup.service has TWO destination modes. Configure exactly one. With
+# neither configured the job refuses to start rather than writing nowhere.
+#
+# MUNIN_BACKUP_MODE may be left unset — it is inferred from whichever pair is
+# present — but setting it explicitly makes the intent obvious in the .env.
+#
+# Mode 'remote': push the snapshot to another host over ssh/rsync. The transfer
+# is verified by comparing the destination's byte count against the snapshot,
+# because rsync exiting 0 does not prove the bytes are readable there.
+# MUNIN_BACKUP_MODE=remote
+# MUNIN_BACKUP_HOST=backup-user@backup-host
+# MUNIN_BACKUP_REMOTE_DIR=/srv/backups/munin-memory
+#
+# Mode 'local': write the snapshot to a locally mounted volume. MUNIN_BACKUP_MOUNT
+# must be the mounted filesystem root and MUNIN_BACKUP_DIR an absolute child of
+# it. The mount is verified before AND after each write, symlinked path
+# components are rejected, and the written file's filesystem identity is checked,
+# so a dropped mount cannot silently redirect backups to the system disk.
+MUNIN_BACKUP_MODE=local
 MUNIN_BACKUP_MOUNT=/mnt/backup
 MUNIN_BACKUP_DIR=/mnt/backup/munin-memory
 # MUNIN_BACKUP_DB=/var/lib/grimnir/munin-memory/memory.db
+# Staging holds a full snapshot before transfer; defaults to /tmp (a tmpfs under
+# the unit's PrivateTmp=yes). Free space is preflighted. See munin-backup.service
+# before pointing this at an SD card.
+# MUNIN_BACKUP_STAGING=/tmp
+# GFS retention, applied at either destination.
+# MUNIN_BACKUP_KEEP_DAILY=14
+# MUNIN_BACKUP_KEEP_SUNDAYS=4
 
 # === Embeddings / Semantic Search ===
 MUNIN_EMBEDDINGS_ENABLED=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ changelog is the canonical record of what moved.
 
 ### Changed
 
+- **`backup-to-nas.sh` now supports both destination models in one script.**
+  It previously existed in two incompatible forms — push to a remote host over
+  ssh/rsync, or write to a local mounted volume — which had diverged between the
+  repository and the deployed fleet host, so an `install-ops.sh` run would have
+  replaced a working backup with one that could not run there. The destination is
+  now chosen by `MUNIN_BACKUP_MODE` (`remote` or `local`, inferred when unset),
+  and every installation-specific value moved out of the script into the ops
+  `.env`: `MUNIN_BACKUP_HOST`/`MUNIN_BACKUP_REMOTE_DIR` for remote,
+  `MUNIN_BACKUP_MOUNT`/`MUNIN_BACKUP_DIR` for local. With neither configured the
+  job refuses to start rather than writing nowhere. Both modes share the
+  free-space preflight, snapshot, integrity check, GFS retention and post-write
+  verification; the remote mode gained verification it never had, comparing the
+  destination's byte count against the snapshot rather than trusting `rsync`'s
+  exit status, and skipping retention entirely when that check fails.
+- **`munin-backup.service` timeout raised 120s → 1800s.** The job had grown into
+  its ceiling: ~105s measured on a 1.85 GB database, so it began failing silently
+  every night from 2026-07-17. Runtime scales at roughly 31s/GB and the database
+  grows steadily, so any snug ceiling merely reschedules the outage.
+
 - Deployment, backup, offsite, service-descriptor, and model-evaluation examples now
   use generic, configurable hosts, identities, paths, remotes, and URLs.
 - **`scripts/install-ops.sh` refuses to swap a host's backup destination model.**

--- a/README.md
+++ b/README.md
@@ -244,12 +244,24 @@ over an existing Git checkout, and does not copy `.env` or database files. Revie
 the service user, paths, reverse-proxy trust boundary, and backup location for your
 host before enabling it.
 
-The optional `munin-backup.timer` intentionally has no local-disk destination
-default. Before enabling it, set `MUNIN_BACKUP_MOUNT` to the mounted filesystem
-root and `MUNIN_BACKUP_DIR` to an absolute child directory in
-`~/munin-ops/.env`. The job verifies the mount before snapshotting or creating
-directories, so a missing mount cannot silently redirect backups to the system
-disk.
+The optional `munin-backup.timer` intentionally has no destination default. It
+supports two modes, configured in `~/munin-ops/.env`, and refuses to start if
+neither is set rather than writing nowhere:
+
+- **`remote`** — push to another host over ssh/rsync. Set `MUNIN_BACKUP_HOST` and
+  `MUNIN_BACKUP_REMOTE_DIR`. The transfer is verified by comparing the
+  destination's byte count against the snapshot, since `rsync` exiting `0` does
+  not prove the bytes are readable there. Retention only runs after that check
+  passes, so a failed transfer never prunes existing snapshots.
+- **`local`** — write to a mounted volume. Set `MUNIN_BACKUP_MOUNT` to the
+  filesystem root and `MUNIN_BACKUP_DIR` to an absolute child. The mount is
+  verified before *and* after each write, symlinked path components are rejected,
+  and the written file's filesystem identity is confirmed — so a dropped mount
+  cannot silently redirect backups to the system disk.
+
+`scripts/install-ops.sh` refuses to install a script whose destination model
+differs from what the host is configured for, because that failure would
+otherwise surface only as a missing backup days later.
 
 For the broader appliance direction, the project now distinguishes between `full-node` and `zero-appliance` deployments. A Pi Zero 2 W is being treated as a constrained profile that needs explicit hardware validation rather than assumed feature parity. See [docs/appliance-profiles.md](docs/appliance-profiles.md).
 

--- a/munin-backup.service
+++ b/munin-backup.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Munin Memory off-host or mounted-volume backup
+Description=Munin Memory backup (remote host or mounted volume)
 After=network-online.target
 Wants=network-online.target
 
@@ -9,15 +9,42 @@ User=<user>
 # Runs from ~/munin-ops (a dedicated ops dir, NOT a git checkout) so cron never
 # executes code out of a mutable/dev checkout. Populate it with scripts/install-ops.sh.
 ExecStart=<ops-dir>/scripts/backup-to-nas.sh
-# Required: MUNIN_BACKUP_MOUNT must be an active mountpoint and
-# MUNIN_BACKUP_DIR must be a strict child. The script rejects / as the mount
-# root and fails closed for an absent mount.
+# The destination is configured, never hardcoded. Set MUNIN_BACKUP_MODE=remote
+# with MUNIN_BACKUP_HOST + MUNIN_BACKUP_REMOTE_DIR, or MUNIN_BACKUP_MODE=local
+# with MUNIN_BACKUP_MOUNT (an active mountpoint) + MUNIN_BACKUP_DIR (a strict
+# child). With neither configured the script refuses to start rather than
+# writing nowhere. See docs/offsite-backup.md and .env.example.
 EnvironmentFile=-<ops-dir>/.env
 StandardOutput=journal
 StandardError=journal
 
-# Timeouts
-TimeoutStartSec=120
+# Staging deliberately stays on the default /tmp (a tmpfs under PrivateTmp=yes).
+#
+# Disk staging was tried and measured worse on the reference host: its root
+# filesystem is the SD/eMMC boot card at 12.5 MB/s sustained, which turned a
+# 32 s snapshot into a >20 min one and would have written ~675 GB/year to the
+# card the OS boots from. Trading a transient ~2 GB of RAM for that is a bad
+# deal, so tmpfs wins there.
+#
+# The residual risk is that the snapshot must fit the tmpfs (~50% of RAM); at
+# the reference host's size and ~17 MB/day of growth that is roughly four months
+# away. backup-to-nas.sh preflights free space and fails loudly with an
+# actionable message rather than dying half-written on ENOSPC. If a fast disk
+# ever backs this host, point MUNIN_BACKUP_STAGING at it.
+
+# Timeouts.
+#
+# This was 120 s, and the job had quietly grown into it: measured on a 1.85 GB
+# database, a run costs ~32 s (sqlite3 .backup) + ~52 s (PRAGMA
+# integrity_check) + ~19 s (rsync) ~= 105 s. It crossed 120 s and then failed
+# silently every night from 2026-07-17 until it was found four days later.
+#
+# Runtime scales with database size at roughly 31 s per GB, and the database
+# grows steadily, so any snug ceiling merely reschedules that outage. 1800 s is
+# deliberately far beyond need: this is a nightly oneshot, so a wide timeout
+# costs nothing, while a tight one costs a silent backup gap. The timer's own
+# scheduling — not this value — is what bounds the job.
+TimeoutStartSec=1800
 
 # Hardening (lighter than the main service — just needs network + sqlite3)
 NoNewPrivileges=yes

--- a/scripts/backup-to-nas.sh
+++ b/scripts/backup-to-nas.sh
@@ -307,9 +307,17 @@ if [ "$MODE" = "remote" ]; then
     # Post-transfer verification. rsync exiting 0 does not by itself prove the
     # expected bytes are readable at the destination under the expected name —
     # verify what actually landed rather than trusting the exit status.
+    # The remote may be GNU or BSD. Ask for the GNU form first and fall back,
+    # then REQUIRE a bare integer: GNU's `-f` means --file-system, so a BSD-style
+    # probe landing on a GNU host prints a filesystem report rather than failing
+    # cleanly. Comparing that against a byte count would be comparing garbage —
+    # demand a number and fail closed otherwise.
     REMOTE_BYTES=$("$SSH_BIN" "$BACKUP_HOST" \
         "stat -c '%s' '${BACKUP_REMOTE_DIR}/${FILENAME}' 2>/dev/null || stat -f '%z' '${BACKUP_REMOTE_DIR}/${FILENAME}' 2>/dev/null" || true)
     REMOTE_BYTES=$(printf '%s' "$REMOTE_BYTES" | tr -d '[:space:]')
+    case "$REMOTE_BYTES" in
+        ''|*[!0-9]*) REMOTE_BYTES="" ;;
+    esac
     if [ -z "$REMOTE_BYTES" ] || [ "$REMOTE_BYTES" != "$SNAPSHOT_BYTES" ]; then
         echo "ERROR: backup did not land intact on ${BACKUP_HOST}." >&2
         echo "       expected ${SNAPSHOT_BYTES} bytes, destination reports '${REMOTE_BYTES:-<missing>}'." >&2

--- a/scripts/backup-to-nas.sh
+++ b/scripts/backup-to-nas.sh
@@ -1,66 +1,142 @@
 #!/bin/bash
 set -euo pipefail
 
-# Munin Memory SQLite backup to an explicitly configured off-host or mounted directory
-# Uses sqlite3 .backup for a consistent snapshot (no file locking issues)
-# Filename format: memory-YYYY-MM-DD-HHMM.db (Heimdall parses this for freshness)
+# Munin Memory SQLite backup.
+#
+# Uses sqlite3 .backup for a consistent snapshot (no file locking issues).
+# Filename format: memory-YYYY-MM-DD-HHMM.db (Heimdall parses this for freshness).
+#
+# TWO DESTINATION MODES, selected by configuration — never hardcoded, so this
+# script stays publication-safe and every installation-specific value lives in
+# the ops .env:
+#
+#   remote  push the snapshot to another host over ssh/rsync
+#           needs MUNIN_BACKUP_HOST and MUNIN_BACKUP_REMOTE_DIR
+#   local   write the snapshot to a locally mounted volume
+#           needs MUNIN_BACKUP_MOUNT and MUNIN_BACKUP_DIR
+#
+# Set MUNIN_BACKUP_MODE explicitly, or leave it unset and it is inferred from
+# whichever pair is configured. Configuring neither is a hard error: a backup
+# that silently writes nowhere is worse than one that refuses to start.
+#
+# Both modes share the free-space preflight, snapshot, integrity check, GFS
+# retention, and post-write verification. Both verify what actually landed at
+# the destination rather than trusting the transfer's exit status.
 
-DB="${MUNIN_BACKUP_DB:-${HOME}/.munin-memory/memory.db}"
-BACKUP_DIR="${MUNIN_BACKUP_DIR:-}"
-if [ -z "$BACKUP_DIR" ]; then
-    echo "ERROR: MUNIN_BACKUP_DIR is required and must name an explicit off-host or mounted backup directory." >&2
-    exit 64
-fi
+# ── Configuration ────────────────────────────────────────────────────────────
+# MUNIN_DB is the historical name for the source database; keep accepting it so
+# an existing ops .env does not silently start backing up the wrong file.
+DB="${MUNIN_BACKUP_DB:-${MUNIN_DB:-${HOME}/.munin-memory/memory.db}}"
+
+# Staging defaults to /tmp, which under the unit's PrivateTmp=yes is a tmpfs.
+# Override with MUNIN_BACKUP_STAGING when a host has fast disk to spare — but
+# read the rationale in munin-backup.service before pointing this at an SD card.
+STAGING_DIR="${MUNIN_BACKUP_STAGING:-/tmp}"
+
+BACKUP_HOST="${MUNIN_BACKUP_HOST:-}"
+BACKUP_REMOTE_DIR="${MUNIN_BACKUP_REMOTE_DIR:-}"
 BACKUP_MOUNT="${MUNIN_BACKUP_MOUNT:-}"
-if [ -z "$BACKUP_MOUNT" ]; then
-    echo "ERROR: MUNIN_BACKUP_MOUNT is required and must name the mounted backup filesystem root." >&2
-    exit 64
-fi
+BACKUP_DIR="${MUNIN_BACKUP_DIR:-}"
+MODE="${MUNIN_BACKUP_MODE:-}"
+
 MOUNTPOINT_BIN="${MUNIN_MOUNTPOINT_BIN:-mountpoint}"
-if ! command -v "$MOUNTPOINT_BIN" >/dev/null 2>&1; then
-    echo "ERROR: mountpoint checker not found: $MOUNTPOINT_BIN" >&2
+SSH_BIN="${MUNIN_SSH_BIN:-ssh}"
+RSYNC_BIN="${MUNIN_RSYNC_BIN:-rsync}"
+
+KEEP_DAILY="${MUNIN_BACKUP_KEEP_DAILY:-14}"
+KEEP_SUNDAYS="${MUNIN_BACKUP_KEEP_SUNDAYS:-4}"
+
+# ── Mode resolution ──────────────────────────────────────────────────────────
+if [ -z "$MODE" ]; then
+    if [ -n "$BACKUP_HOST" ]; then
+        MODE="remote"
+    elif [ -n "$BACKUP_MOUNT" ] || [ -n "$BACKUP_DIR" ]; then
+        MODE="local"
+    else
+        echo "ERROR: no backup destination is configured." >&2
+        echo "       Set MUNIN_BACKUP_MODE=remote with MUNIN_BACKUP_HOST and" >&2
+        echo "       MUNIN_BACKUP_REMOTE_DIR, or MUNIN_BACKUP_MODE=local with" >&2
+        echo "       MUNIN_BACKUP_MOUNT and MUNIN_BACKUP_DIR." >&2
+        exit 64
+    fi
+fi
+
+case "$MODE" in
+    remote|local) ;;
+    *) echo "ERROR: MUNIN_BACKUP_MODE must be 'remote' or 'local', got '${MODE}'." >&2; exit 64 ;;
+esac
+
+if [ "$MODE" = "remote" ]; then
+    [ -n "$BACKUP_HOST" ] || { echo "ERROR: MUNIN_BACKUP_MODE=remote requires MUNIN_BACKUP_HOST." >&2; exit 64; }
+    [ -n "$BACKUP_REMOTE_DIR" ] || { echo "ERROR: MUNIN_BACKUP_MODE=remote requires MUNIN_BACKUP_REMOTE_DIR." >&2; exit 64; }
+    case "$BACKUP_REMOTE_DIR" in
+        /*) ;;
+        *) echo "ERROR: MUNIN_BACKUP_REMOTE_DIR must be an absolute path." >&2; exit 64 ;;
+    esac
+else
+    [ -n "$BACKUP_DIR" ] || { echo "ERROR: MUNIN_BACKUP_MODE=local requires MUNIN_BACKUP_DIR." >&2; exit 64; }
+    [ -n "$BACKUP_MOUNT" ] || { echo "ERROR: MUNIN_BACKUP_MODE=local requires MUNIN_BACKUP_MOUNT." >&2; exit 64; }
+    command -v "$MOUNTPOINT_BIN" >/dev/null 2>&1 || { echo "ERROR: mountpoint checker not found: $MOUNTPOINT_BIN" >&2; exit 69; }
+
+    # Both paths must be absolute and lexically normalized. Rejecting dot
+    # segments prevents a configured child path from escaping the mount root.
+    case "$BACKUP_MOUNT" in /*) ;; *) echo "ERROR: MUNIN_BACKUP_MOUNT must be an absolute path." >&2; exit 64 ;; esac
+    case "$BACKUP_DIR" in /*) ;; *) echo "ERROR: MUNIN_BACKUP_DIR must be an absolute path." >&2; exit 64 ;; esac
+    case "/${BACKUP_MOUNT#/}/" in *"/../"*|*"/./"*) echo "ERROR: MUNIN_BACKUP_MOUNT must not contain dot path segments." >&2; exit 64 ;; esac
+    case "/${BACKUP_DIR#/}/" in *"/../"*|*"/./"*) echo "ERROR: MUNIN_BACKUP_DIR must not contain dot path segments." >&2; exit 64 ;; esac
+
+    while [ "$BACKUP_MOUNT" != "/" ] && [ "${BACKUP_MOUNT%/}" != "$BACKUP_MOUNT" ]; do BACKUP_MOUNT="${BACKUP_MOUNT%/}"; done
+    while [ "$BACKUP_DIR" != "/" ] && [ "${BACKUP_DIR%/}" != "$BACKUP_DIR" ]; do BACKUP_DIR="${BACKUP_DIR%/}"; done
+    if [ "$BACKUP_MOUNT" = "/" ]; then
+        echo "ERROR: MUNIN_BACKUP_MOUNT must not be /; configure a dedicated mounted filesystem." >&2
+        exit 64
+    fi
+    case "$BACKUP_DIR" in
+        "$BACKUP_MOUNT"/*) ;;
+        "$BACKUP_MOUNT") echo "ERROR: MUNIN_BACKUP_DIR must be a child of MUNIN_BACKUP_MOUNT, not the mount root itself." >&2; exit 64 ;;
+        *) echo "ERROR: MUNIN_BACKUP_DIR must be inside MUNIN_BACKUP_MOUNT." >&2; exit 64 ;;
+    esac
+fi
+
+TIMESTAMP=$(date -u +%Y-%m-%d-%H%M)
+FILENAME="memory-${TIMESTAMP}.db"
+LOCAL_TMP="${STAGING_DIR}/${FILENAME}"
+
+# Remove the staging snapshot on EVERY exit path, not just the successful one,
+# and take sqlite's sidecars with it: `.backup` leaves a <file>-journal (and can
+# leave -wal/-shm) next to the snapshot, so removing only $LOCAL_TMP strands
+# them. Observed for real — an interrupted run left an orphaned -journal behind.
+trap 'rm -f "$LOCAL_TMP" "${LOCAL_TMP}-journal" "${LOCAL_TMP}-wal" "${LOCAL_TMP}-shm"' EXIT
+
+# ── Portable stat ────────────────────────────────────────────────────────────
+# The flavour is detected ONCE and never mixed: GNU spells the format `-c`,
+# while GNU's `-f` means --file-system, so a BSD-style `stat -f '%d' path` on
+# GNU treats '%d' as a filename and reports filesystem status instead of a
+# device ID. Falling back across flavours would compare the wrong value rather
+# than fail honestly.
+if stat -c '%d' . >/dev/null 2>&1; then
+    STAT_FLAVOR="gnu"
+elif stat -f '%d' . >/dev/null 2>&1; then
+    STAT_FLAVOR="bsd"
+else
+    echo "ERROR: no usable stat(1) flavour for backup verification." >&2
     exit 69
 fi
 
-# Both paths must be absolute and lexically normalized. Rejecting dot segments
-# prevents a configured child path from escaping the verified mount root.
-case "$BACKUP_MOUNT" in
-    /*) ;;
-    *) echo "ERROR: MUNIN_BACKUP_MOUNT must be an absolute path." >&2; exit 64 ;;
-esac
-case "$BACKUP_DIR" in
-    /*) ;;
-    *) echo "ERROR: MUNIN_BACKUP_DIR must be an absolute path." >&2; exit 64 ;;
-esac
-case "/${BACKUP_MOUNT#/}/" in
-    *"/../"*|*"/./"*) echo "ERROR: MUNIN_BACKUP_MOUNT must not contain dot path segments." >&2; exit 64 ;;
-esac
-case "/${BACKUP_DIR#/}/" in
-    *"/../"*|*"/./"*) echo "ERROR: MUNIN_BACKUP_DIR must not contain dot path segments." >&2; exit 64 ;;
-esac
+device_id() {
+    if [ "$STAT_FLAVOR" = "gnu" ]; then stat -c '%d' "$1" 2>/dev/null; else stat -f '%d' "$1" 2>/dev/null; fi
+}
 
-# Normalize trailing slashes before enforcing containment.
-while [ "$BACKUP_MOUNT" != "/" ] && [ "${BACKUP_MOUNT%/}" != "$BACKUP_MOUNT" ]; do
-    BACKUP_MOUNT="${BACKUP_MOUNT%/}"
-done
-while [ "$BACKUP_DIR" != "/" ] && [ "${BACKUP_DIR%/}" != "$BACKUP_DIR" ]; do
-    BACKUP_DIR="${BACKUP_DIR%/}"
-done
-if [ "$BACKUP_MOUNT" = "/" ]; then
-    echo "ERROR: MUNIN_BACKUP_MOUNT must not be /; configure a dedicated mounted filesystem." >&2
-    exit 64
-fi
-case "$BACKUP_DIR" in
-    "$BACKUP_MOUNT"/*) ;;
-    "$BACKUP_MOUNT") echo "ERROR: MUNIN_BACKUP_DIR must be a child of MUNIN_BACKUP_MOUNT, not the mount root itself." >&2; exit 64 ;;
-    *) echo "ERROR: MUNIN_BACKUP_DIR must be inside MUNIN_BACKUP_MOUNT." >&2; exit 64 ;;
-esac
+size_bytes() {
+    if [ "$STAT_FLAVOR" = "gnu" ]; then stat -c '%s' "$1" 2>/dev/null; else stat -f '%z' "$1" 2>/dev/null; fi
+}
 
-# Lexical containment above is necessary but not sufficient: a symlink anywhere
-# between the verified mount root and the destination resolves outside the mount,
-# and both mkdir and install follow it. Without this check the job can report a
-# successful mounted-volume backup while writing the plaintext database elsewhere
-# on the system.
+# ── Local-mode destination guards ────────────────────────────────────────────
+# Lexical containment is necessary but not sufficient: a symlink anywhere
+# between the verified mount root and the destination resolves outside the
+# mount, and both mkdir and install follow it. Without this the job can report a
+# successful mounted-volume backup while writing the plaintext database
+# elsewhere on the system.
 assert_no_symlink_components() {
     if [ -L "$BACKUP_MOUNT" ]; then
         echo "ERROR: MUNIN_BACKUP_MOUNT is a symlink and cannot be verified as a mount root: $BACKUP_MOUNT" >&2
@@ -72,11 +148,7 @@ assert_no_symlink_components() {
     # Manual split (no `set --`) so path segments are never glob-expanded.
     while [ -n "$rest" ]; do
         segment="${rest%%/*}"
-        if [ "$segment" = "$rest" ]; then
-            rest=""
-        else
-            rest="${rest#*/}"
-        fi
+        if [ "$segment" = "$rest" ]; then rest=""; else rest="${rest#*/}"; fi
         [ -z "$segment" ] && continue
         current="$current/$segment"
         if [ -L "$current" ]; then
@@ -87,10 +159,10 @@ assert_no_symlink_components() {
 }
 
 # Re-validate the mount immediately before every destination mutation. The
-# preflight below runs before a potentially slow SQLite snapshot, and a
-# removable/NAS mount can drop during that window — after which mkdir would
-# recreate the destination on the root filesystem and the backup would silently
-# succeed locally.
+# preflight runs before a potentially slow SQLite snapshot, and a removable/NAS
+# mount can drop during that window — after which mkdir would recreate the
+# destination on the root filesystem and the backup would silently succeed
+# locally.
 assert_mount_active() {
     if ! "$MOUNTPOINT_BIN" -q -- "$BACKUP_MOUNT"; then
         echo "ERROR: MUNIN_BACKUP_MOUNT is $1: $BACKUP_MOUNT" >&2
@@ -98,34 +170,11 @@ assert_mount_active() {
     fi
 }
 
-# Filesystem identity of a path. The stat flavour is detected ONCE and never
-# mixed: GNU spells the format `-c`, while GNU's `-f` means --file-system, so a
-# BSD-style `stat -f '%d' path` on GNU treats '%d' as a filename and reports
-# filesystem status instead of a device ID. Falling back across flavours would
-# therefore compare the wrong value rather than fail honestly.
-if stat -c '%d' . >/dev/null 2>&1; then
-    STAT_FLAVOR="gnu"
-elif stat -f '%d' . >/dev/null 2>&1; then
-    STAT_FLAVOR="bsd"
-else
-    echo "ERROR: no usable stat(1) flavour for backup device verification." >&2
-    exit 69
-fi
-
-device_id() {
-    if [ "$STAT_FLAVOR" = "gnu" ]; then
-        stat -c '%d' "$1" 2>/dev/null
-    else
-        stat -f '%d' "$1" 2>/dev/null
-    fi
-}
-
 # Bind the destination to the mounted filesystem's identity, not just to a path
-# string, so a nested mount or a race that leaves the path resolving elsewhere is
-# caught before the database is written.
-# Guarded assignments: a bare `dev=$(device_id ...)` would abort at the
-# assignment under `set -e`, skipping the actionable message below and making a
-# transient stat failure look like a silent service exit.
+# string, so a nested mount or a race that leaves the path resolving elsewhere
+# is caught before the database is written. Guarded assignments: a bare
+# `dev=$(device_id ...)` would abort at the assignment under `set -e`, skipping
+# the actionable message below.
 assert_dest_on_mounted_fs() {
     local mount_dev dest_dev
     if ! mount_dev=$(device_id "$BACKUP_MOUNT") || [ -z "$mount_dev" ]; then
@@ -142,111 +191,89 @@ assert_dest_on_mounted_fs() {
     fi
 }
 
-# This check is deliberately before sqlite3 and mkdir. If a removable/NAS mount
-# disappears, mkdir must never recreate the destination on the root filesystem.
-if ! "$MOUNTPOINT_BIN" -q -- "$BACKUP_MOUNT"; then
-    echo "ERROR: MUNIN_BACKUP_MOUNT is not an active mountpoint: $BACKUP_MOUNT" >&2
-    exit 69
+echo "$(date -Iseconds) Starting Munin backup (mode=${MODE})..."
+
+if [ "$MODE" = "local" ]; then
+    # Deliberately before sqlite3 and mkdir. If a removable/NAS mount
+    # disappears, mkdir must never recreate the destination on the root fs.
+    if ! "$MOUNTPOINT_BIN" -q -- "$BACKUP_MOUNT"; then
+        echo "ERROR: MUNIN_BACKUP_MOUNT is not an active mountpoint: $BACKUP_MOUNT" >&2
+        exit 69
+    fi
+    assert_no_symlink_components
 fi
-assert_no_symlink_components
-TIMESTAMP=$(date -u +%Y-%m-%d-%H%M)
-FILENAME="memory-${TIMESTAMP}.db"
-LOCAL_TMP=$(mktemp "${TMPDIR:-/tmp}/munin-memory-backup.XXXXXX.db")
-trap 'rm -f "$LOCAL_TMP"' EXIT
 
-echo "$(date -Iseconds) Starting Munin backup..."
-
-# 1. Create a consistent snapshot using sqlite3 .backup
-sqlite3 "$DB" ".backup $LOCAL_TMP"
-
-# 2. Verify integrity of the backup
-INTEGRITY=$(sqlite3 "$LOCAL_TMP" "PRAGMA integrity_check;" 2>&1)
-if [ "$INTEGRITY" != "ok" ]; then
-    echo "ERROR: Integrity check failed: $INTEGRITY" >&2
-    rm -f "$LOCAL_TMP"
+# ── 0. Preflight: staging free space ─────────────────────────────────────────
+# The snapshot is a full copy of the DB, so staging needs room for it. Fail
+# loudly and immediately rather than writing most of a snapshot and dying on
+# ENOSPC — a half-run that reports failure is far cheaper to diagnose than one
+# that fails 90% of the way through a long job.
+DB_BYTES=$(size_bytes "$DB")
+if [ -z "$DB_BYTES" ]; then
+    echo "ERROR: cannot stat the source database: $DB" >&2
+    exit 66
+fi
+DB_KB=$(( DB_BYTES / 1024 ))
+AVAIL_KB=$(df -Pk "$STAGING_DIR" | awk 'NR==2 {print $4}')
+NEED_KB=$(( DB_KB * 12 / 10 ))   # snapshot + 20% headroom
+if [ "$AVAIL_KB" -lt "$NEED_KB" ]; then
+    echo "ERROR: staging dir ${STAGING_DIR} has ${AVAIL_KB} KB free but the" >&2
+    echo "       snapshot needs ~${NEED_KB} KB (database is ${DB_KB} KB)." >&2
+    echo "       Point MUNIN_BACKUP_STAGING at a location with more room, or" >&2
+    echo "       shrink the database. Refusing to start a doomed snapshot." >&2
     exit 1
 fi
 
-# 3. Copy to the configured directory. It may be a local disk or a mounted NAS.
-#    Revalidate immediately before each mutation — the snapshot above is slow
-#    enough for a mount to disappear, and for a symlink to be planted, after the
-#    preflight checks passed.
-assert_mount_active "no longer an active mountpoint"
-assert_no_symlink_components
-mkdir -p "$BACKUP_DIR"
-assert_mount_active "no longer an active mountpoint"
-assert_no_symlink_components
-assert_dest_on_mounted_fs
-install -m 600 "$LOCAL_TMP" "$BACKUP_DIR/$FILENAME"
+# ── 1. Consistent snapshot ───────────────────────────────────────────────────
+sqlite3 "$DB" ".backup $LOCAL_TMP"
 
-# Post-write verification. Path-based check-then-use cannot be made atomic in
-# shell, so a narrow race remains between the last check and `install`. Verify
-# where the file ACTUALLY landed and remove it if it is not on the mounted
-# filesystem: a wrong-location write then becomes a loud failure instead of a
-# silently "successful" backup sitting on the root filesystem.
-written_dev=""
-mount_dev_now=""
-written_dev=$(device_id "$BACKUP_DIR/$FILENAME") || true
-mount_dev_now=$(device_id "$BACKUP_MOUNT") || true
-if [ -z "$written_dev" ] || [ "$written_dev" != "$mount_dev_now" ] \
-   || ! "$MOUNTPOINT_BIN" -q -- "$BACKUP_MOUNT"; then
-    rm -f "$BACKUP_DIR/$FILENAME"
-    echo "ERROR: backup did not land on the mounted filesystem; removed $BACKUP_DIR/$FILENAME" >&2
-    exit 69
+# ── 2. Verify snapshot integrity ─────────────────────────────────────────────
+INTEGRITY=$(sqlite3 "$LOCAL_TMP" "PRAGMA integrity_check;" 2>&1)
+if [ "$INTEGRITY" != "ok" ]; then
+    echo "ERROR: Integrity check failed: $INTEGRITY" >&2
+    exit 1  # staging snapshot is removed by the EXIT trap
 fi
+SNAPSHOT_BYTES=$(size_bytes "$LOCAL_TMP")
 
-# 4. Cleanup local temp
-rm -f "$LOCAL_TMP"
-
-# 5. Prune old backups — GFS retention:
-#    - keep the 14 most recent daily snapshots
-#    - plus the 4 most recent Sunday snapshots (rolling monthly coverage)
+# ── 3. GFS retention, applied identically at either destination ──────────────
+# Keep the N most recent daily snapshots plus the M most recent Sunday ones.
 #
-# SIGPIPE-safety: the old prune used `ls -1t ... | head -n N`. Under
+# SIGPIPE-safety: an earlier prune used `ls -1t ... | head -n N`. Under
 # `set -o pipefail`, `head` closes the pipe after N lines, `ls` keeps writing,
 # gets SIGPIPE, and the pipeline exit status becomes 141 — which `set -e` then
-# treats as a fatal error. The rsync had already succeeded, but the service
-# reported failure nightly and retention never ran (dailies piled up). The fix:
-# read the full `ls` output into a bash array (no live pipe for a producer to
-# die on), then slice the first N with array indexing. No `head`, no SIGPIPE.
-(
+# treats as fatal. The transfer had already succeeded, but the service reported
+# failure nightly and retention never ran (dailies piled up). Read the full `ls`
+# output into an array instead — no live pipe for a producer to die on.
+#
+# `ls -1 | sort -r` rather than `ls -1t`: retention follows the date the
+# snapshot REPRESENTS (encoded in the filename), not the file's mtime. A restore
+# or an `rsync --ignore-times` re-sync can give an old-dated file a fresh mtime,
+# which under `-t` would keep a stale snapshot and prune a recent one. Lexical
+# descending = date descending because filenames are zero-padded ISO dates.
+read -r -d '' PRUNE_SCRIPT <<'REMOTE' || true
 set -euo pipefail
-cd "$BACKUP_DIR" || exit 0
+cd "$1" || exit 0
+keep_daily="$2"
+keep_sundays="$3"
 
 keep=$(mktemp)
 trap 'rm -f "$keep"' EXIT
 
-# All snapshots, sorted by encoded filename date (newest first), read into an
-# array via a `while read` loop. Using `ls -1 | sort -r` instead of `ls -1t`
-# ensures retention is based on the date the snapshot *represents* (encoded in
-# the filename as YYYY-MM-DD), not the file's mtime. A backfill/restore/rsync
-# --ignore-times re-sync can touch an old-dated file and give it a fresh mtime,
-# which would make `ls -t` sort it as "newest" and keep a stale snapshot while
-# pruning a genuinely recent one. Lexical descending = date descending because
-# filenames are zero-padded ISO dates. `sort` drains its input fully before
-# emitting output, so there is no live producer for `| head` to truncate — no
-# SIGPIPE possible. (`while read` is portable to bash 3.2; `mapfile` is bash 4+.)
 all=()
 while IFS= read -r line; do
     all+=("$line")
 done < <(ls -1 memory-*.db 2>/dev/null | sort -r || true)
 
-# Keep the 14 most recent daily snapshots (array slice, not `head`). The
-# `${all[@]+...}` guard keeps `set -u` happy when the array is empty.
 i=0
 for f in ${all[@]+"${all[@]}"}; do
-    [ "$i" -ge 14 ] && break
+    [ "$i" -ge "$keep_daily" ] && break
     printf '%s\n' "$f" >> "$keep"
     i=$((i + 1))
 done
 
-# Plus the 4 most recent Sunday snapshots, in newest-first order. A counter +
-# `break` replaces the old `... | head -n 4`, which was the real SIGPIPE source:
-# the loop kept producing after head closed the pipe at the 4th match, and under
-# pipefail that surfaced as exit 141 → `set -e` aborted the whole backup.
 sundays=0
 for f in ${all[@]+"${all[@]}"}; do
-    [ "$sundays" -ge 4 ] && break
+    [ "$sundays" -ge "$keep_sundays" ] && break
     d=$(printf '%s\n' "$f" | sed -nE 's/^memory-([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/p')
     [ -z "$d" ] && continue
     dow=$(date -d "$d" +%u 2>/dev/null || date -j -f "%Y-%m-%d" "$d" +%u 2>/dev/null || echo 0)
@@ -256,8 +283,6 @@ for f in ${all[@]+"${all[@]}"}; do
     fi
 done
 
-# Delete everything not in the keep set. grep -v exits 1 when it matches nothing
-# to delete (all files kept) — guard with `|| true` so that is not fatal.
 prune=()
 while IFS= read -r line; do
     prune+=("$line")
@@ -265,6 +290,71 @@ done < <(ls -1 memory-*.db 2>/dev/null | grep -vxFf "$keep" || true)
 if [ "${#prune[@]}" -gt 0 ]; then
     printf '%s\0' "${prune[@]}" | xargs -0 -r rm --
 fi
-)
+REMOTE
 
-echo "$(date -Iseconds) Backup complete: ${FILENAME}"
+# ── 4. Deliver to the destination ────────────────────────────────────────────
+if [ "$MODE" = "remote" ]; then
+    "$SSH_BIN" "$BACKUP_HOST" "mkdir -p '${BACKUP_REMOTE_DIR}'"
+
+    # No -z: on a fast LAN the sending CPU, not the link, is the bottleneck.
+    # Measured on a 1.85 GB snapshot over this link:
+    #   rsync -az  29 s  (~65 MB/s, gzip-bound)
+    #   rsync -a   19 s  (~100 MB/s, near line rate)
+    # Compression would be right over a slow WAN; here it is a pessimisation.
+    # tests/backup-script.test.ts pins the intent so it is not "tidied" back.
+    "$RSYNC_BIN" -a "$LOCAL_TMP" "${BACKUP_HOST}:${BACKUP_REMOTE_DIR}/${FILENAME}"
+
+    # Post-transfer verification. rsync exiting 0 does not by itself prove the
+    # expected bytes are readable at the destination under the expected name —
+    # verify what actually landed rather than trusting the exit status.
+    REMOTE_BYTES=$("$SSH_BIN" "$BACKUP_HOST" \
+        "stat -c '%s' '${BACKUP_REMOTE_DIR}/${FILENAME}' 2>/dev/null || stat -f '%z' '${BACKUP_REMOTE_DIR}/${FILENAME}' 2>/dev/null" || true)
+    REMOTE_BYTES=$(printf '%s' "$REMOTE_BYTES" | tr -d '[:space:]')
+    if [ -z "$REMOTE_BYTES" ] || [ "$REMOTE_BYTES" != "$SNAPSHOT_BYTES" ]; then
+        echo "ERROR: backup did not land intact on ${BACKUP_HOST}." >&2
+        echo "       expected ${SNAPSHOT_BYTES} bytes, destination reports '${REMOTE_BYTES:-<missing>}'." >&2
+        echo "       Retention was NOT run, so existing snapshots are untouched." >&2
+        exit 69
+    fi
+
+    "$SSH_BIN" "$BACKUP_HOST" "bash -s '${BACKUP_REMOTE_DIR}' '${KEEP_DAILY}' '${KEEP_SUNDAYS}'" <<<"$PRUNE_SCRIPT"
+else
+    # Revalidate immediately before each mutation — the snapshot above is slow
+    # enough for a mount to disappear, and for a symlink to be planted, after
+    # the preflight checks passed.
+    assert_mount_active "no longer an active mountpoint"
+    assert_no_symlink_components
+    mkdir -p "$BACKUP_DIR"
+    assert_mount_active "no longer an active mountpoint"
+    assert_no_symlink_components
+    assert_dest_on_mounted_fs
+    install -m 600 "$LOCAL_TMP" "$BACKUP_DIR/$FILENAME"
+
+    # Post-write verification. Path-based check-then-use cannot be made atomic
+    # in shell, so a narrow race remains between the last check and `install`.
+    # Verify where the file ACTUALLY landed and remove it if it is not on the
+    # mounted filesystem: a wrong-location write becomes a loud failure instead
+    # of a silently "successful" backup sitting on the root filesystem.
+    written_dev=""
+    mount_dev_now=""
+    written_dev=$(device_id "$BACKUP_DIR/$FILENAME") || true
+    mount_dev_now=$(device_id "$BACKUP_MOUNT") || true
+    if [ -z "$written_dev" ] || [ "$written_dev" != "$mount_dev_now" ] \
+       || ! "$MOUNTPOINT_BIN" -q -- "$BACKUP_MOUNT"; then
+        rm -f "$BACKUP_DIR/$FILENAME"
+        echo "ERROR: backup did not land on the mounted filesystem; removed $BACKUP_DIR/$FILENAME" >&2
+        exit 69
+    fi
+
+    written_bytes=$(size_bytes "$BACKUP_DIR/$FILENAME") || true
+    if [ "$written_bytes" != "$SNAPSHOT_BYTES" ]; then
+        rm -f "$BACKUP_DIR/$FILENAME"
+        echo "ERROR: backup is truncated (expected ${SNAPSHOT_BYTES} bytes, wrote ${written_bytes:-0}); removed." >&2
+        exit 69
+    fi
+
+    bash -s "$BACKUP_DIR" "$KEEP_DAILY" "$KEEP_SUNDAYS" <<<"$PRUNE_SCRIPT"
+fi
+
+# ── 5. Staging cleanup is handled by the EXIT trap. ──────────────────────────
+echo "$(date -Iseconds) Backup complete: ${FILENAME} (mode=${MODE})"

--- a/scripts/install-ops.sh
+++ b/scripts/install-ops.sh
@@ -41,10 +41,12 @@ UNITS=(munin-backup.service munin-backup.timer munin-offsite.service munin-offsi
 #
 # Refuse instead, and say exactly what to do. Override deliberately with
 # MUNIN_OPS_ALLOW_MODEL_CHANGE=true once the host's .env matches the new model.
-backup_destination_model() {  # path → remote | local-mount | unknown | absent
+backup_destination_model() {  # path → dual | remote | local-mount | unknown | absent
   local f="$1"
   [[ -f "$f" ]] || { echo "absent"; return; }
-  if grep -qE '^[[:space:]]*NAS_HOST=' "$f"; then
+  if grep -q 'MUNIN_BACKUP_MODE' "$f"; then
+    echo "dual"          # supports both destinations, selected by configuration
+  elif grep -qE '^[[:space:]]*NAS_HOST=' "$f"; then
     echo "remote"
   elif grep -q 'MUNIN_BACKUP_MOUNT' "$f"; then
     echo "local-mount"
@@ -53,14 +55,50 @@ backup_destination_model() {  # path → remote | local-mount | unknown | absent
   fi
 }
 
+# A dual-mode script can serve either destination, but ONLY if this host is
+# actually configured for one. Installing it over a single-mode script whose
+# settings were compiled in — rather than present in the ops .env — would leave
+# the job with no destination and it would refuse to start every night. Check
+# the config before allowing that upgrade.
+ops_env_configures_a_destination() {
+  local env_file="${OPS_DIR}/.env"
+  [[ -f "$env_file" ]] || return 1
+  grep -qE '^[[:space:]]*(MUNIN_BACKUP_MODE|MUNIN_BACKUP_HOST|MUNIN_BACKUP_MOUNT)=' "$env_file"
+}
+
 echo "==> Installing operational scripts into ${OPS_DIR}/scripts (from ${REPO_DIR})"
 install -d -m 755 "${OPS_DIR}/scripts"
 for s in "${SCRIPTS[@]}"; do
   if [[ "$s" == "backup-to-nas.sh" ]]; then
     src_model=$(backup_destination_model "${REPO_DIR}/scripts/${s}")
     dst_model=$(backup_destination_model "${OPS_DIR}/scripts/${s}")
-    if [[ "$dst_model" != "absent" && "$dst_model" != "unknown" &&
-          "$src_model" != "unknown" && "$src_model" != "$dst_model" ]]; then
+    # Upgrading a single-mode deployment to the dual-mode script is allowed, but
+    # only once this host's ops .env names a destination — otherwise the new
+    # script has nothing to write to and refuses to start every night.
+    if [[ "$src_model" == "dual" && "$dst_model" != "dual" && "$dst_model" != "absent" ]]; then
+      if ! ops_env_configures_a_destination; then
+        {
+          echo "ERROR: this host is not configured for the dual-mode backup script."
+          echo "       deployed: ${dst_model}   (destination was compiled into the script)"
+          echo "       incoming: dual           (destination comes from the ops .env)"
+          echo
+          echo "       Add ONE of these to ${OPS_DIR}/.env first:"
+          echo "         MUNIN_BACKUP_MODE=remote"
+          echo "         MUNIN_BACKUP_HOST=<user@host>"
+          echo "         MUNIN_BACKUP_REMOTE_DIR=<absolute path on that host>"
+          echo "       or:"
+          echo "         MUNIN_BACKUP_MODE=local"
+          echo "         MUNIN_BACKUP_MOUNT=<active mountpoint>"
+          echo "         MUNIN_BACKUP_DIR=<a strict child of it>"
+          echo
+          echo "       Nothing has been installed; the deployed backup is untouched."
+        } >&2
+        exit 1
+      fi
+      echo "    backup-to-nas.sh: ${dst_model} -> dual (ops .env names a destination)"
+    elif [[ "$dst_model" != "absent" && "$dst_model" != "unknown" &&
+            "$src_model" != "unknown" && "$src_model" != "dual" &&
+            "$src_model" != "$dst_model" ]]; then
       if [[ "${MUNIN_OPS_ALLOW_MODEL_CHANGE:-}" != "true" ]]; then
         {
           echo "ERROR: refusing to change this host's backup destination model."

--- a/tests/backup-script.test.ts
+++ b/tests/backup-script.test.ts
@@ -17,6 +17,13 @@ function makeScratch(): string {
   return dir;
 }
 
+/** The free-space preflight stats the source DB, so it must exist. */
+function makeDummyDb(dir: string): string {
+  const p = join(dir, "memory.db");
+  writeFileSync(p, "x".repeat(4096));
+  return p;
+}
+
 function writeExecutable(path: string, body: string): string {
   writeFileSync(path, body, { mode: 0o755 });
   return path;
@@ -59,7 +66,7 @@ describe("backup destination safety", () => {
     const result = spawnSync("bash", [backupScript], { env, encoding: "utf8" });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("MUNIN_BACKUP_DIR is required");
+    expect(result.stderr).toContain("no backup destination is configured");
   });
 
   it("fails closed when no mount root is explicitly configured", () => {
@@ -73,7 +80,7 @@ describe("backup destination safety", () => {
     const result = spawnSync("bash", [backupScript], { env, encoding: "utf8" });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("MUNIN_BACKUP_MOUNT is required");
+    expect(result.stderr).toContain("requires MUNIN_BACKUP_MOUNT");
   });
 
   it("fails before snapshotting when the configured mount is not active", () => {
@@ -136,6 +143,107 @@ describe("backup destination safety", () => {
     expect(result.stderr).toContain("must be a child of MUNIN_BACKUP_MOUNT");
   });
 
+  it("infers remote mode and pushes to the configured host", () => {
+    // Remote mode had no test coverage at all before the two destination models
+    // were unified: the deployed script hardcoded its host, so nothing exercised it.
+    const scratch = makeScratch();
+    const binDir = join(scratch, "bin");
+    const landed = join(scratch, "landed");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(landed, { recursive: true });
+    stubSqlite3(binDir);
+
+    // Stub ssh/rsync as local filesystem operations against `landed`.
+    const sshLog = join(scratch, "ssh.log");
+    writeExecutable(
+      join(binDir, "fake-ssh"),
+      `#!/bin/bash\nhost="$1"; shift\necho "$host :: $*" >> "${sshLog}"\nif [[ "$*" == *"stat -c"* ]]; then\n  f=$(printf '%s' "$*" | sed -nE "s/.*'([^']*memory-[^']*\\.db)'.*/\\1/p" | head -1)\n  b=$(basename "$f")\n  stat -f '%z' "${landed}/$b" 2>/dev/null || stat -c '%s' "${landed}/$b" 2>/dev/null\n  exit 0\nfi\nexit 0\n`,
+    );
+    writeExecutable(
+      join(binDir, "fake-rsync"),
+      `#!/bin/bash\nsrc="\${@: -2:1}"; dst="\${@: -1}"\ncp "$src" "${landed}/$(basename "$dst")"\n`,
+    );
+
+    const result = spawnSync("bash", [backupScript], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        HOME: scratch,
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
+        MUNIN_BACKUP_HOST: "backup@example.invalid",
+        MUNIN_BACKUP_REMOTE_DIR: "/srv/backups/munin",
+        MUNIN_SSH_BIN: join(binDir, "fake-ssh"),
+        MUNIN_RSYNC_BIN: join(binDir, "fake-rsync"),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("mode=remote");
+    expect(spawnSync("ls", [landed], { encoding: "utf8" }).stdout).toMatch(/memory-\d{4}-\d{2}-\d{2}-\d{4}\.db/);
+  });
+
+  it("fails when the remote copy does not match the snapshot size", () => {
+    // rsync exiting 0 does not prove the expected bytes are readable at the
+    // destination under the expected name. Verify, do not trust the exit status.
+    const scratch = makeScratch();
+    const binDir = join(scratch, "bin");
+    mkdirSync(binDir, { recursive: true });
+    stubSqlite3(binDir);
+    writeExecutable(join(binDir, "fake-ssh"), `#!/bin/bash\nif [[ "$*" == *"stat -c"* ]]; then echo 1; fi\nexit 0\n`);
+    writeExecutable(join(binDir, "fake-rsync"), `#!/bin/bash\nexit 0\n`);
+
+    const result = spawnSync("bash", [backupScript], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        HOME: scratch,
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
+        MUNIN_BACKUP_HOST: "backup@example.invalid",
+        MUNIN_BACKUP_REMOTE_DIR: "/srv/backups/munin",
+        MUNIN_SSH_BIN: join(binDir, "fake-ssh"),
+        MUNIN_RSYNC_BIN: join(binDir, "fake-rsync"),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("did not land intact");
+    expect(result.stderr).toContain("Retention was NOT run");
+  });
+
+  it("rejects a remote mode that is missing its required configuration", () => {
+    const scratch = makeScratch();
+    const result = spawnSync("bash", [backupScript], {
+      env: {
+        ...process.env,
+        HOME: scratch,
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
+        MUNIN_BACKUP_MODE: "remote",
+      },
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("requires MUNIN_BACKUP_HOST");
+  });
+
+  it("rejects an unknown destination mode instead of guessing", () => {
+    const scratch = makeScratch();
+    const result = spawnSync("bash", [backupScript], {
+      env: { ...process.env, HOME: scratch, MUNIN_BACKUP_MODE: "nas" },
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must be 'remote' or 'local'");
+  });
+
+  it("keeps rsync uncompressed — -z is a pessimisation on a fast LAN", () => {
+    // Pins the intent recorded in the script so it is not "tidied" back to -az.
+    const body = readFileSync(backupScript, "utf8");
+    expect(body).toMatch(/rsync[^\n]*-a\s/);
+    expect(body).not.toMatch(/\$RSYNC_BIN"?\s+-az/);
+  });
+
   it("loads the ops environment file where the explicit destination is configured", () => {
     expect(backupUnit).toContain("EnvironmentFile=-<ops-dir>/.env");
   });
@@ -171,7 +279,7 @@ exit 1
         ...process.env,
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         HOME: scratch,
-        MUNIN_BACKUP_DB: join(scratch, "memory.db"),
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
         MUNIN_BACKUP_DIR: dest,
         MUNIN_BACKUP_MOUNT: mount,
         MUNIN_MOUNTPOINT_BIN: mountpointBin,
@@ -216,7 +324,7 @@ exit 1
         ...process.env,
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         HOME: scratch,
-        MUNIN_BACKUP_DB: join(scratch, "memory.db"),
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
         MUNIN_BACKUP_DIR: dest,
         MUNIN_BACKUP_MOUNT: mount,
         MUNIN_MOUNTPOINT_BIN: mountpointBin,
@@ -249,7 +357,7 @@ exit 1
         ...process.env,
         PATH: `${binDir}:${process.env.PATH ?? ""}`,
         HOME: scratch,
-        MUNIN_BACKUP_DB: join(scratch, "memory.db"),
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
         MUNIN_BACKUP_DIR: join(mount, "escape"),
         MUNIN_BACKUP_MOUNT: mount,
         MUNIN_MOUNTPOINT_BIN: "true",

--- a/tests/backup-script.test.ts
+++ b/tests/backup-script.test.ts
@@ -157,7 +157,7 @@ describe("backup destination safety", () => {
     const sshLog = join(scratch, "ssh.log");
     writeExecutable(
       join(binDir, "fake-ssh"),
-      `#!/bin/bash\nhost="$1"; shift\necho "$host :: $*" >> "${sshLog}"\nif [[ "$*" == *"stat -c"* ]]; then\n  f=$(printf '%s' "$*" | sed -nE "s/.*'([^']*memory-[^']*\\.db)'.*/\\1/p" | head -1)\n  b=$(basename "$f")\n  stat -f '%z' "${landed}/$b" 2>/dev/null || stat -c '%s' "${landed}/$b" 2>/dev/null\n  exit 0\nfi\nexit 0\n`,
+      `#!/bin/bash\nhost="$1"; shift\necho "$host :: $*" >> "${sshLog}"\nif [[ "$*" == *"stat -c"* ]]; then\n  f=$(printf '%s' "$*" | sed -nE "s/.*'([^']*memory-[^']*\\.db)'.*/\\1/p" | head -1)\n  b=$(basename "$f")\n  wc -c < "${landed}/$b" 2>/dev/null | tr -d ' '\n  exit 0\nfi\nexit 0\n`,
     );
     writeExecutable(
       join(binDir, "fake-rsync"),
@@ -191,6 +191,39 @@ describe("backup destination safety", () => {
     mkdirSync(binDir, { recursive: true });
     stubSqlite3(binDir);
     writeExecutable(join(binDir, "fake-ssh"), `#!/bin/bash\nif [[ "$*" == *"stat -c"* ]]; then echo 1; fi\nexit 0\n`);
+    writeExecutable(join(binDir, "fake-rsync"), `#!/bin/bash\nexit 0\n`);
+
+    const result = spawnSync("bash", [backupScript], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        HOME: scratch,
+        MUNIN_BACKUP_DB: makeDummyDb(scratch),
+        MUNIN_BACKUP_HOST: "backup@example.invalid",
+        MUNIN_BACKUP_REMOTE_DIR: "/srv/backups/munin",
+        MUNIN_SSH_BIN: join(binDir, "fake-ssh"),
+        MUNIN_RSYNC_BIN: join(binDir, "fake-rsync"),
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("did not land intact");
+    expect(result.stderr).toContain("Retention was NOT run");
+  });
+
+  it("fails closed when the remote size probe returns non-numeric output", () => {
+    // GNU stat's `-f` means --file-system, so a BSD-style probe on a GNU host
+    // prints a filesystem report instead of failing. Comparing that against a
+    // byte count would compare garbage — demand a bare integer.
+    const scratch = makeScratch();
+    const binDir = join(scratch, "bin");
+    mkdirSync(binDir, { recursive: true });
+    stubSqlite3(binDir);
+    writeExecutable(
+      join(binDir, "fake-ssh"),
+      `#!/bin/bash\nif [[ "$*" == *"stat -c"* ]]; then echo "  File: \\"/srv\\"  ID: 0 Namelen: 255"; fi\nexit 0\n`,
+    );
     writeExecutable(join(binDir, "fake-rsync"), `#!/bin/bash\nexit 0\n`);
 
     const result = spawnSync("bash", [backupScript], {

--- a/tests/install-ops-guard.test.ts
+++ b/tests/install-ops-guard.test.ts
@@ -1,21 +1,25 @@
 /**
- * install-ops.sh must never silently swap a host's backup destination model.
+ * install-ops.sh must never leave a host with a backup that cannot run.
  *
- * backup-to-nas.sh exists in two incompatible forms — push to a remote host over
- * ssh/rsync, or write to a local mounted volume — and a host is provisioned for
- * exactly one. Installing the other does not fail at install time; it fails on
- * the next timer fire, silently, and surfaces days later as a missing off-host
- * copy of the memory database.
+ * backup-to-nas.sh has existed in three shapes: push to a remote host over
+ * ssh/rsync, write to a local mounted volume, and (now) a dual-mode script that
+ * does either based on the ops .env. Installing a shape the host is not
+ * configured for does not fail at install time — it fails on the next timer
+ * fire, silently, and surfaces days later as a missing off-host copy of the
+ * memory database.
+ *
+ * Tests run install-ops.sh out of a SYNTHETIC repo directory so every incoming
+ * shape stays reachable, independent of which one the real repo currently ships.
  */
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const installOps = join(repoRoot, "scripts", "install-ops.sh");
+const realInstallOps = join(repoRoot, "scripts", "install-ops.sh");
 
 const scratch: string[] = [];
 function makeScratch(): string {
@@ -30,68 +34,105 @@ afterEach(() => {
   }
 });
 
-const REMOTE_SCRIPT = `#!/bin/bash\nNAS_HOST="203.0.113.10"\nNAS_DIR="/srv/backups"\nrsync -a "$1" "magnus@\${NAS_HOST}:\${NAS_DIR}/"\n`;
-const LOCAL_SCRIPT = `#!/bin/bash\nBACKUP_MOUNT="\${MUNIN_BACKUP_MOUNT:-}"\ninstall -m 600 "$1" "\$BACKUP_MOUNT/x"\n`;
+const REMOTE = `#!/bin/bash\nNAS_HOST="203.0.113.10"\nrsync -a "$1" "u@\${NAS_HOST}:/srv/b/"\n`;
+const LOCAL = `#!/bin/bash\nBACKUP_MOUNT="\${MUNIN_BACKUP_MOUNT:-}"\ninstall -m 600 "$1" "\$BACKUP_MOUNT/x"\n`;
+const DUAL = `#!/bin/bash\nMODE="\${MUNIN_BACKUP_MODE:-}"\nBACKUP_MOUNT="\${MUNIN_BACKUP_MOUNT:-}"\n`;
 
-/** Stage an ops dir with a deployed backup script of the given model. */
-function stageOpsDir(body: string): string {
+/** A synthetic repo whose backup script has the given shape. */
+function makeRepo(backupBody: string): string {
+  const repo = join(makeScratch(), "repo");
+  mkdirSync(join(repo, "scripts"), { recursive: true });
+  copyFileSync(realInstallOps, join(repo, "scripts", "install-ops.sh"));
+  chmodSync(join(repo, "scripts", "install-ops.sh"), 0o755);
+  for (const [name, body] of [
+    ["backup-to-nas.sh", backupBody],
+    ["offsite-backup.sh", "#!/bin/bash\n"],
+    ["offsite-snapshot.sh", "#!/bin/bash\n"],
+  ] as const) {
+    writeFileSync(join(repo, "scripts", name), body);
+    chmodSync(join(repo, "scripts", name), 0o755);
+  }
+  return repo;
+}
+
+/** An ops dir with a deployed backup script, and optionally a configured .env. */
+function makeOpsDir(deployedBody: string, envBody?: string): string {
   const opsDir = join(makeScratch(), "munin-ops");
   mkdirSync(join(opsDir, "scripts"), { recursive: true });
   const p = join(opsDir, "scripts", "backup-to-nas.sh");
-  writeFileSync(p, body);
+  writeFileSync(p, deployedBody);
   chmodSync(p, 0o755);
+  if (envBody !== undefined) writeFileSync(join(opsDir, ".env"), envBody);
   return opsDir;
 }
 
-function runInstall(opsDir: string, extraEnv: Record<string, string> = {}) {
-  return spawnSync("bash", [installOps], {
+function run(repo: string, opsDir: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync("bash", [join(repo, "scripts", "install-ops.sh")], {
     env: { ...process.env, MUNIN_OPS_DIR: opsDir, ...extraEnv },
     encoding: "utf8",
   });
 }
 
-describe("install-ops.sh backup destination-model guard", () => {
-  it("refuses to replace a remote-model deployment with the local-mount model", () => {
-    // The exact production situation: huginmunin runs the remote model, while
-    // the repo's script had been switched to local-mount. A reinstall would have
-    // left the nightly backup exiting 64 every night.
-    const opsDir = stageOpsDir(REMOTE_SCRIPT);
-    const result = runInstall(opsDir);
+describe("install-ops.sh backup destination guard", () => {
+  it("refuses to swap a remote deployment for a local-mount script", () => {
+    // The original production hazard: the repo's script was local-mount while
+    // the deployed host ran remote and had no mounted volume at all.
+    const r = run(makeRepo(LOCAL), makeOpsDir(REMOTE));
 
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("refusing to change this host's backup destination model");
-    expect(result.stderr).toMatch(/deployed:\s+remote/);
-    expect(result.stderr).toContain("MUNIN_OPS_ALLOW_MODEL_CHANGE=true");
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("refusing to change this host's backup destination model");
+    expect(r.stderr).toMatch(/deployed:\s+remote/);
+    expect(r.stderr).toContain("MUNIN_BACKUP_MOUNT");
+    expect(r.stderr).toContain("NAS_HOST");
   });
 
-  it("aborts before touching sudo or the deployed script", () => {
-    const opsDir = stageOpsDir(REMOTE_SCRIPT);
-    const result = runInstall(opsDir);
+  it("refuses the dual-mode upgrade when the ops .env names no destination", () => {
+    // The dual script reads its destination from the .env. A host whose
+    // destination was compiled into the old script has nothing configured, so
+    // installing dual would leave it refusing to start every night.
+    const r = run(makeRepo(DUAL), makeOpsDir(REMOTE, "MUNIN_LLM_BASE_URL=https://example.invalid\n"));
 
-    // The guard must run in the scripts loop, ahead of the units loop — otherwise
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("not configured for the dual-mode backup script");
+    expect(r.stderr).toContain("MUNIN_BACKUP_HOST=");
+    expect(r.stderr).toContain("MUNIN_BACKUP_MOUNT=");
+  });
+
+  it("allows the dual-mode upgrade once the ops .env names a destination", () => {
+    const r = run(
+      makeRepo(DUAL),
+      makeOpsDir(REMOTE, "MUNIN_BACKUP_MODE=remote\nMUNIN_BACKUP_HOST=u@h\nMUNIN_BACKUP_REMOTE_DIR=/srv/b\n"),
+    );
+
+    expect(r.stderr).not.toContain("not configured for the dual-mode");
+    expect(r.stderr).not.toContain("refusing to change");
+    expect(r.stdout).toContain("remote -> dual");
+  });
+
+  it("aborts before sudo and leaves the deployed script untouched", () => {
+    const opsDir = makeOpsDir(REMOTE);
+    const r = run(makeRepo(LOCAL), opsDir);
+
+    // The guard lives in the scripts loop, ahead of the units loop — otherwise
     // it would prompt for sudo before refusing.
-    expect(result.stdout).not.toContain("Installing systemd units");
-    expect(result.stderr).toContain("the deployed backup is untouched");
-    // The deployed script must still be the remote-model one.
+    expect(r.stdout).not.toContain("Installing systemd units");
+    expect(r.stderr).toContain("the deployed backup is untouched");
     const deployed = spawnSync("cat", [join(opsDir, "scripts", "backup-to-nas.sh")], {
       encoding: "utf8",
     }).stdout;
     expect(deployed).toContain("NAS_HOST=");
   });
 
-  it("names both models and what each requires, so the error is actionable", () => {
-    const result = runInstall(stageOpsDir(REMOTE_SCRIPT));
-
-    expect(result.stderr).toContain("MUNIN_BACKUP_MOUNT");
-    expect(result.stderr).toContain("NAS_HOST");
+  it("does not fire when deployed and incoming already match", () => {
+    const r = run(makeRepo(LOCAL), makeOpsDir(LOCAL));
+    expect(r.stderr).not.toContain("refusing to change");
+    expect(r.stderr).not.toContain("not configured for the dual-mode");
   });
 
-  it("does not fire when the deployed script already uses the incoming model", () => {
-    // Same model on both sides must not trip the guard. Asserted by the absence
-    // of the refusal, not by a successful install — the install proceeds into
-    // sudo territory, which this test deliberately does not reach.
-    const result = runInstall(stageOpsDir(LOCAL_SCRIPT));
-
-    expect(result.stderr).not.toContain("refusing to change");
+  it("does not fire on a first install where nothing is deployed yet", () => {
+    const opsDir = join(makeScratch(), "munin-ops");
+    const r = run(makeRepo(DUAL), opsDir);
+    expect(r.stderr).not.toContain("refusing to change");
+    expect(r.stderr).not.toContain("not configured for the dual-mode");
   });
 });


### PR DESCRIPTION
Supersedes #218. Closes the architecture split behind it.

## The split

`backup-to-nas.sh` existed in two incompatible forms, diverged between repo and production:

| | repository | deployed host |
|---|---|---|
| Destination | local mounted volume | remote NAS over ssh |
| Mechanism | `install -m 600` | `rsync -a` |
| Config | `MUNIN_BACKUP_MOUNT`/`_DIR` | host + path **hardcoded** |

The deployed host has **no local mounted backup volume** and its ops `.env` sets neither variable, so the repo's script exits 64 there. An `install-ops.sh` run would have replaced a just-repaired nightly backup with one that could not run — silently, from its next timer fire. #219 guards that; this fixes it.

## One script, two modes

Destination chosen by `MUNIN_BACKUP_MODE` (`remote`/`local`, inferred when unset). Every installation-specific value moved into the ops `.env`, so the script stays publication-safe with **no hardcoded host**. Configuring neither is a hard error — a backup that writes nowhere is worse than one that refuses to start.

Nothing was dropped from either side:

- **from the deployed script** — staging dir + free-space preflight, EXIT trap that also clears sqlite's `-journal`/`-wal`/`-shm` sidecars, `rsync -a` without `-z` (measured 19s vs 29s gzip-bound)
- **from the repository** — mount revalidation before every mutation, symlink-component rejection, filesystem-identity check, post-write verification with removal on mismatch

**Remote mode gained verification it never had.** `rsync` exiting 0 does not prove the expected bytes are readable at the destination under the expected name, so the destination's byte count is compared against the snapshot — and retention is skipped entirely when that fails, so a bad transfer can never prune good snapshots.

`munin-backup.service` keeps the placeholder templating while taking #218's **120s → 1800s** timeout. The job had grown into the old ceiling (~105s on 1.85 GB) and failed silently nightly from 2026-07-17.

`install-ops.sh` learns a third classification, `dual`, allowed over a single-mode deployment **only once the host's `.env` names a destination** — otherwise the upgrade would reproduce the very failure the guard prevents.

## Verification

Real end-to-end run against the production host and NAS:

```
Starting Munin backup (mode=remote)...
Backup complete: memory-2026-07-21-1925.db (mode=remote)
EXIT=0     real 1m26s
```

- Landed **1,988,239,360 bytes**; size verification passed
- Retention applied (count held at 17); staging left clean, no stranded sidecars
- Also confirmed it fails closed with the host's *current* `.env`: `no backup destination is configured` + exact remedy

Suite: 21 backup/guard tests (5 new remote-mode, incl. a failing-transfer case), 2,348 total pass, lint + both typechecks + build clean, shellcheck clean at warning level.

## Deploy note

Merging alone changes nothing on the host — the guard will refuse until `~/munin-ops/.env` gains `MUNIN_BACKUP_MODE`/`_HOST`/`_REMOTE_DIR`. That `.env` edit must happen first, then `install-ops.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)