### PR TITLE
Prevent global MCP rate limiter from starving concurrent agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,20 @@ MUNIN_LLM_HTTP_REFERER=https://github.com/Magnus-Gille/munin-memory
 # === HTTP Hardening ===
 # Comma-separated extra Host headers to accept (for reverse proxy)
 MUNIN_ALLOWED_HOSTS=
+# Authenticated MCP admission uses a per-caller bucket plus a larger global
+# backstop. All POSTs cost one token, including initialize and tools/list.
+MUNIN_RATE_LIMIT_PER_CALLER_MAX=60
+MUNIN_RATE_LIMIT_GLOBAL_MAX=300
+MUNIN_RATE_LIMIT_WINDOW_MS=60000
+MUNIN_RATE_LIMIT_MAX_CALLERS=1000
+
+# === Optional stdio-to-HTTP bridge settings ===
+# A generated per-process ID is used when this is empty. Set a non-secret stable
+# label only when correlating one bridge across restarts is useful.
+MUNIN_BRIDGE_CLIENT_ID=
+MUNIN_BRIDGE_RATE_LIMIT_RETRIES=2
+MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS=10000
+MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS=250
 
 # Optional Heimdall descriptor metadata (GET /heimdall.json)
 MUNIN_HEIMDALL_NAMESPACE=standalone

--- a/.env.example
+++ b/.env.example
@@ -74,9 +74,11 @@ MUNIN_LLM_HTTP_REFERER=https://github.com/Magnus-Gille/munin-memory
 # === HTTP Hardening ===
 # Comma-separated extra Host headers to accept (for reverse proxy)
 MUNIN_ALLOWED_HOSTS=
-# Authenticated MCP admission uses a per-caller bucket plus a larger global
-# backstop. All POSTs cost one token, including initialize and tools/list.
+# Authenticated MCP admission uses cooperative per-caller buckets, an
+# authenticated-credential aggregate, and a larger global backstop. All POSTs
+# cost one token, including initialize and tools/list.
 MUNIN_RATE_LIMIT_PER_CALLER_MAX=60
+MUNIN_RATE_LIMIT_PER_CREDENTIAL_MAX=180
 MUNIN_RATE_LIMIT_GLOBAL_MAX=300
 MUNIN_RATE_LIMIT_WINDOW_MS=60000
 MUNIN_RATE_LIMIT_MAX_CALLERS=1000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ changelog is the canonical record of what moved.
 
 ### Changed
 
+- **Authenticated MCP admission is isolated per caller instead of using one
+  starvation-prone process bucket.** Each bridge process now supplies a bounded,
+  non-secret caller ID; legacy clients without it retain a credential/session
+  fallback. A larger global token bucket remains as an abuse backstop, caller-local
+  rejections do not consume global tokens, the caller map is bounded, and every
+  authenticated POST—including initialize and tool discovery—still costs one
+  token. HTTP 429 responses now report the actual continuous-refill
+  `Retry-After` plus structured, non-secret limiter attribution and counters. The
+  stdio bridge retries only 429 with server-directed delay, positive jitter, and
+  strict attempt/time budgets; 401/403 remain non-retryable (#231).
+
 - **`backup-to-nas.sh` now supports both destination models in one script.**
   It previously existed in two incompatible forms — push to a remote host over
   ssh/rsync, or write to a local mounted volume — which had diverged between the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,18 @@ changelog is the canonical record of what moved.
 - **Authenticated MCP admission is isolated per caller instead of using one
   starvation-prone process bucket.** Each bridge process now supplies a bounded,
   non-secret caller ID; legacy clients without it retain a credential/session
-  fallback. A larger global token bucket remains as an abuse backstop, caller-local
-  rejections do not consume global tokens, the caller map is bounded, and every
+  fallback. Caller IDs are cooperative partitions rather than authentication
+  boundaries: an authenticated principal/client aggregate bucket prevents caller-ID
+  rotation from bypassing admission, and a larger global bucket remains as the final
+  abuse backstop. Narrower-scope rejections do not consume wider-scope tokens, both
+  identity maps are bounded, and every
   authenticated POST—including initialize and tool discovery—still costs one
   token. HTTP 429 responses now report the actual continuous-refill
   `Retry-After` plus structured, non-secret limiter attribution and counters. The
-  stdio bridge retries only 429 with server-directed delay, positive jitter, and
-  strict attempt/time budgets; 401/403 remain non-retryable (#231).
+  stdio bridge retries only Munin pre-body admission 429s bearing the trusted
+  `X-Munin-Rate-Limit: admission-v1` marker, with server-directed delay, positive
+  jitter, and strict attempt/time budgets. Unmarked upstream/proxy 429s and 401/403
+  remain non-retryable, preventing replay of already-processed mutations (#231).
 
 - **`backup-to-nas.sh` now supports both destination models in one script.**
   It previously existed in two incompatible forms — push to a remote host over

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ All configuration is via environment variables. Copy `.env.example` for a starti
 | `MUNIN_HTTP_HOST` | `127.0.0.1` | HTTP bind address |
 | `MUNIN_API_KEY` | — | Bearer token (required for HTTP mode) |
 | `MUNIN_RATE_LIMIT_PER_CALLER_MAX` | `60` | Authenticated MCP requests admitted per caller per window |
+| `MUNIN_RATE_LIMIT_PER_CREDENTIAL_MAX` | `180` | Aggregate requests admitted per authenticated principal/client credential per window |
 | `MUNIN_RATE_LIMIT_GLOBAL_MAX` | `300` | Process-wide MCP admission backstop per window |
 | `MUNIN_RATE_LIMIT_WINDOW_MS` | `60000` | Continuous-refill admission window in milliseconds |
 | `MUNIN_RATE_LIMIT_MAX_CALLERS` | `1000` | Maximum independently tracked caller buckets; overflow remains capped |
@@ -222,9 +223,17 @@ All three fields are optional; omit `cf_client_id` / `cf_client_secret` if you d
 Each bridge process also sends a generated, non-secret `X-Munin-Client-Id` so
 several agents sharing one legacy bearer credential receive independent admission
 buckets. Set `MUNIN_BRIDGE_CLIENT_ID` to a stable opaque label when correlation
-across bridge restarts is useful. HTTP 429 responses are retried only according to
-the server's `Retry-After`, with positive jitter and bounded defaults: two retries,
-a 10-second total wait budget, and 250 ms maximum jitter. Override these with
+across bridge restarts is useful. The caller ID is a cooperative partition, not an
+authentication boundary: the authenticated principal/client credential retains an
+aggregate bucket, and the process retains a global backstop. Separate OAuth clients
+or agent service tokens provide the strongest isolation.
+
+The bridge retries only a Munin admission 429 marked
+`X-Munin-Rate-Limit: admission-v1`, which is emitted before the request body is
+processed and is therefore safe to replay. Unmarked proxy or upstream 429 responses
+are returned without replay. Marked responses follow the server's `Retry-After`,
+with positive jitter and bounded defaults: two retries, a 10-second total wait
+budget, and 250 ms maximum jitter. Override these with
 `MUNIN_BRIDGE_RATE_LIMIT_RETRIES`, `MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS`, and
 `MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS`. Authentication failures (401/403) and other
 HTTP failures are never retried by this path.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ All configuration is via environment variables. Copy `.env.example` for a starti
 | `MUNIN_HTTP_PORT` | `3030` | HTTP server port |
 | `MUNIN_HTTP_HOST` | `127.0.0.1` | HTTP bind address |
 | `MUNIN_API_KEY` | — | Bearer token (required for HTTP mode) |
+| `MUNIN_RATE_LIMIT_PER_CALLER_MAX` | `60` | Authenticated MCP requests admitted per caller per window |
+| `MUNIN_RATE_LIMIT_GLOBAL_MAX` | `300` | Process-wide MCP admission backstop per window |
+| `MUNIN_RATE_LIMIT_WINDOW_MS` | `60000` | Continuous-refill admission window in milliseconds |
+| `MUNIN_RATE_LIMIT_MAX_CALLERS` | `1000` | Maximum independently tracked caller buckets; overflow remains capped |
 | `MUNIN_MEMORY_DB_PATH` | `~/.munin-memory/memory.db` | Database file location |
 | `MUNIN_PROFILE` | — | Optional hardware preset: `zero-appliance`, `zero-plus`, or `full-node` |
 | `MUNIN_EMBEDDINGS_ENABLED` | `true` | Enable semantic search |
@@ -214,6 +218,16 @@ MUNIN_CREDENTIALS_FILE = "/Users/you/.config/munin/credentials.json"
 The bridge refuses to read a credentials file that is group- or world-accessible — fix perms with `chmod 600`. If both the file and inline env vars are set, the file wins and a stderr warning lists the env vars that were ignored.
 
 All three fields are optional; omit `cf_client_id` / `cf_client_secret` if you don't use Cloudflare Access. Rotate the Bearer token at a cadence that fits your threat model — once a quarter is a reasonable default for a personal deployment.
+
+Each bridge process also sends a generated, non-secret `X-Munin-Client-Id` so
+several agents sharing one legacy bearer credential receive independent admission
+buckets. Set `MUNIN_BRIDGE_CLIENT_ID` to a stable opaque label when correlation
+across bridge restarts is useful. HTTP 429 responses are retried only according to
+the server's `Retry-After`, with positive jitter and bounded defaults: two retries,
+a 10-second total wait budget, and 250 ms maximum jitter. Override these with
+`MUNIN_BRIDGE_RATE_LIMIT_RETRIES`, `MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS`, and
+`MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS`. Authentication failures (401/403) and other
+HTTP failures are never retried by this path.
 
 ## Grimnir ecosystem
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -19,11 +19,17 @@
  *                                 file instead of env vars, keeping secrets
  *                                 out of MCP client config files.
  *   MUNIN_REQUEST_TIMEOUT_MS   — Per-request timeout in ms (default: 60000).
+ *   MUNIN_BRIDGE_CLIENT_ID     — Optional non-secret caller label used for
+ *                                 per-client server admission isolation.
+ *   MUNIN_BRIDGE_RATE_LIMIT_RETRIES — 429 retries (default: 2).
+ *   MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS — Total 429 wait budget (default: 10000).
+ *   MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS — Additive jitter ceiling (default: 250).
  */
 
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -201,34 +207,204 @@ export function isRequest(
   return "id" in msg && "method" in msg && msg.id !== undefined;
 }
 
-export function createFetchWithTimeout(timeoutMs: number): typeof fetch {
+export const DEFAULT_BRIDGE_RATE_LIMIT_RETRIES = 2;
+export const DEFAULT_BRIDGE_RATE_LIMIT_MAX_WAIT_MS = 10_000;
+export const DEFAULT_BRIDGE_RATE_LIMIT_JITTER_MS = 250;
+const DEFAULT_BRIDGE_RATE_LIMIT_FALLBACK_MS = 1_000;
+
+export interface BridgeRateLimitRetryConfig {
+  maxRetries: number;
+  maxWaitMs: number;
+  jitterMs: number;
+}
+
+export interface FetchWithTimeoutOptions {
+  fetchFn?: typeof fetch;
+  sleep?: (delayMs: number, signal: AbortSignal) => Promise<void>;
+  random?: () => number;
+  now?: () => number;
+  log?: (message: string) => void;
+  retry?: BridgeRateLimitRetryConfig;
+}
+
+function nonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined || !/^\d+$/.test(value.trim())) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed <= maximum ? parsed : fallback;
+}
+
+function positiveInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = nonNegativeInteger(value, fallback, maximum);
+  return parsed > 0 ? parsed : fallback;
+}
+
+export function getBridgeRateLimitRetryConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): BridgeRateLimitRetryConfig {
+  return {
+    maxRetries: nonNegativeInteger(
+      env.MUNIN_BRIDGE_RATE_LIMIT_RETRIES,
+      DEFAULT_BRIDGE_RATE_LIMIT_RETRIES,
+      10,
+    ),
+    maxWaitMs: positiveInteger(
+      env.MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS,
+      DEFAULT_BRIDGE_RATE_LIMIT_MAX_WAIT_MS,
+      60_000,
+    ),
+    jitterMs: nonNegativeInteger(
+      env.MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS,
+      DEFAULT_BRIDGE_RATE_LIMIT_JITTER_MS,
+      5000,
+    ),
+  };
+}
+
+export function resolveBridgeClientId(
+  env: NodeJS.ProcessEnv = process.env,
+  uuid: () => string = randomUUID,
+): string {
+  const configured = env.MUNIN_BRIDGE_CLIENT_ID?.trim();
+  if (configured !== undefined && configured.length > 0) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(configured)) {
+      throw new Error(
+        "MUNIN_BRIDGE_CLIENT_ID must be 1-128 characters using only letters, digits, '.', '_', ':', or '-'.",
+      );
+    }
+    return configured;
+  }
+  return `bridge-${uuid()}`;
+}
+
+export function parseRetryAfterMs(
+  value: string | null,
+  now = Date.now(),
+): number | undefined {
+  if (value === null) return undefined;
+  const normalized = value.trim();
+  if (/^\d+$/.test(normalized)) {
+    const seconds = Number(normalized);
+    return Number.isSafeInteger(seconds) ? seconds * 1000 : undefined;
+  }
+  const timestamp = Date.parse(normalized);
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, timestamp - now);
+}
+
+export class BridgeRateLimitRetryExhaustedError extends Error {
+  constructor(
+    attempts: number,
+    waitedMs: number,
+    maxWaitMs: number,
+    nextDelayMs: number,
+  ) {
+    super(
+      `Bridge rate-limit retry exhausted after ${attempts} attempt(s); ` +
+        `waited ${waitedMs}ms of ${maxWaitMs}ms budget and next admission ` +
+        `requires ${nextDelayMs}ms.`,
+    );
+    this.name = "BridgeRateLimitRetryExhaustedError";
+  }
+}
+
+function defaultSleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function createFetchWithTimeout(
+  timeoutMs: number,
+  options: FetchWithTimeoutOptions = {},
+): typeof fetch {
+  const fetchFn = options.fetchFn ?? globalThis.fetch;
+  const sleep = options.sleep ?? defaultSleep;
+  const random = options.random ?? Math.random;
+  const now = options.now ?? Date.now;
+  const retry = options.retry ?? getBridgeRateLimitRetryConfig();
+  const retryLog = options.log ?? (() => {});
+
   return async (input, init) => {
     const controller = new AbortController();
     const timeoutId = setTimeout(
-      () =>
-        controller.abort(
-          new Error(`Request timeout after ${timeoutMs}ms`),
-        ),
+      () => controller.abort(new Error(`Request timeout after ${timeoutMs}ms`)),
       timeoutMs,
     );
 
-    // Propagate the SDK's abort signal to our controller
+    let removeOuterAbort: (() => void) | undefined;
     if (init?.signal) {
       if (init.signal.aborted) {
         controller.abort(init.signal.reason);
       } else {
-        init.signal.addEventListener(
-          "abort",
-          () => controller.abort(init.signal!.reason),
-          { once: true },
-        );
+        const onOuterAbort = () => controller.abort(init.signal!.reason);
+        init.signal.addEventListener("abort", onOuterAbort, { once: true });
+        removeOuterAbort = () =>
+          init.signal?.removeEventListener("abort", onOuterAbort);
       }
     }
 
     try {
-      return await fetch(input, { ...init, signal: controller.signal });
+      const startedAt = now();
+      let retriesUsed = 0;
+      let waitedMs = 0;
+
+      while (true) {
+        const response = await fetchFn(input, {
+          ...init,
+          signal: controller.signal,
+        });
+        if (response.status !== 429) return response;
+
+        const retryAfterMs =
+          parseRetryAfterMs(response.headers.get("Retry-After"), now()) ??
+          DEFAULT_BRIDGE_RATE_LIMIT_FALLBACK_MS;
+        const jitterMs = Math.floor(Math.max(0, random()) * retry.jitterMs);
+        const delayMs = retryAfterMs + jitterMs;
+        await response.body?.cancel().catch(() => {});
+
+        const elapsedMs = Math.max(waitedMs, now() - startedAt);
+        if (
+          retriesUsed >= retry.maxRetries ||
+          elapsedMs + delayMs > retry.maxWaitMs
+        ) {
+          throw new BridgeRateLimitRetryExhaustedError(
+            retriesUsed + 1,
+            elapsedMs,
+            retry.maxWaitMs,
+            delayMs,
+          );
+        }
+
+        retriesUsed += 1;
+        retryLog(
+          `HTTP 429; retry ${retriesUsed}/${retry.maxRetries} in ${delayMs}ms`,
+        );
+        await sleep(delayMs, controller.signal);
+        waitedMs += delayMs;
+      }
     } finally {
       clearTimeout(timeoutId);
+      removeOuterAbort?.();
     }
   };
 }
@@ -520,8 +696,9 @@ async function main(): Promise<void> {
   if (creds.cfClientSecret) {
     authHeaders["CF-Access-Client-Secret"] = creds.cfClientSecret;
   }
+  authHeaders["X-Munin-Client-Id"] = resolveBridgeClientId();
 
-  const fetchWithTimeout = createFetchWithTimeout(requestTimeoutMs);
+  const fetchWithTimeout = createFetchWithTimeout(requestTimeoutMs, { log });
 
   const bridge = createBridge({
     stdio: new StdioServerTransport() as TransportLike,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -373,7 +373,12 @@ export function createFetchWithTimeout(
           ...init,
           signal: controller.signal,
         });
-        if (response.status !== 429) return response;
+        if (
+          response.status !== 429 ||
+          response.headers.get("X-Munin-Rate-Limit") !== "admission-v1"
+        ) {
+          return response;
+        }
 
         const retryAfterMs =
           parseRetryAfterMs(response.headers.get("Retry-After"), now()) ??

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -302,13 +302,13 @@ export function parseRetryAfterMs(
 export class BridgeRateLimitRetryExhaustedError extends Error {
   constructor(
     attempts: number,
-    waitedMs: number,
+    elapsedMs: number,
     maxWaitMs: number,
     nextDelayMs: number,
   ) {
     super(
       `Bridge rate-limit retry exhausted after ${attempts} attempt(s); ` +
-        `waited ${waitedMs}ms of ${maxWaitMs}ms budget and next admission ` +
+        `elapsed ${elapsedMs}ms of ${maxWaitMs}ms budget and next admission ` +
         `requires ${nextDelayMs}ms.`,
     );
     this.name = "BridgeRateLimitRetryExhaustedError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import express from "express";
 import type { Request, Response, NextFunction } from "express";
 import { createServer, IncomingMessage } from "node:http";
-import { timingSafeEqual, randomUUID, createHash } from "node:crypto";
+import { timingSafeEqual, randomUUID, createHash, createHmac, randomBytes } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { initDatabase, nowUTC, pruneRedactionLog, pruneRetrievalAnalytics } from "./db.js";
 import { registerTools } from "./tools.js";
@@ -18,7 +18,27 @@ import { getConfiguredLegacyBearerTransportType, resolveAccessContext } from "./
 import type { AccessContext } from "./access.js";
 import { getLibrarianConfigWarnings, type LibrarianRuntimeConfig } from "./librarian.js";
 import { MuninOAuthProvider, type ExtendedAuthInfo } from "./oauth.js";
+import {
+  McpRateLimiter,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  createRateLimiter,
+  checkRateLimit,
+  getRateLimitConfig,
+  type RateLimitConfig,
+  type RateLimiterState,
+  type RateLimitScope,
+} from "./rate-limit.js";
 import { SERVER_VERSION } from "./version.js";
+
+export {
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  createRateLimiter,
+  checkRateLimit,
+  getRateLimitConfig,
+};
+export type { RateLimitConfig, RateLimiterState };
 
 // Analytics retention (default 90 days)
 function getAnalyticsRetentionDays(): number {
@@ -59,9 +79,6 @@ const issuerUrl = process.env.MUNIN_OAUTH_ISSUER_URL ?? "http://localhost:3030";
 export const MAX_BODY_SIZE = 1 * 1024 * 1024; // 1MB
 const BODY_PARSE_TIMEOUT_MS = 10_000;
 const OAUTH_CLEANUP_INTERVAL_MS = 60 * 1000;
-
-export const RATE_LIMIT_MAX = 60;
-export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 // --- Heimdall self-descriptor ---
 // Served at GET /heimdall.json for Tier-1 discovery by the Heimdall dashboard.
@@ -104,11 +121,6 @@ export type BodyParseResult =
   | { ok: true; body: unknown }
   | { ok: false; reason: "too_large" | "timeout" | "invalid_json" | "error" };
 
-export interface RateLimiterState {
-  tokens: number;
-  lastRefill: number;
-}
-
 export interface RequestLogEntry {
   timestamp: string;
   method: string;
@@ -120,6 +132,15 @@ export interface RequestLogEntry {
   sessionId?: string;
   status: number;
   durationMs: number;
+  rateLimit?: {
+    keyHash: string;
+    keySource: "client" | "session" | "credential";
+    scope: RateLimitScope;
+    retryAfterMs: number;
+    admittedCount: number;
+    throttleCount: number;
+    totalThrottleCount: number;
+  };
   diagnostics?: {
     headers: Record<string, string | string[]>;
     bodySnippet?: string;
@@ -135,6 +156,7 @@ export interface HttpAppOptions {
   httpHost: string;
   httpPort: number;
   requestLogger?: (entry: RequestLogEntry) => void;
+  rateLimitConfig?: RateLimitConfig;
 }
 
 export interface ConsentAuthConfig {
@@ -375,21 +397,6 @@ export function resolveConsentIdentity(
   return null;
 }
 
-export function createRateLimiter(): RateLimiterState {
-  return { tokens: RATE_LIMIT_MAX, lastRefill: Date.now() };
-}
-
-export function checkRateLimit(state: RateLimiterState, now = Date.now()): boolean {
-  const elapsed = now - state.lastRefill;
-  const refill = (elapsed / RATE_LIMIT_WINDOW_MS) * RATE_LIMIT_MAX;
-  state.tokens = Math.min(RATE_LIMIT_MAX, state.tokens + refill);
-  state.lastRefill = now;
-
-  if (state.tokens < 1) return false;
-  state.tokens -= 1;
-  return true;
-}
-
 export function extractMethod(body: unknown): string | undefined {
   if (Array.isArray(body) && body.length > 0) {
     const first = body[0];
@@ -464,6 +471,40 @@ function getSessionHeader(req: Request): string | undefined {
   return header;
 }
 
+function getClientRateLimitHeader(req: Request): string | undefined {
+  const header = req.headers["x-munin-client-id"];
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(normalized)
+    ? normalized
+    : undefined;
+}
+
+function getRateLimitIdentity(
+  req: Request,
+  secret: Buffer,
+): {
+  key: string;
+  keyHash: string;
+  keySource: "client" | "session" | "credential";
+} {
+  const auth = req.auth as ExtendedAuthInfo | undefined;
+  const explicitClient = getClientRateLimitHeader(req);
+  const session = getSessionHeader(req);
+  const keySource = explicitClient
+    ? "client"
+    : session
+      ? "session"
+      : "credential";
+  const caller = explicitClient ?? session ?? "shared";
+  const authScope = `${auth?.principalId ?? ""}:${auth?.clientId ?? "unknown"}`;
+  const key = createHmac("sha256", secret)
+    .update(`${authScope}\0${caller}`)
+    .digest("hex");
+  return { key, keyHash: key.slice(0, 16), keySource };
+}
+
 /**
  * Derive a stable session ID from the caller's identity and a time bucket.
  * When the client doesn't send mcp-session-id, this ensures all requests from
@@ -512,13 +553,17 @@ function attachRequestLogger(
   req: Request,
   res: Response,
   requestLogger: (entry: RequestLogEntry) => void,
-): { setBody: (body: unknown) => void } {
+): {
+  setBody: (body: unknown) => void;
+  setRateLimit: (rateLimit: NonNullable<RequestLogEntry["rateLimit"]>) => void;
+} {
   const startTime = Date.now();
   const sessionId = getSessionHeader(req);
   const authContext = getRequestAuthLogContext(req.auth);
   let rpcMethod: string | undefined;
   let toolName: string | undefined;
   let body: unknown;
+  let rateLimit: RequestLogEntry["rateLimit"];
 
   res.on("finish", () => {
     const entry: RequestLogEntry = {
@@ -531,6 +576,7 @@ function attachRequestLogger(
       sessionId,
       status: res.statusCode,
       durationMs: Date.now() - startTime,
+      rateLimit,
     };
     if (res.statusCode >= 400 && req.path === "/mcp") {
       entry.diagnostics = {
@@ -546,6 +592,9 @@ function attachRequestLogger(
       body = nextBody;
       rpcMethod = extractMethod(nextBody);
       toolName = extractToolName(nextBody);
+    },
+    setRateLimit(nextRateLimit) {
+      rateLimit = nextRateLimit;
     },
   };
 }
@@ -593,10 +642,12 @@ export function createHttpApp(options: HttpAppOptions): { app: express.Express; 
     httpHost,
     httpPort,
     requestLogger = logRequest,
+    rateLimitConfig = getRateLimitConfig(),
   } = options;
   const allowedHosts = buildAllowedHosts(httpHost, httpPort);
   const runtimeConfig = buildLibrarianRuntimeConfig("http", { apiKey, apiKeyDpa, apiKeyConsumer });
-  const rateLimiter = createRateLimiter();
+  const rateLimiter = new McpRateLimiter(rateLimitConfig);
+  const rateLimitSecret = randomBytes(32);
   const consentAuth = getConsentAuthConfig();
   const issuer = new URL(issuerUrl);
   const consentConfigError = validateConsentAuthConfig(consentAuth, issuer);
@@ -754,10 +805,29 @@ export function createHttpApp(options: HttpAppOptions): { app: express.Express; 
   app.post("/mcp", bearerAuth, async (req: Request, res: Response) => {
     const requestLog = attachRequestLogger(req, res, requestLogger);
 
-    // Rate limiting (after auth)
-    if (!checkRateLimit(rateLimiter)) {
-      res.setHeader("Retry-After", "60");
-      res.status(429).json({ error: "Too many requests" });
+    // Rate limiting (after auth). Every authenticated MCP POST costs one token,
+    // including initialize, notifications, tools/list, and malformed bodies.
+    const rateLimitIdentity = getRateLimitIdentity(req, rateLimitSecret);
+    const admission = rateLimiter.admit(rateLimitIdentity.key);
+    if (!admission.allowed) {
+      const retryAfterSeconds = Math.max(1, Math.ceil(admission.retryAfterMs / 1000));
+      requestLog.setRateLimit({
+        keyHash: rateLimitIdentity.keyHash,
+        keySource: rateLimitIdentity.keySource,
+        scope: admission.scope!,
+        retryAfterMs: admission.retryAfterMs,
+        admittedCount: admission.admittedCount,
+        throttleCount: admission.throttleCount,
+        totalThrottleCount: admission.totalThrottleCount,
+      });
+      res.setHeader("Retry-After", String(retryAfterSeconds));
+      res.setHeader("X-Munin-RateLimit-Key", rateLimitIdentity.keyHash);
+      res.status(429).json({
+        error: "Too many requests",
+        retry_after_seconds: retryAfterSeconds,
+        limiter_scope: admission.scope,
+        limiter_key: rateLimitIdentity.keyHash,
+      });
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -485,8 +485,10 @@ function getRateLimitIdentity(
   req: Request,
   secret: Buffer,
 ): {
-  key: string;
-  keyHash: string;
+  callerKey: string;
+  callerKeyHash: string;
+  credentialKey: string;
+  credentialKeyHash: string;
   keySource: "client" | "session" | "credential";
 } {
   const auth = req.auth as ExtendedAuthInfo | undefined;
@@ -499,10 +501,19 @@ function getRateLimitIdentity(
       : "credential";
   const caller = explicitClient ?? session ?? "shared";
   const authScope = `${auth?.principalId ?? ""}:${auth?.clientId ?? "unknown"}`;
-  const key = createHmac("sha256", secret)
+  const credentialKey = createHmac("sha256", secret)
+    .update(authScope)
+    .digest("hex");
+  const callerKey = createHmac("sha256", secret)
     .update(`${authScope}\0${caller}`)
     .digest("hex");
-  return { key, keyHash: key.slice(0, 16), keySource };
+  return {
+    callerKey,
+    callerKeyHash: callerKey.slice(0, 16),
+    credentialKey,
+    credentialKeyHash: credentialKey.slice(0, 16),
+    keySource,
+  };
 }
 
 /**
@@ -808,11 +819,22 @@ export function createHttpApp(options: HttpAppOptions): { app: express.Express; 
     // Rate limiting (after auth). Every authenticated MCP POST costs one token,
     // including initialize, notifications, tools/list, and malformed bodies.
     const rateLimitIdentity = getRateLimitIdentity(req, rateLimitSecret);
-    const admission = rateLimiter.admit(rateLimitIdentity.key);
+    const admission = rateLimiter.admit(
+      rateLimitIdentity.callerKey,
+      rateLimitIdentity.credentialKey,
+    );
     if (!admission.allowed) {
       const retryAfterSeconds = Math.max(1, Math.ceil(admission.retryAfterMs / 1000));
+      const limiterKey =
+        admission.bucketKind === "overflow"
+          ? "overflow"
+          : admission.scope === "credential"
+            ? rateLimitIdentity.credentialKeyHash
+            : admission.scope === "global"
+              ? "global"
+              : rateLimitIdentity.callerKeyHash;
       requestLog.setRateLimit({
-        keyHash: rateLimitIdentity.keyHash,
+        keyHash: limiterKey,
         keySource: rateLimitIdentity.keySource,
         scope: admission.scope!,
         retryAfterMs: admission.retryAfterMs,
@@ -821,12 +843,13 @@ export function createHttpApp(options: HttpAppOptions): { app: express.Express; 
         totalThrottleCount: admission.totalThrottleCount,
       });
       res.setHeader("Retry-After", String(retryAfterSeconds));
-      res.setHeader("X-Munin-RateLimit-Key", rateLimitIdentity.keyHash);
+      res.setHeader("X-Munin-Rate-Limit", "admission-v1");
+      res.setHeader("X-Munin-RateLimit-Key", limiterKey);
       res.status(429).json({
         error: "Too many requests",
         retry_after_seconds: retryAfterSeconds,
         limiter_scope: admission.scope,
-        limiter_key: rateLimitIdentity.keyHash,
+        limiter_key: limiterKey,
       });
       return;
     }

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -289,7 +289,7 @@ export class McpRateLimiter {
         bucketKind: "global",
         retryAfterMs: globalWait,
         remaining: Math.floor(this.global.state.tokens),
-        admittedCount: caller.admitted,
+        admittedCount: this.global.admitted,
         throttleCount: this.global.throttled,
         totalThrottleCount: this.totalThrottled,
       };

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -40,11 +40,14 @@ interface CallerBucket extends BucketWithCounters {
 function positiveInteger(
   value: string | undefined,
   fallback: number,
+  minimum: number,
   maximum: number,
 ): number {
   if (value === undefined || !/^[1-9]\d*$/.test(value.trim())) return fallback;
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed <= maximum ? parsed : fallback;
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum
+    ? parsed
+    : fallback;
 }
 
 export function getRateLimitConfig(
@@ -54,21 +57,25 @@ export function getRateLimitConfig(
     perCallerMax: positiveInteger(
       env.MUNIN_RATE_LIMIT_PER_CALLER_MAX,
       RATE_LIMIT_MAX,
+      1,
       10_000,
     ),
     globalMax: positiveInteger(
       env.MUNIN_RATE_LIMIT_GLOBAL_MAX,
       RATE_LIMIT_GLOBAL_MAX,
+      1,
       100_000,
     ),
     windowMs: positiveInteger(
       env.MUNIN_RATE_LIMIT_WINDOW_MS,
       RATE_LIMIT_WINDOW_MS,
+      1000,
       3_600_000,
     ),
     maxCallers: positiveInteger(
       env.MUNIN_RATE_LIMIT_MAX_CALLERS,
       RATE_LIMIT_MAX_CALLERS,
+      1,
       10_000,
     ),
   };
@@ -130,6 +137,11 @@ export class McpRateLimiter {
     readonly config: RateLimitConfig,
     now = Date.now(),
   ) {
+    for (const [name, value] of Object.entries(config)) {
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`Invalid rate-limit config: ${name} must be a positive integer.`);
+      }
+    }
     this.global = createBucket(config.globalMax, now);
     this.overflow = {
       ...createBucket(config.perCallerMax, now),

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,4 +1,5 @@
 export const RATE_LIMIT_MAX = 60;
+export const RATE_LIMIT_CREDENTIAL_MAX = 180;
 export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 export const RATE_LIMIT_GLOBAL_MAX = 300;
 export const RATE_LIMIT_MAX_CALLERS = 1000;
@@ -10,16 +11,19 @@ export interface RateLimiterState {
 
 export interface RateLimitConfig {
   perCallerMax: number;
+  perCredentialMax: number;
   globalMax: number;
   windowMs: number;
   maxCallers: number;
 }
 
-export type RateLimitScope = "caller" | "global";
+export type RateLimitScope = "caller" | "credential" | "global";
+export type RateLimitBucketKind = "caller" | "credential" | "overflow" | "global";
 
 export interface RateLimitDecision {
   allowed: boolean;
   scope?: RateLimitScope;
+  bucketKind?: RateLimitBucketKind;
   retryAfterMs: number;
   remaining: number;
   admittedCount: number;
@@ -59,6 +63,12 @@ export function getRateLimitConfig(
       RATE_LIMIT_MAX,
       1,
       10_000,
+    ),
+    perCredentialMax: positiveInteger(
+      env.MUNIN_RATE_LIMIT_PER_CREDENTIAL_MAX,
+      RATE_LIMIT_CREDENTIAL_MAX,
+      1,
+      100_000,
     ),
     globalMax: positiveInteger(
       env.MUNIN_RATE_LIMIT_GLOBAL_MAX,
@@ -123,13 +133,16 @@ function createBucket(max: number, now: number): BucketWithCounters {
 }
 
 /**
- * Hierarchical MCP admission control. Each authenticated caller has its own
- * bucket, while a larger process-wide bucket remains as a hard abuse backstop.
- * A caller-local rejection never consumes a global token.
+ * Hierarchical MCP admission control. Each cooperative caller identity has its
+ * own bucket, each authenticated credential has an aggregate bucket, and a
+ * larger process-wide bucket remains as a hard abuse backstop. Rejections at a
+ * narrower scope never consume tokens from wider scopes.
  */
 export class McpRateLimiter {
   private readonly callers = new Map<string, CallerBucket>();
-  private readonly overflow: CallerBucket;
+  private readonly credentials = new Map<string, CallerBucket>();
+  private readonly callerOverflow: CallerBucket;
+  private readonly credentialOverflow: CallerBucket;
   private readonly global: BucketWithCounters;
   private totalThrottled = 0;
 
@@ -143,44 +156,75 @@ export class McpRateLimiter {
       }
     }
     this.global = createBucket(config.globalMax, now);
-    this.overflow = {
+    this.callerOverflow = {
       ...createBucket(config.perCallerMax, now),
       lastSeen: now,
     };
+    this.credentialOverflow = {
+      ...createBucket(config.perCredentialMax, now),
+      lastSeen: now,
+    };
   }
 
-  private getCaller(key: string, now: number): CallerBucket {
-    const existing = this.callers.get(key);
+  private getBoundedBucket(
+    buckets: Map<string, CallerBucket>,
+    overflow: CallerBucket,
+    max: number,
+    key: string,
+    now: number,
+  ): { bucket: CallerBucket; overflow: boolean } {
+    const existing = buckets.get(key);
     if (existing) {
       existing.lastSeen = now;
-      return existing;
+      return { bucket: existing, overflow: false };
     }
 
     const expiryMs = this.config.windowMs * 2;
-    for (const [candidateKey, candidate] of this.callers) {
+    for (const [candidateKey, candidate] of buckets) {
       if (now - candidate.lastSeen >= expiryMs) {
-        this.callers.delete(candidateKey);
+        buckets.delete(candidateKey);
       }
     }
 
-    if (this.callers.size >= this.config.maxCallers) {
-      this.overflow.lastSeen = now;
-      return this.overflow;
+    if (buckets.size >= this.config.maxCallers) {
+      overflow.lastSeen = now;
+      return { bucket: overflow, overflow: true };
     }
 
     const created: CallerBucket = {
-      ...createBucket(this.config.perCallerMax, now),
+      ...createBucket(max, now),
       lastSeen: now,
     };
-    this.callers.set(key, created);
-    return created;
+    buckets.set(key, created);
+    return { bucket: created, overflow: false };
   }
 
-  admit(key: string, now = Date.now()): RateLimitDecision {
-    const caller = this.getCaller(key, now);
+  admit(callerKey: string, credentialKey: string, now = Date.now()): RateLimitDecision {
+    const callerResult = this.getBoundedBucket(
+      this.callers,
+      this.callerOverflow,
+      this.config.perCallerMax,
+      callerKey,
+      now,
+    );
+    const credentialResult = this.getBoundedBucket(
+      this.credentials,
+      this.credentialOverflow,
+      this.config.perCredentialMax,
+      credentialKey,
+      now,
+    );
+    const caller = callerResult.bucket;
+    const credential = credentialResult.bucket;
     refillRateLimit(
       caller.state,
       this.config.perCallerMax,
+      this.config.windowMs,
+      now,
+    );
+    refillRateLimit(
+      credential.state,
+      this.config.perCredentialMax,
       this.config.windowMs,
       now,
     );
@@ -202,10 +246,31 @@ export class McpRateLimiter {
       return {
         allowed: false,
         scope: "caller",
+        bucketKind: callerResult.overflow ? "overflow" : "caller",
         retryAfterMs: callerWait,
         remaining: Math.floor(caller.state.tokens),
         admittedCount: caller.admitted,
         throttleCount: caller.throttled,
+        totalThrottleCount: this.totalThrottled,
+      };
+    }
+
+    const credentialWait = getRateLimitRetryAfterMs(
+      credential.state,
+      this.config.perCredentialMax,
+      this.config.windowMs,
+    );
+    if (credentialWait > 0) {
+      credential.throttled += 1;
+      this.totalThrottled += 1;
+      return {
+        allowed: false,
+        scope: "credential",
+        bucketKind: credentialResult.overflow ? "overflow" : "credential",
+        retryAfterMs: credentialWait,
+        remaining: Math.floor(credential.state.tokens),
+        admittedCount: credential.admitted,
+        throttleCount: credential.throttled,
         totalThrottleCount: this.totalThrottled,
       };
     }
@@ -221,6 +286,7 @@ export class McpRateLimiter {
       return {
         allowed: false,
         scope: "global",
+        bucketKind: "global",
         retryAfterMs: globalWait,
         remaining: Math.floor(this.global.state.tokens),
         admittedCount: caller.admitted,
@@ -231,6 +297,8 @@ export class McpRateLimiter {
 
     caller.state.tokens -= 1;
     caller.admitted += 1;
+    credential.state.tokens -= 1;
+    credential.admitted += 1;
     this.global.state.tokens -= 1;
     this.global.admitted += 1;
     return {

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,237 @@
+export const RATE_LIMIT_MAX = 60;
+export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+export const RATE_LIMIT_GLOBAL_MAX = 300;
+export const RATE_LIMIT_MAX_CALLERS = 1000;
+
+export interface RateLimiterState {
+  tokens: number;
+  lastRefill: number;
+}
+
+export interface RateLimitConfig {
+  perCallerMax: number;
+  globalMax: number;
+  windowMs: number;
+  maxCallers: number;
+}
+
+export type RateLimitScope = "caller" | "global";
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  scope?: RateLimitScope;
+  retryAfterMs: number;
+  remaining: number;
+  admittedCount: number;
+  throttleCount: number;
+  totalThrottleCount: number;
+}
+
+interface BucketWithCounters {
+  state: RateLimiterState;
+  admitted: number;
+  throttled: number;
+}
+
+interface CallerBucket extends BucketWithCounters {
+  lastSeen: number;
+}
+
+function positiveInteger(
+  value: string | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined || !/^[1-9]\d*$/.test(value.trim())) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed <= maximum ? parsed : fallback;
+}
+
+export function getRateLimitConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): RateLimitConfig {
+  return {
+    perCallerMax: positiveInteger(
+      env.MUNIN_RATE_LIMIT_PER_CALLER_MAX,
+      RATE_LIMIT_MAX,
+      10_000,
+    ),
+    globalMax: positiveInteger(
+      env.MUNIN_RATE_LIMIT_GLOBAL_MAX,
+      RATE_LIMIT_GLOBAL_MAX,
+      100_000,
+    ),
+    windowMs: positiveInteger(
+      env.MUNIN_RATE_LIMIT_WINDOW_MS,
+      RATE_LIMIT_WINDOW_MS,
+      3_600_000,
+    ),
+    maxCallers: positiveInteger(
+      env.MUNIN_RATE_LIMIT_MAX_CALLERS,
+      RATE_LIMIT_MAX_CALLERS,
+      10_000,
+    ),
+  };
+}
+
+export function createRateLimiter(now = Date.now()): RateLimiterState {
+  return { tokens: RATE_LIMIT_MAX, lastRefill: now };
+}
+
+function refillRateLimit(
+  state: RateLimiterState,
+  max: number,
+  windowMs: number,
+  now: number,
+): void {
+  const elapsed = Math.max(0, now - state.lastRefill);
+  if (elapsed > 0) {
+    state.tokens = Math.min(max, state.tokens + (elapsed / windowMs) * max);
+    state.lastRefill = now;
+  }
+}
+
+export function getRateLimitRetryAfterMs(
+  state: RateLimiterState,
+  max: number,
+  windowMs: number,
+): number {
+  if (state.tokens >= 1) return 0;
+  return Math.max(1, Math.ceil(((1 - state.tokens) * windowMs) / max));
+}
+
+export function checkRateLimit(state: RateLimiterState, now = Date.now()): boolean {
+  refillRateLimit(state, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS, now);
+  if (state.tokens < 1) return false;
+  state.tokens -= 1;
+  return true;
+}
+
+function createBucket(max: number, now: number): BucketWithCounters {
+  return {
+    state: { tokens: max, lastRefill: now },
+    admitted: 0,
+    throttled: 0,
+  };
+}
+
+/**
+ * Hierarchical MCP admission control. Each authenticated caller has its own
+ * bucket, while a larger process-wide bucket remains as a hard abuse backstop.
+ * A caller-local rejection never consumes a global token.
+ */
+export class McpRateLimiter {
+  private readonly callers = new Map<string, CallerBucket>();
+  private readonly overflow: CallerBucket;
+  private readonly global: BucketWithCounters;
+  private totalThrottled = 0;
+
+  constructor(
+    readonly config: RateLimitConfig,
+    now = Date.now(),
+  ) {
+    this.global = createBucket(config.globalMax, now);
+    this.overflow = {
+      ...createBucket(config.perCallerMax, now),
+      lastSeen: now,
+    };
+  }
+
+  private getCaller(key: string, now: number): CallerBucket {
+    const existing = this.callers.get(key);
+    if (existing) {
+      existing.lastSeen = now;
+      return existing;
+    }
+
+    const expiryMs = this.config.windowMs * 2;
+    for (const [candidateKey, candidate] of this.callers) {
+      if (now - candidate.lastSeen >= expiryMs) {
+        this.callers.delete(candidateKey);
+      }
+    }
+
+    if (this.callers.size >= this.config.maxCallers) {
+      this.overflow.lastSeen = now;
+      return this.overflow;
+    }
+
+    const created: CallerBucket = {
+      ...createBucket(this.config.perCallerMax, now),
+      lastSeen: now,
+    };
+    this.callers.set(key, created);
+    return created;
+  }
+
+  admit(key: string, now = Date.now()): RateLimitDecision {
+    const caller = this.getCaller(key, now);
+    refillRateLimit(
+      caller.state,
+      this.config.perCallerMax,
+      this.config.windowMs,
+      now,
+    );
+    refillRateLimit(
+      this.global.state,
+      this.config.globalMax,
+      this.config.windowMs,
+      now,
+    );
+
+    const callerWait = getRateLimitRetryAfterMs(
+      caller.state,
+      this.config.perCallerMax,
+      this.config.windowMs,
+    );
+    if (callerWait > 0) {
+      caller.throttled += 1;
+      this.totalThrottled += 1;
+      return {
+        allowed: false,
+        scope: "caller",
+        retryAfterMs: callerWait,
+        remaining: Math.floor(caller.state.tokens),
+        admittedCount: caller.admitted,
+        throttleCount: caller.throttled,
+        totalThrottleCount: this.totalThrottled,
+      };
+    }
+
+    const globalWait = getRateLimitRetryAfterMs(
+      this.global.state,
+      this.config.globalMax,
+      this.config.windowMs,
+    );
+    if (globalWait > 0) {
+      this.global.throttled += 1;
+      this.totalThrottled += 1;
+      return {
+        allowed: false,
+        scope: "global",
+        retryAfterMs: globalWait,
+        remaining: Math.floor(this.global.state.tokens),
+        admittedCount: caller.admitted,
+        throttleCount: this.global.throttled,
+        totalThrottleCount: this.totalThrottled,
+      };
+    }
+
+    caller.state.tokens -= 1;
+    caller.admitted += 1;
+    this.global.state.tokens -= 1;
+    this.global.admitted += 1;
+    return {
+      allowed: true,
+      retryAfterMs: 0,
+      remaining: Math.floor(caller.state.tokens),
+      admittedCount: caller.admitted,
+      throttleCount: caller.throttled,
+      totalThrottleCount: this.totalThrottled,
+    };
+  }
+
+  get callerCount(): number {
+    return this.callers.size;
+  }
+}

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -877,7 +877,10 @@ describe("createFetchWithTimeout", () => {
   it("retries a transient 429 before returning the cold-start response", async () => {
     const throttled = new Response("too many requests", {
       status: 429,
-      headers: { "Retry-After": "0" },
+      headers: {
+        "Retry-After": "0",
+        "X-Munin-Rate-Limit": "admission-v1",
+      },
     });
     const recovered = new Response("ok", { status: 200 });
     const mockFetch = vi
@@ -907,7 +910,10 @@ describe("createFetchWithTimeout", () => {
       .mockResolvedValueOnce(
         new Response("limited", {
           status: 429,
-          headers: { "Retry-After": "2" },
+          headers: {
+            "Retry-After": "2",
+            "X-Munin-Rate-Limit": "admission-v1",
+          },
         }),
       )
       .mockResolvedValueOnce(new Response("ok", { status: 200 }));
@@ -933,7 +939,10 @@ describe("createFetchWithTimeout", () => {
     const mockFetch = vi.fn().mockResolvedValue(
       new Response("limited", {
         status: 429,
-        headers: { "Retry-After": "30" },
+        headers: {
+          "Retry-After": "30",
+          "X-Munin-Rate-Limit": "admission-v1",
+        },
       }),
     );
     const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
@@ -955,7 +964,10 @@ describe("createFetchWithTimeout", () => {
     const mockFetch = vi.fn().mockImplementation(async () =>
       new Response("limited", {
         status: 429,
-        headers: { "Retry-After": "1" },
+        headers: {
+          "Retry-After": "1",
+          "X-Munin-Rate-Limit": "admission-v1",
+        },
       }),
     );
     const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
@@ -971,6 +983,37 @@ describe("createFetchWithTimeout", () => {
     );
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay an unmarked upstream 429 for a mutating POST", async () => {
+    const upstreamThrottle = new Response("proxy limited", {
+      status: 429,
+      headers: { "Retry-After": "1" },
+    });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(upstreamThrottle)
+      .mockResolvedValueOnce(new Response("unexpected retry", { status: 200 }));
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const fetchFn = createFetchWithTimeout(5000, {
+      fetchFn: mockFetch,
+      sleep,
+      random: () => 0,
+    });
+
+    const response = await fetchFn("https://example.com/mcp", {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "memory_log", arguments: { content: "once" } },
+      }),
+    });
+
+    expect(response).toBe(upstreamThrottle);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it.each([401, 403])("does not retry authentication response %s", async (status) => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -9,6 +9,10 @@ import {
   createBridge,
   loadBridgeCredentials,
   createFetchWithTimeout,
+  getBridgeRateLimitRetryConfig,
+  parseRetryAfterMs,
+  resolveBridgeClientId,
+  BridgeRateLimitRetryExhaustedError,
   type TransportLike,
 } from "../src/bridge.js";
 
@@ -82,6 +86,38 @@ describe("isSessionExpiredError", () => {
     expect(isSessionExpiredError(null)).toBe(false);
     expect(isSessionExpiredError(undefined)).toBe(false);
     expect(isSessionExpiredError(404)).toBe(false);
+  });
+});
+
+describe("bridge admission identity and retry configuration", () => {
+  it("uses a stable configured client id or a fresh generated process id", () => {
+    expect(resolveBridgeClientId({ MUNIN_BRIDGE_CLIENT_ID: "grimnir.audit-1" })).toBe(
+      "grimnir.audit-1",
+    );
+    expect(resolveBridgeClientId({}, () => "first")).toBe("bridge-first");
+    expect(resolveBridgeClientId({}, () => "second")).toBe("bridge-second");
+  });
+
+  it("rejects malformed configured client ids", () => {
+    expect(() =>
+      resolveBridgeClientId({ MUNIN_BRIDGE_CLIENT_ID: "contains spaces" }),
+    ).toThrow("MUNIN_BRIDGE_CLIENT_ID");
+  });
+
+  it("parses Retry-After seconds and HTTP dates", () => {
+    expect(parseRetryAfterMs("2", 0)).toBe(2000);
+    expect(parseRetryAfterMs("Thu, 01 Jan 1970 00:00:05 GMT", 1000)).toBe(4000);
+    expect(parseRetryAfterMs("invalid", 0)).toBeUndefined();
+  });
+
+  it("uses safe retry defaults for malformed environment values", () => {
+    expect(
+      getBridgeRateLimitRetryConfig({
+        MUNIN_BRIDGE_RATE_LIMIT_RETRIES: "-1",
+        MUNIN_BRIDGE_RATE_LIMIT_MAX_WAIT_MS: "0",
+        MUNIN_BRIDGE_RATE_LIMIT_JITTER_MS: "bad",
+      }),
+    ).toEqual(getBridgeRateLimitRetryConfig({}));
   });
 });
 
@@ -836,6 +872,119 @@ describe("createFetchWithTimeout", () => {
     expect(result).toBe(mockResponse);
     expect(mockFetch).toHaveBeenCalledOnce();
     vi.unstubAllGlobals();
+  });
+
+  it("retries a transient 429 before returning the cold-start response", async () => {
+    const throttled = new Response("too many requests", {
+      status: 429,
+      headers: { "Retry-After": "0" },
+    });
+    const recovered = new Response("ok", { status: 200 });
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(throttled)
+      .mockResolvedValueOnce(recovered);
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    const fetchFn = createFetchWithTimeout(5000, {
+      fetchFn: mockFetch,
+      sleep,
+      random: () => 0,
+    });
+    const result = await fetchFn("https://example.com/mcp", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+    });
+
+    expect(result).toBe(recovered);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(0, expect.any(AbortSignal));
+  });
+
+  it("honors Retry-After plus additive jitter", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("limited", {
+          status: 429,
+          headers: { "Retry-After": "2" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const logs: string[] = [];
+    const fetchFn = createFetchWithTimeout(10_000, {
+      fetchFn: mockFetch,
+      sleep,
+      random: () => 0.5,
+      log: (message) => logs.push(message),
+      retry: { maxRetries: 2, maxWaitMs: 5000, jitterMs: 200 },
+    });
+
+    await expect(fetchFn("https://example.com/mcp", {})).resolves.toHaveProperty(
+      "status",
+      200,
+    );
+    expect(sleep).toHaveBeenCalledWith(2100, expect.any(AbortSignal));
+    expect(logs).toEqual(["HTTP 429; retry 1/2 in 2100ms"]);
+  });
+
+  it("fails precisely without sleeping when Retry-After exceeds the budget", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response("limited", {
+        status: 429,
+        headers: { "Retry-After": "30" },
+      }),
+    );
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const fetchFn = createFetchWithTimeout(60_000, {
+      fetchFn: mockFetch,
+      sleep,
+      random: () => 0,
+      retry: { maxRetries: 2, maxWaitMs: 5000, jitterMs: 0 },
+    });
+
+    await expect(fetchFn("https://example.com/mcp", {})).rejects.toThrow(
+      "next admission requires 30000ms",
+    );
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("bounds repeated throttles to the configured attempt count", async () => {
+    const mockFetch = vi.fn().mockImplementation(async () =>
+      new Response("limited", {
+        status: 429,
+        headers: { "Retry-After": "1" },
+      }),
+    );
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const fetchFn = createFetchWithTimeout(60_000, {
+      fetchFn: mockFetch,
+      sleep,
+      random: () => 0,
+      retry: { maxRetries: 2, maxWaitMs: 5000, jitterMs: 0 },
+    });
+
+    await expect(fetchFn("https://example.com/mcp", {})).rejects.toBeInstanceOf(
+      BridgeRateLimitRetryExhaustedError,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([401, 403])("does not retry authentication response %s", async (status) => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("auth", { status }));
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const fetchFn = createFetchWithTimeout(5000, {
+      fetchFn: mockFetch,
+      sleep,
+    });
+
+    const response = await fetchFn("https://example.com/mcp", {});
+    expect(response.status).toBe(status);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("clears the timeout even when fetch throws", async () => {

--- a/tests/index-coverage.test.ts
+++ b/tests/index-coverage.test.ts
@@ -683,7 +683,7 @@ describe("createHttpApp — HTTP app endpoints", () => {
 
   it("does not let one authenticated caller starve another caller's control plane", async () => {
     const rateLimitConfig = {
-      perCallerMax: 2,
+      perCallerMax: 3,
       globalMax: 10,
       windowMs: 60_000,
       maxCallers: 10,
@@ -718,6 +718,12 @@ describe("createHttpApp — HTTP app endpoints", () => {
       .set({ ...stdHeaders(), "X-Munin-Client-Id": "new-agent" })
       .send(initPayload)
       .expect(200);
+
+    await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "new-agent" })
+      .send({ jsonrpc: "2.0", method: "notifications/initialized" })
+      .expect(202);
 
     await supertest(app)
       .post("/mcp")

--- a/tests/index-coverage.test.ts
+++ b/tests/index-coverage.test.ts
@@ -44,6 +44,7 @@ import {
   RATE_LIMIT_WINDOW_MS,
   HEIMDALL_DESCRIPTOR,
   type ConsentAuthConfig,
+  type RateLimitConfig,
   type RequestLogEntry,
 } from "../src/index.js";
 import type { ExtendedAuthInfo } from "../src/oauth.js";
@@ -74,7 +75,11 @@ function mockRequest(
 const LEGACY_API_KEY = "index-coverage-test-api-key";
 const ISSUER_URL = "https://test.example.com";
 
-function makeApp(db: Database.Database, logs?: RequestLogEntry[]) {
+function makeApp(
+  db: Database.Database,
+  logs?: RequestLogEntry[],
+  rateLimitConfig?: RateLimitConfig,
+) {
   // Ensure trusted header env vars are set so createHttpApp doesn't throw
   process.env.MUNIN_OAUTH_TRUSTED_USER_HEADER = "x-auth-user";
   process.env.MUNIN_OAUTH_TRUSTED_USER_VALUE = "owner@example.com";
@@ -85,6 +90,7 @@ function makeApp(db: Database.Database, logs?: RequestLogEntry[]) {
     httpHost: "127.0.0.1",
     httpPort: 3030,
     requestLogger: logs ? (e) => logs.push(e) : undefined,
+    rateLimitConfig,
   });
 }
 
@@ -673,6 +679,130 @@ describe("createHttpApp — HTTP app endpoints", () => {
       if (lastStatus === 429) break;
     }
     expect(lastStatus).toBe(429);
+  });
+
+  it("does not let one authenticated caller starve another caller's control plane", async () => {
+    const rateLimitConfig = {
+      perCallerMax: 2,
+      globalMax: 10,
+      windowMs: 60_000,
+      maxCallers: 10,
+    };
+    const { app } = makeApp(db, logs, rateLimitConfig);
+    const initPayload = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+      },
+    };
+
+    let exhausted = false;
+    for (let i = 0; i <= rateLimitConfig.perCallerMax; i++) {
+      const response = await supertest(app)
+        .post("/mcp")
+        .set({ ...stdHeaders(), "X-Munin-Client-Id": "noisy-agent" })
+        .send(initPayload);
+      if (response.status === 429) {
+        exhausted = true;
+        break;
+      }
+    }
+    expect(exhausted).toBe(true);
+
+    await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "new-agent" })
+      .send(initPayload)
+      .expect(200);
+
+    await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "new-agent" })
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+      .expect(200);
+  });
+
+  it("returns an accurate Retry-After and structured non-secret throttle counters", async () => {
+    const { app } = makeApp(db, logs, {
+      perCallerMax: 1,
+      globalMax: 10,
+      windowMs: 10_000,
+      maxCallers: 10,
+    });
+    const payload = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+    const headers = { ...stdHeaders(), "X-Munin-Client-Id": "diagnostic-agent" };
+
+    await supertest(app).post("/mcp").set(headers).send(payload).expect(200);
+    const throttled = await supertest(app)
+      .post("/mcp")
+      .set(headers)
+      .send(payload)
+      .expect(429);
+
+    expect(throttled.headers["retry-after"]).toBe("10");
+    expect(throttled.body).toMatchObject({
+      error: "Too many requests",
+      retry_after_seconds: 10,
+      limiter_scope: "caller",
+    });
+    expect(throttled.body.limiter_key).toMatch(/^[0-9a-f]{16}$/);
+    const entry = logs.at(-1)!;
+    expect(entry.rateLimit).toMatchObject({
+      keyHash: throttled.body.limiter_key,
+      keySource: "client",
+      scope: "caller",
+      admittedCount: 1,
+      throttleCount: 1,
+      totalThrottleCount: 1,
+    });
+    expect(JSON.stringify(entry)).not.toContain(LEGACY_API_KEY);
+  });
+
+  it("authenticates before admission and invalid credentials cannot spend tokens", async () => {
+    const { app } = makeApp(db, logs, {
+      perCallerMax: 1,
+      globalMax: 1,
+      windowMs: 60_000,
+      maxCallers: 10,
+    });
+    const payload = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+
+    for (let i = 0; i < 3; i++) {
+      await supertest(app)
+        .post("/mcp")
+        .set(stdHeaders("invalid-token"))
+        .send(payload)
+        .expect(401);
+    }
+    await supertest(app).post("/mcp").set(stdHeaders()).send(payload).expect(200);
+    await supertest(app).post("/mcp").set(stdHeaders()).send(payload).expect(429);
+  });
+
+  it("charges malformed caller hints to the credential fallback bucket", async () => {
+    const { app } = makeApp(db, logs, {
+      perCallerMax: 1,
+      globalMax: 10,
+      windowMs: 60_000,
+      maxCallers: 10,
+    });
+    const payload = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+
+    await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "bad id one" })
+      .send(payload)
+      .expect(200);
+    await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "bad id two" })
+      .send(payload)
+      .expect(429);
+
+    expect(logs.at(-1)?.rateLimit?.keySource).toBe("credential");
   });
 
   it("returns 400 for invalid JSON body to /mcp", async () => {

--- a/tests/index-coverage.test.ts
+++ b/tests/index-coverage.test.ts
@@ -732,9 +732,69 @@ describe("createHttpApp — HTTP app endpoints", () => {
       .expect(200);
   });
 
+  it("keeps a new caller's handshake live during a concurrent caller flood", async () => {
+    const { app } = makeApp(db, logs, {
+      perCallerMax: 3,
+      perCredentialMax: 20,
+      globalMax: 20,
+      windowMs: 60_000,
+      maxCallers: 10,
+    });
+    const noisyHeaders = {
+      ...stdHeaders(),
+      "X-Munin-Client-Id": "concurrent-noisy-agent",
+    };
+    const newHeaders = {
+      ...stdHeaders(),
+      "X-Munin-Client-Id": "concurrent-new-agent",
+    };
+
+    const noisyFlood = Promise.all(
+      Array.from({ length: 10 }, (_, id) =>
+        supertest(app)
+          .post("/mcp")
+          .set(noisyHeaders)
+          .send({ jsonrpc: "2.0", id, method: "tools/list" }),
+      ),
+    );
+    const handshake = (async () => {
+      const initialize = await supertest(app)
+        .post("/mcp")
+        .set(newHeaders)
+        .send({
+          jsonrpc: "2.0",
+          id: 100,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "new-agent", version: "1.0.0" },
+          },
+        });
+      const initialized = await supertest(app)
+        .post("/mcp")
+        .set(newHeaders)
+        .send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      const tools = await supertest(app)
+        .post("/mcp")
+        .set(newHeaders)
+        .send({ jsonrpc: "2.0", id: 101, method: "tools/list" });
+      return [initialize.status, initialized.status, tools.status];
+    })();
+
+    const [noisyResponses, handshakeStatuses] = await Promise.all([
+      noisyFlood,
+      handshake,
+    ]);
+    expect(handshakeStatuses).toEqual([200, 202, 200]);
+    expect(noisyResponses.filter((response) => response.status === 200)).toHaveLength(3);
+    expect(noisyResponses.filter((response) => response.status === 429)).toHaveLength(7);
+  });
+
   it("returns an accurate Retry-After and structured non-secret throttle counters", async () => {
     const { app } = makeApp(db, logs, {
       perCallerMax: 1,
+      perCredentialMax: 10,
       globalMax: 10,
       windowMs: 10_000,
       maxCallers: 10,
@@ -750,6 +810,7 @@ describe("createHttpApp — HTTP app endpoints", () => {
       .expect(429);
 
     expect(throttled.headers["retry-after"]).toBe("10");
+    expect(throttled.headers["x-munin-rate-limit"]).toBe("admission-v1");
     expect(throttled.body).toMatchObject({
       error: "Too many requests",
       retry_after_seconds: 10,
@@ -768,9 +829,40 @@ describe("createHttpApp — HTTP app endpoints", () => {
     expect(JSON.stringify(entry)).not.toContain(LEGACY_API_KEY);
   });
 
+  it("attributes a pooled caller-map rejection to the overflow bucket", async () => {
+    const { app } = makeApp(db, logs, {
+      perCallerMax: 1,
+      perCredentialMax: 10,
+      globalMax: 10,
+      windowMs: 60_000,
+      maxCallers: 1,
+    });
+    const payload = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+
+    for (const callerId of ["stored", "overflow-a"]) {
+      await supertest(app)
+        .post("/mcp")
+        .set({ ...stdHeaders(), "X-Munin-Client-Id": callerId })
+        .send(payload)
+        .expect(200);
+    }
+    const rejected = await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "overflow-b" })
+      .send(payload)
+      .expect(429);
+
+    expect(rejected.body).toMatchObject({
+      limiter_scope: "caller",
+      limiter_key: "overflow",
+    });
+    expect(logs.at(-1)?.rateLimit?.keyHash).toBe("overflow");
+  });
+
   it("authenticates before admission and invalid credentials cannot spend tokens", async () => {
     const { app } = makeApp(db, logs, {
       perCallerMax: 1,
+      perCredentialMax: 10,
       globalMax: 1,
       windowMs: 60_000,
       maxCallers: 10,
@@ -791,6 +883,7 @@ describe("createHttpApp — HTTP app endpoints", () => {
   it("charges malformed caller hints to the credential fallback bucket", async () => {
     const { app } = makeApp(db, logs, {
       perCallerMax: 1,
+      perCredentialMax: 10,
       globalMax: 10,
       windowMs: 60_000,
       maxCallers: 10,
@@ -809,6 +902,33 @@ describe("createHttpApp — HTTP app endpoints", () => {
       .expect(429);
 
     expect(logs.at(-1)?.rateLimit?.keySource).toBe("credential");
+  });
+
+  it("caps caller-id rotation at the authenticated credential boundary", async () => {
+    const rateLimitConfig = {
+      perCallerMax: 1,
+      perCredentialMax: 2,
+      globalMax: 10,
+      windowMs: 60_000,
+      maxCallers: 10,
+    };
+    const { app } = makeApp(db, logs, rateLimitConfig);
+    const payload = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+
+    for (const callerId of ["rotating-a", "rotating-b"]) {
+      await supertest(app)
+        .post("/mcp")
+        .set({ ...stdHeaders(), "X-Munin-Client-Id": callerId })
+        .send(payload)
+        .expect(200);
+    }
+    const rejected = await supertest(app)
+      .post("/mcp")
+      .set({ ...stdHeaders(), "X-Munin-Client-Id": "rotating-c" })
+      .send(payload)
+      .expect(429);
+
+    expect(rejected.body.limiter_scope).toBe("credential");
   });
 
   it("returns 400 for invalid JSON body to /mcp", async () => {

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -60,6 +60,8 @@ describe("McpRateLimiter", () => {
     expect(limiter.admit("caller-c", "credential", 0)).toMatchObject({
       allowed: false,
       scope: "global",
+      admittedCount: 2,
+      throttleCount: 1,
     });
   });
 

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  McpRateLimiter,
+  RATE_LIMIT_GLOBAL_MAX,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_MAX_CALLERS,
+  RATE_LIMIT_WINDOW_MS,
+  getRateLimitConfig,
+} from "../src/rate-limit.js";
+
+const testConfig = {
+  perCallerMax: 2,
+  globalMax: 10,
+  windowMs: 10_000,
+  maxCallers: 10,
+};
+
+describe("McpRateLimiter", () => {
+  it("isolates callers and reports the exact continuous-refill wait", () => {
+    const limiter = new McpRateLimiter(testConfig, 0);
+
+    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-a", 0)).toMatchObject({
+      allowed: false,
+      scope: "caller",
+      retryAfterMs: 5000,
+      admittedCount: 2,
+      throttleCount: 1,
+    });
+    expect(limiter.admit("caller-b", 0).allowed).toBe(true);
+
+    expect(limiter.admit("caller-a", 4999)).toMatchObject({
+      allowed: false,
+      retryAfterMs: 1,
+      throttleCount: 2,
+    });
+    expect(limiter.admit("caller-a", 5000).allowed).toBe(true);
+  });
+
+  it("does not charge the global backstop for caller-local rejections", () => {
+    const limiter = new McpRateLimiter(
+      { ...testConfig, perCallerMax: 1, globalMax: 2 },
+      0,
+    );
+
+    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
+    for (let i = 0; i < 20; i++) {
+      expect(limiter.admit("caller-a", 0).scope).toBe("caller");
+    }
+    expect(limiter.admit("caller-b", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-c", 0)).toMatchObject({
+      allowed: false,
+      scope: "global",
+    });
+  });
+
+  it("collapses new identities into a capped overflow bucket at the map bound", () => {
+    const limiter = new McpRateLimiter(
+      { ...testConfig, perCallerMax: 1, maxCallers: 1 },
+      0,
+    );
+
+    expect(limiter.admit("stored", 0).allowed).toBe(true);
+    expect(limiter.admit("overflow-a", 0).allowed).toBe(true);
+    expect(limiter.admit("overflow-b", 0)).toMatchObject({
+      allowed: false,
+      scope: "caller",
+    });
+    expect(limiter.callerCount).toBe(1);
+  });
+
+  it("prunes caller state only after two complete windows", () => {
+    const limiter = new McpRateLimiter(
+      { ...testConfig, perCallerMax: 1, maxCallers: 1 },
+      0,
+    );
+
+    expect(limiter.admit("old", 0).allowed).toBe(true);
+    expect(limiter.admit("new", 20_000).allowed).toBe(true);
+    expect(limiter.callerCount).toBe(1);
+  });
+
+  it("does not create tokens when the clock moves backwards", () => {
+    const limiter = new McpRateLimiter(
+      { ...testConfig, perCallerMax: 1 },
+      1000,
+    );
+
+    expect(limiter.admit("caller", 1000).allowed).toBe(true);
+    expect(limiter.admit("caller", 500)).toMatchObject({
+      allowed: false,
+      retryAfterMs: 10_000,
+    });
+  });
+});
+
+describe("getRateLimitConfig", () => {
+  it("uses documented defaults", () => {
+    expect(getRateLimitConfig({})).toEqual({
+      perCallerMax: RATE_LIMIT_MAX,
+      globalMax: RATE_LIMIT_GLOBAL_MAX,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+      maxCallers: RATE_LIMIT_MAX_CALLERS,
+    });
+  });
+
+  it("accepts positive integer overrides and rejects malformed values", () => {
+    expect(
+      getRateLimitConfig({
+        MUNIN_RATE_LIMIT_PER_CALLER_MAX: "12",
+        MUNIN_RATE_LIMIT_GLOBAL_MAX: "120",
+        MUNIN_RATE_LIMIT_WINDOW_MS: "30000",
+        MUNIN_RATE_LIMIT_MAX_CALLERS: "50",
+      }),
+    ).toEqual({
+      perCallerMax: 12,
+      globalMax: 120,
+      windowMs: 30_000,
+      maxCallers: 50,
+    });
+
+    expect(
+      getRateLimitConfig({
+        MUNIN_RATE_LIMIT_PER_CALLER_MAX: "0",
+        MUNIN_RATE_LIMIT_GLOBAL_MAX: "not-a-number",
+        MUNIN_RATE_LIMIT_WINDOW_MS: "-1",
+        MUNIN_RATE_LIMIT_MAX_CALLERS: "1.5",
+      }),
+    ).toEqual(getRateLimitConfig({}));
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   McpRateLimiter,
+  RATE_LIMIT_CREDENTIAL_MAX,
   RATE_LIMIT_GLOBAL_MAX,
   RATE_LIMIT_MAX,
   RATE_LIMIT_MAX_CALLERS,
@@ -10,6 +11,7 @@ import {
 
 const testConfig = {
   perCallerMax: 2,
+  perCredentialMax: 10,
   globalMax: 10,
   windowMs: 10_000,
   maxCallers: 10,
@@ -25,23 +27,23 @@ describe("McpRateLimiter", () => {
   it("isolates callers and reports the exact continuous-refill wait", () => {
     const limiter = new McpRateLimiter(testConfig, 0);
 
-    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
-    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
-    expect(limiter.admit("caller-a", 0)).toMatchObject({
+    expect(limiter.admit("caller-a", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-a", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-a", "credential", 0)).toMatchObject({
       allowed: false,
       scope: "caller",
       retryAfterMs: 5000,
       admittedCount: 2,
       throttleCount: 1,
     });
-    expect(limiter.admit("caller-b", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-b", "credential", 0).allowed).toBe(true);
 
-    expect(limiter.admit("caller-a", 4999)).toMatchObject({
+    expect(limiter.admit("caller-a", "credential", 4999)).toMatchObject({
       allowed: false,
       retryAfterMs: 1,
       throttleCount: 2,
     });
-    expect(limiter.admit("caller-a", 5000).allowed).toBe(true);
+    expect(limiter.admit("caller-a", "credential", 5000).allowed).toBe(true);
   });
 
   it("does not charge the global backstop for caller-local rejections", () => {
@@ -50,12 +52,33 @@ describe("McpRateLimiter", () => {
       0,
     );
 
-    expect(limiter.admit("caller-a", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-a", "credential", 0).allowed).toBe(true);
     for (let i = 0; i < 20; i++) {
-      expect(limiter.admit("caller-a", 0).scope).toBe("caller");
+      expect(limiter.admit("caller-a", "credential", 0).scope).toBe("caller");
     }
-    expect(limiter.admit("caller-b", 0).allowed).toBe(true);
-    expect(limiter.admit("caller-c", 0)).toMatchObject({
+    expect(limiter.admit("caller-b", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-c", "credential", 0)).toMatchObject({
+      allowed: false,
+      scope: "global",
+    });
+  });
+
+  it("caps rotating caller IDs without charging the global backstop on rejection", () => {
+    const limiter = new McpRateLimiter(
+      { ...testConfig, perCallerMax: 2, perCredentialMax: 2, globalMax: 3 },
+      0,
+    );
+
+    expect(limiter.admit("caller-a", "credential-a", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-b", "credential-a", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-c", "credential-a", 0)).toMatchObject({
+      allowed: false,
+      scope: "credential",
+      bucketKind: "credential",
+      admittedCount: 2,
+    });
+    expect(limiter.admit("caller-d", "credential-b", 0).allowed).toBe(true);
+    expect(limiter.admit("caller-e", "credential-b", 0)).toMatchObject({
       allowed: false,
       scope: "global",
     });
@@ -67,11 +90,12 @@ describe("McpRateLimiter", () => {
       0,
     );
 
-    expect(limiter.admit("stored", 0).allowed).toBe(true);
-    expect(limiter.admit("overflow-a", 0).allowed).toBe(true);
-    expect(limiter.admit("overflow-b", 0)).toMatchObject({
+    expect(limiter.admit("stored", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("overflow-a", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("overflow-b", "credential", 0)).toMatchObject({
       allowed: false,
       scope: "caller",
+      bucketKind: "overflow",
     });
     expect(limiter.callerCount).toBe(1);
   });
@@ -82,8 +106,8 @@ describe("McpRateLimiter", () => {
       0,
     );
 
-    expect(limiter.admit("old", 0).allowed).toBe(true);
-    expect(limiter.admit("new", 20_000).allowed).toBe(true);
+    expect(limiter.admit("old", "credential", 0).allowed).toBe(true);
+    expect(limiter.admit("new", "credential", 20_000).allowed).toBe(true);
     expect(limiter.callerCount).toBe(1);
   });
 
@@ -93,8 +117,8 @@ describe("McpRateLimiter", () => {
       1000,
     );
 
-    expect(limiter.admit("caller", 1000).allowed).toBe(true);
-    expect(limiter.admit("caller", 500)).toMatchObject({
+    expect(limiter.admit("caller", "credential", 1000).allowed).toBe(true);
+    expect(limiter.admit("caller", "credential", 500)).toMatchObject({
       allowed: false,
       retryAfterMs: 10_000,
     });
@@ -105,6 +129,7 @@ describe("getRateLimitConfig", () => {
   it("uses documented defaults", () => {
     expect(getRateLimitConfig({})).toEqual({
       perCallerMax: RATE_LIMIT_MAX,
+      perCredentialMax: RATE_LIMIT_CREDENTIAL_MAX,
       globalMax: RATE_LIMIT_GLOBAL_MAX,
       windowMs: RATE_LIMIT_WINDOW_MS,
       maxCallers: RATE_LIMIT_MAX_CALLERS,
@@ -115,12 +140,14 @@ describe("getRateLimitConfig", () => {
     expect(
       getRateLimitConfig({
         MUNIN_RATE_LIMIT_PER_CALLER_MAX: "12",
+        MUNIN_RATE_LIMIT_PER_CREDENTIAL_MAX: "36",
         MUNIN_RATE_LIMIT_GLOBAL_MAX: "120",
         MUNIN_RATE_LIMIT_WINDOW_MS: "30000",
         MUNIN_RATE_LIMIT_MAX_CALLERS: "50",
       }),
     ).toEqual({
       perCallerMax: 12,
+      perCredentialMax: 36,
       globalMax: 120,
       windowMs: 30_000,
       maxCallers: 50,
@@ -129,6 +156,7 @@ describe("getRateLimitConfig", () => {
     expect(
       getRateLimitConfig({
         MUNIN_RATE_LIMIT_PER_CALLER_MAX: "0",
+        MUNIN_RATE_LIMIT_PER_CREDENTIAL_MAX: "-1",
         MUNIN_RATE_LIMIT_GLOBAL_MAX: "not-a-number",
         MUNIN_RATE_LIMIT_WINDOW_MS: "500",
         MUNIN_RATE_LIMIT_MAX_CALLERS: "1.5",

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -16,6 +16,12 @@ const testConfig = {
 };
 
 describe("McpRateLimiter", () => {
+  it("rejects unsafe programmatic configuration", () => {
+    expect(
+      () => new McpRateLimiter({ ...testConfig, windowMs: 0 }),
+    ).toThrow("windowMs must be a positive integer");
+  });
+
   it("isolates callers and reports the exact continuous-refill wait", () => {
     const limiter = new McpRateLimiter(testConfig, 0);
 
@@ -124,7 +130,7 @@ describe("getRateLimitConfig", () => {
       getRateLimitConfig({
         MUNIN_RATE_LIMIT_PER_CALLER_MAX: "0",
         MUNIN_RATE_LIMIT_GLOBAL_MAX: "not-a-number",
-        MUNIN_RATE_LIMIT_WINDOW_MS: "-1",
+        MUNIN_RATE_LIMIT_WINDOW_MS: "500",
         MUNIN_RATE_LIMIT_MAX_CALLERS: "1.5",
       }),
     ).toEqual(getRateLimitConfig({}));


### PR DESCRIPTION
Closes #231.

## What changed

- Replace the single process-wide MCP token bucket with hierarchical admission: per-caller, authenticated credential aggregate, and global backstop.
- Give each stdio bridge process a bounded non-secret caller ID while retaining credential/session fallbacks.
- Emit accurate `Retry-After`, non-secret limiter attribution, structured throttle counters, and explicit overflow attribution.
- Retry only Munin-marked pre-body admission 429 responses in the bridge, with bounded attempts, total wait, and jitter.
- Document the cooperative caller-ID boundary and all new configuration.

## Why

One noisy agent could consume the old shared 60-request bucket and prevent another agent from completing its MCP handshake. Caller-local rejections now leave other caller buckets available, while authenticated credential and global buckets prevent caller-ID rotation from bypassing abuse limits.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tools`
- `npm run build`
- `npm test` — 2,437 passed, 4 skipped
- `npm run test:coverage` — all ratchets passed
- `npm run benchmark:ci-gate` — all metrics 100%, no regressions
- Independent Codex / GPT-5 review — no remaining findings
