### PR TITLE
fix(deps): patch compatible production advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changelog is the canonical record of what moved.
 
 ### Security
 
+- Raised compatible transitive overrides for `body-parser`, `fast-uri`, and
+  `protobufjs` to their patched release lines. The remaining npm advisories are
+  tracked separately because their available fixes require unsupported major
+  overrides in the MCP SDK or Transformers dependency trees and the affected
+  Windows static-file/image-processing paths are not exposed by Munin (#236).
+  `npm audit --omit=dev` therefore still reports four transitive nodes (two
+  moderate, two high); the dated triage note records why they are not reachable
+  in Munin's supported runtime and forbids a zero-advisory claim.
 - Hardened the read-time untrusted-content boundary against sigil-free and
   Unicode-lookalike closure text (#198). Values already identified as untrusted
   retain the existing delimiters, `untrusted_content` flag, and provenance notice,

--- a/docs/dependency-advisory-triage-2026-07.md
+++ b/docs/dependency-advisory-triage-2026-07.md
@@ -1,0 +1,45 @@
+# Dependency advisory triage — 2026-07-22
+
+This note records the production-only `npm audit` review performed against
+Munin Memory v0.5.0 after schema v20 shipped. It distinguishes compatible
+remediation from advisories whose published fix is outside the declaring
+package's supported range. Residual upstream work is tracked in issue #236.
+
+## Remediated with compatible overrides
+
+| Package | Advisory class | Resolution |
+|---|---|---|
+| `body-parser` | Invalid limits can disable size enforcement | Override to `^2.3.0`, within Express's declared `^2.2.1` range. |
+| `fast-uri` | Host confusion during URI parsing/canonicalization | Override to `^3.1.4`, within Ajv's declared major line. |
+| `protobufjs` | Infinite loop while parsing malicious `.proto` options | Override to `^7.6.5`, within the ONNX dependency's declared major line. |
+
+These overrides must continue to pass the full test, typecheck, build, and
+benchmark gates because they affect runtime dependency trees even where Munin
+does not call the vulnerable surface directly.
+
+## Upstream-blocked advisories
+
+### `@hono/node-server`
+
+The MCP SDK v1.29.0 declares `@hono/node-server ^1.19.9`; npm reports the fix
+for the Windows encoded-backslash static-file traversal in v2.0.5 or later.
+Forcing that major would put the SDK outside its tested dependency contract.
+Munin supports macOS and Linux and does not expose Hono's static-file server, so
+the affected path is not reachable in the supported deployment. Keep the SDK
+current and adopt its compatible fix when upstream moves to the v2 line.
+
+### `sharp`
+
+Transformers v4.2.0 declares `sharp ^0.34.5`; the libvips advisory is fixed in
+Sharp v0.35.0 or later. Munin imports Transformers only to construct the
+`feature-extraction` text-embedding pipeline in `src/embeddings.ts`; it accepts
+no image input and no Munin code path invokes Sharp or libvips. Forcing an
+unsupported Sharp major would risk the embedding runtime for an unreachable
+image-processing path. Adopt the first Transformers release that declares a
+fixed Sharp line, then rerun the embedding and ARM64 deployment gates.
+
+## Review rule
+
+Re-run `npm audit --omit=dev` whenever the MCP SDK or Transformers changes. Do
+not describe the repository as having zero advisories until compatible upstream
+releases remove both residual findings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2033,21 +2033,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2831,9 +2844,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -4320,9 +4333,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5644,17 +5657,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -76,9 +76,11 @@
   },
   "overrides": {
     "adm-zip": "^0.6.0",
+    "body-parser": "^2.3.0",
+    "fast-uri": "^3.1.4",
     "hono": "^4.12.25",
     "@hono/node-server": "^1.19.13",
-    "protobufjs": "^7.6.3",
+    "protobufjs": "^7.6.5",
     "form-data": "^4.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

- raises compatible overrides for `body-parser`, `fast-uri`, and `protobufjs`
- records the dated production advisory/reachability analysis
- tracks upstream-blocked Hono and Sharp remediation in #236
- explicitly preserves the residual audit count instead of claiming a clean audit

## Why

`npm audit --omit=dev` reported seven production dependency nodes. Three advisory families have compatible fixes within their declaring packages' supported ranges. The remaining Hono and Sharp fixes require unsupported major overrides and affect paths Munin does not expose (Windows static serving and image processing).

## Impact

The production audit count falls from seven nodes (1 low, 3 moderate, 3 high) to four nodes (2 moderate, 2 high), with the residual risk and upgrade triggers documented.

## Verification

- `npm ci`
- `npm ls` confirms `body-parser@2.3.0`, `fast-uri@3.1.4`, `protobufjs@7.6.5`
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tools`
- `npm run build`
- `npm run test:coverage` — 2,446 passed, 4 skipped; all ratchets green
- lexical benchmark CI gate
- hybrid/vector benchmark gate with sqlite-vec required
- `git diff --check`

Independent review: M5 `qwen3-coder-next-80b` (ledger `5086c234-402d-428b-8ea0-262d96411661`) returned PASS with two low documentation findings; both were fixed. Native Codex review found no remaining blocker.