### PR TITLE
Add five-minute install and first-success flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # === Core ===
+# The canonical local quick start (`./scripts/quickstart.sh`) writes no .env and
+# defaults to lexical stdio through generated client config. Copy this file only
+# when configuring a persistent HTTP/service or enabling optional features.
 MUNIN_MEMORY_DB_PATH=~/.munin-memory/memory.db
 MUNIN_MEMORY_MAX_CONTENT_SIZE=100000
 
@@ -49,6 +52,8 @@ MUNIN_BACKUP_DIR=/mnt/backup/munin-memory
 # MUNIN_BACKUP_KEEP_SUNDAYS=4
 
 # === Embeddings / Semantic Search ===
+# Quick start deliberately sets these three to false in its generated local
+# client examples; change them only after the first write-to-resume check.
 MUNIN_EMBEDDINGS_ENABLED=true
 MUNIN_SEMANTIC_ENABLED=true
 MUNIN_HYBRID_ENABLED=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: npm
       # Native ARM64 evidence for the exact user-facing path, including its own
       # locked dependency install. The smoke script enforces <5 minutes.
       - run: npm run quickstart:smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - run: npm run typecheck
       - run: npm run typecheck:tools
       - run: npm run build
+      # Exercises the actual canonical shell entry point in an isolated
+      # data/config root and enforces the five-minute first-success budget.
+      - run: npm run quickstart:smoke
       # Runs the full suite with V8 coverage and enforces the ratchet floors
       # in vitest.config.ts (statements/branches/functions/lines). Raise the
       # floors when coverage rises; never lower them to admit a regression.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quickstart-arm64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      # Native ARM64 evidence for the exact user-facing path, including its own
+      # locked dependency install. The smoke script enforces <5 minutes.
+      - run: npm run quickstart:smoke
+        env:
+          MUNIN_QUICKSTART_SMOKE_FULL_INSTALL: "1"
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ changelog is the canonical record of what moved.
 - Added the canonical five-minute local install and first-success flow (#225):
   `scripts/quickstart.sh` performs locked install/build plus a fail-fast
   platform, Node, SQLite/FTS5, path/permission, profile/model, port, and auth
-  preflight; generates schema-checked placeholder-only configs for Codex,
+  preflight; generates format-checked placeholder-only configs for Codex,
   Claude Code/Desktop, and generic Streamable HTTP; and verifies
-  orient/status/write/log/resume/read against an owner-only database. The
+  orient/status+health/write/log/resume/read against an owner-only database. The
   lexical-first default avoids token handling, network exposure, and model
   download during onboarding. A clean-environment smoke lane enforces the
   five-minute budget and records duration, RSS, database, and disk footprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Added
+
+- Added the canonical five-minute local install and first-success flow (#225):
+  `scripts/quickstart.sh` performs locked install/build plus a fail-fast
+  platform, Node, SQLite/FTS5, path/permission, profile/model, port, and auth
+  preflight; generates schema-checked placeholder-only configs for Codex,
+  Claude Code/Desktop, and generic Streamable HTTP; and verifies
+  orient/status/write/log/resume/read against an owner-only database. The
+  lexical-first default avoids token handling, network exposure, and model
+  download during onboarding. A clean-environment smoke lane enforces the
+  five-minute budget and records duration, RSS, database, and disk footprint.
+  The tool cleanup timer now releases the event loop so one-shot CLI processes
+  terminate normally.
+
 ### Security
 
 - Raised compatible transitive overrides for `body-parser`, `fast-uri`, and

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ cd munin-memory
 The quick start installs the locked dependencies, builds Munin, preflights the
 runtime/SQLite/paths/profile/port/auth posture, generates placeholder-only
 configs for Codex, Claude Code, Claude Desktop, and generic Streamable HTTP,
-then verifies orient → status → write/log → resume → read against a fresh or
-existing owner-only database. It defaults to local stdio and lexical search so
+then verifies orient → status/health → write/log → resume → read against a fresh
+or existing owner-only database. It defaults to local stdio and lexical search so
 first success needs neither a bearer credential nor an embedding-model download.
 
 See [the five-minute quick-start guide](docs/quickstart.md) for client setup,

--- a/README.md
+++ b/README.md
@@ -102,14 +102,26 @@ No full rewrite is recommended as the first move: keep the MCP and SQLite contra
 - Node.js 20+
 - npm
 
-### Install and build
+### Canonical five-minute path
 
 ```bash
 git clone https://github.com/Magnus-Gille/munin-memory.git
 cd munin-memory
-npm ci
-npm run build
+./scripts/quickstart.sh
 ```
+
+The quick start installs the locked dependencies, builds Munin, preflights the
+runtime/SQLite/paths/profile/port/auth posture, generates placeholder-only
+configs for Codex, Claude Code, Claude Desktop, and generic Streamable HTTP,
+then verifies orient → status → write/log → resume → read against a fresh or
+existing owner-only database. It defaults to local stdio and lexical search so
+first success needs neither a bearer credential nor an embedding-model download.
+
+See [the five-minute quick-start guide](docs/quickstart.md) for client setup,
+semantic enablement, measurements, upgrade/rollback, and uninstall behavior.
+
+For developer-only manual setup, run `npm ci && npm run build` and use the
+transport commands below.
 
 ### Local mode (stdio)
 

--- a/docs/appliance-profiles.md
+++ b/docs/appliance-profiles.md
@@ -17,6 +17,12 @@ That means the right first move is **not** a full rewrite of the codebase. The r
 
 ## Profiles
 
+For installation, start with the lexical-first
+[five-minute quick start](quickstart.md), pass the intended profile to preflight,
+and enable its semantic defaults after the first write-to-resume check. This
+keeps model download latency out of onboarding without changing the profile's
+steady-state recommendation below.
+
 | Profile (`MUNIN_PROFILE`) | Target hardware | Default capabilities | Notes |
 |---------|-----------------|----------------------|-------|
 | `zero-appliance` | Raspberry Pi 3A+ / Pi Zero 2 W (512 MB-class) — the cheapest, primary target (both sourceable to Jan 2030) | Core memory **+ q8 semantic/hybrid search** | **Updated 2026-06-18:** the 2026-06-18 on-hardware RAM-fit sweep proved q8 MiniLM semantic fits a 128 MB cgroup cap (peak anon ≈ 74–99 MB across query/write/concurrent; ≈ 91–94 MB under sustained burst at appliance caps), so this tier ships semantic ON via q8, not lexical-only. See "Validated RAM-fit findings" below. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,8 +95,10 @@ npm run quickstart:smoke
 
 The smoke test creates a temporary HOME-independent data/config root, builds the
 CLI, runs the complete lexical-first flow, checks the five-minute budget and
-owner-only artifact modes, and deletes only its temporary directory. The same
-flow is also covered through Vitest against a fresh database.
+owner-only artifact modes, and deletes only its temporary directory. CI also
+runs the full canonical install on native Linux ARM64 and reports its install,
+cold-start, RSS, database, and disk measurements. The same flow is covered
+through Vitest against a fresh database.
 
 ## Measurement record
 
@@ -112,7 +114,7 @@ fresh data/config directory:
 | lexical-first, profile unset | 4.0 s | 265 ms | 4.29 s | 80.0 MiB | 432 KiB | 502 MiB |
 
 These numbers are evidence for that machine, not a universal promise. CI runs
-the isolated Linux smoke lane. Appliance RAM evidence for `zero-appliance`,
+isolated Linux x64 and native ARM64 smoke lanes. Appliance RAM evidence for `zero-appliance`,
 `zero-plus`, and `full-node` remains in
 [`appliance-profiles.md`](appliance-profiles.md); the quick start defaults to
 lexical mode specifically so model download time and semantic working-set size

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,16 +106,17 @@ through Vitest against a fresh database.
 memory, database size, and checkout/data/config disk footprint. It contains no
 credential values.
 
-Measured 2026-07-22 on macOS with Node 26.5.0, a warm npm package cache, and a
-fresh data/config directory:
+Measured 2026-07-22 on fresh data/config directories. The Linux run used the
+native GitHub-hosted `ubuntu-24.04-arm` image and an empty npm cache:
 
 | Mode | Install | MCP cold start and six-step check | Total | RSS | Database | Checkout + dependencies + data/config |
 |---|---:|---:|---:|---:|---:|---:|
-| lexical-first, profile unset | 4.0 s | 265 ms | 4.29 s | 80.0 MiB | 432 KiB | 502 MiB |
+| macOS ARM64, Node 26.5.0, warm npm cache | 4.0 s | 265 ms | 4.29 s | 80.0 MiB | 432 KiB | 502 MiB |
+| Ubuntu 24.04 ARM64, Node 22.23.1, empty npm cache | 12.0 s | 306 ms | 13 s wall | 89.5 MiB | 432 KiB | 520.4 MiB |
 
-These numbers are evidence for that machine, not a universal promise. CI runs
-isolated Linux x64 and native ARM64 smoke lanes. Appliance RAM evidence for `zero-appliance`,
-`zero-plus`, and `full-node` remains in
+These numbers are evidence for those runners, not a universal promise. CI runs
+isolated Linux x64 and native ARM64 smoke lanes. Appliance RAM evidence for
+`zero-appliance`, `zero-plus`, and `full-node` remains in
 [`appliance-profiles.md`](appliance-profiles.md); the quick start defaults to
 lexical mode specifically so model download time and semantic working-set size
 cannot prevent first success.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,145 @@
+# Five-minute quick start
+
+Status: canonical local installation and first-success path for macOS and Linux.
+
+## Outcome
+
+From a fresh checkout, one command installs locked dependencies, builds Munin,
+checks the local environment, creates an owner-only database/config directory,
+generates client examples, and verifies a complete MCP write-to-resume flow:
+
+```bash
+git clone https://github.com/Magnus-Gille/munin-memory.git
+cd munin-memory
+./scripts/quickstart.sh
+```
+
+The default is deliberately local stdio plus lexical search. It downloads no
+embedding model, opens no network port, and needs no bearer credential. After
+first success, enable a hardware profile and embeddings if desired.
+
+The command fails before starting a service when it finds an unsupported Node
+or OS version, an unknown profile, missing build output, unavailable SQLite
+FTS5, unsafe/unwritable or symbolic-link data/config/database paths, an occupied HTTP port, an empty
+embedding model override, or HTTP mode without a configured bearer credential.
+Credential values are never displayed or written into generated examples.
+
+## What success proves
+
+The verifier launches the built server and connects the official MCP client over
+stdio. It therefore covers process startup, initialization, transport, tool
+schemas, persistence, shutdown, and read-back. It:
+
+1. performs the required `memory_orient` handshake;
+2. reads `memory_status`;
+3. creates an isolated state entry under `onboarding/quickstart`;
+4. appends a milestone log;
+5. retrieves the context with `memory_resume`; and
+6. reads the new state back and verifies its content.
+
+The database defaults to `~/.munin-memory/memory.db`. Generated examples and a
+machine-readable `last-run.json` report are written under
+`~/.config/munin-memory/`, all with owner-only permissions.
+
+## Connect a client
+
+The quick start generates four artifacts:
+
+- `codex.toml`: merge its tables into `~/.codex/config.toml`;
+- `claude-code.txt`: run the contained `claude mcp add-json` command;
+- `claude-desktop.json`: merge the `munin-memory` entry into the existing
+  `mcpServers` object;
+- `streamable-http.json`: generic HTTP shape with the literal placeholder
+  `<MUNIN_API_KEY>`.
+
+Do not replace a client's entire existing configuration with an example. Merge
+only the Munin entry, restart the client, call `memory_orient`, and then inspect
+`onboarding/quickstart` with `memory_resume` or `memory_list`.
+
+## Optional modes
+
+Run preflight without creating configs or memory:
+
+```bash
+./scripts/quickstart.sh --preflight-only
+```
+
+Select and validate an appliance profile:
+
+```bash
+./scripts/quickstart.sh --profile zero-appliance
+```
+
+The generated local examples intentionally use lexical-first settings. After
+verification, edit the chosen client entry to set
+`MUNIN_EMBEDDINGS_ENABLED`, `MUNIN_SEMANTIC_ENABLED`, and
+`MUNIN_HYBRID_ENABLED` to `true`, add `MUNIN_PROFILE`, and restart the client.
+The first semantic start may download model data.
+
+HTTP preflight checks port and auth before startup but never prints the token:
+
+```bash
+MUNIN_API_KEY="$(openssl rand -hex 32)" \
+  ./scripts/quickstart.sh --transport http --server-url http://127.0.0.1:3030/mcp
+```
+
+Store the key in a permission-restricted environment or credential file. Put it
+into a real client's secure credential surface in place of the generated
+placeholder; never commit it.
+
+## Automated smoke test
+
+```bash
+npm run quickstart:smoke
+```
+
+The smoke test creates a temporary HOME-independent data/config root, builds the
+CLI, runs the complete lexical-first flow, checks the five-minute budget and
+owner-only artifact modes, and deletes only its temporary directory. The same
+flow is also covered through Vitest against a fresh database.
+
+## Measurement record
+
+`last-run.json` records install, cold-start, and total duration plus resident
+memory, database size, and checkout/data/config disk footprint. It contains no
+credential values.
+
+Measured 2026-07-22 on macOS with Node 26.5.0, a warm npm package cache, and a
+fresh data/config directory:
+
+| Mode | Install | MCP cold start and six-step check | Total | RSS | Database | Checkout + dependencies + data/config |
+|---|---:|---:|---:|---:|---:|---:|
+| lexical-first, profile unset | 4.0 s | 265 ms | 4.29 s | 80.0 MiB | 432 KiB | 502 MiB |
+
+These numbers are evidence for that machine, not a universal promise. CI runs
+the isolated Linux smoke lane. Appliance RAM evidence for `zero-appliance`,
+`zero-plus`, and `full-node` remains in
+[`appliance-profiles.md`](appliance-profiles.md); the quick start defaults to
+lexical mode specifically so model download time and semantic working-set size
+cannot prevent first success.
+
+## Upgrade, rollback, and uninstall
+
+The database and generated client examples live outside the source checkout, so
+normal code upgrades do not replace them:
+
+```bash
+cp ~/.munin-memory/memory.db ~/.munin-memory/memory.db.pre-upgrade
+git pull --ff-only
+npm ci
+npm run build
+./scripts/quickstart.sh --preflight-only
+```
+
+Stop any running Munin process before copying the live database directly; the
+documented SQLite-safe backup path remains authoritative for services. Keep the
+production `.env` and database outside release directories. For rollback,
+restore the previous code/tag, run its locked `npm ci && npm run build`, and
+point it at the unchanged database only when that release supports the active
+schema. Forward-only migrations mean a database backup—not a code checkout—is
+the rollback boundary for schema changes.
+
+To uninstall the local code, remove the checkout and the Munin entry from each
+client. Retain `~/.munin-memory` and `~/.config/munin-memory` unless data erasure
+is intentional. Deleting either directory is separate, explicit, and not part
+of the uninstall command.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ stdio. It therefore covers process startup, initialization, transport, tool
 schemas, persistence, shutdown, and read-back. It:
 
 1. performs the required `memory_orient` handshake;
-2. reads `memory_status`;
+2. reads `memory_status` and the owner-only `memory_health` snapshot;
 3. creates an isolated state entry under `onboarding/quickstart`;
 4. appends a milestone log;
 5. retrieves the context with `memory_resume`; and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,9 +20,10 @@ first success, enable a hardware profile and embeddings if desired.
 
 The command fails before starting a service when it finds an unsupported Node
 or OS version, an unknown profile, missing build output, unavailable SQLite
-FTS5, unsafe/unwritable or symbolic-link data/config/database paths, an occupied HTTP port, an empty
-embedding model override, or HTTP mode without a configured bearer credential.
-Credential values are never displayed or written into generated examples.
+FTS5, unsafe/unwritable or symbolic-link data/config/database paths, insecure
+SQLite sidecars, an unavailable HTTP bind address, an empty embedding model
+override, or HTTP mode without a configured bearer credential. Credential
+values are never displayed or written into generated examples.
 
 ## What success proves
 
@@ -58,7 +59,7 @@ only the Munin entry, restart the client, call `memory_orient`, and then inspect
 
 ## Optional modes
 
-Run preflight without creating configs or memory:
+Run preflight without creating directories, configs, or memory:
 
 ```bash
 ./scripts/quickstart.sh --preflight-only
@@ -76,7 +77,8 @@ verification, edit the chosen client entry to set
 `MUNIN_HYBRID_ENABLED` to `true`, add `MUNIN_PROFILE`, and restart the client.
 The first semantic start may download model data.
 
-HTTP preflight checks port and auth before startup but never prints the token:
+HTTP preflight checks the configured `MUNIN_HTTP_HOST`/`MUNIN_HTTP_PORT` bind and
+auth before startup but never prints the token:
 
 ```bash
 MUNIN_API_KEY="$(openssl rand -hex 32)" \
@@ -86,6 +88,12 @@ MUNIN_API_KEY="$(openssl rand -hex 32)" \
 Store the key in a permission-restricted environment or credential file. Put it
 into a real client's secure credential surface in place of the generated
 placeholder; never commit it.
+
+`--transport http` selects HTTP preflight and the generated HTTP example; the
+first-success verifier deliberately remains local stdio so onboarding never
+opens a network service. `last-run.json` records the requested `transport` and
+the independently explicit `verifiedTransport` (`stdio`) so the report cannot
+be mistaken for an HTTP end-to-end test.
 
 ## Automated smoke test
 
@@ -103,8 +111,8 @@ through Vitest against a fresh database.
 ## Measurement record
 
 `last-run.json` records install, cold-start, and total duration plus resident
-memory, database size, and checkout/data/config disk footprint. It contains no
-credential values.
+memory, database size, checkout/data/config disk footprint, requested transport,
+and `verifiedTransport`. It contains no credential values.
 
 Measured 2026-07-22 on fresh data/config directories. The Linux run used the
 native GitHub-hosted `ubuntu-24.04-arm` image and an empty npm cache:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "uuid": "^14.0.1"
       },
       "bin": {
-        "munin-admin": "dist/admin-cli.js"
+        "munin-admin": "dist/admin-cli.js",
+        "munin-quickstart": "dist/quickstart-cli.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,18 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "munin-admin": "dist/admin-cli.js"
+    "munin-admin": "dist/admin-cli.js",
+    "munin-quickstart": "dist/quickstart-cli.js"
   },
   "scripts": {
-    "build": "tsc && chmod +x dist/admin-cli.js",
+    "build": "tsc && chmod +x dist/admin-cli.js dist/quickstart-cli.js",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "typecheck:tools": "tsc --noEmit -p tsconfig.tools.json",
     "lint": "eslint .",
     "admin": "tsx src/admin-cli.ts",
     "dev": "tsx watch src/index.ts",
+    "quickstart": "./scripts/quickstart.sh",
+    "quickstart:smoke": "./scripts/quickstart-smoke.sh",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/scripts/quickstart-smoke.sh
+++ b/scripts/quickstart-smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/munin-quickstart-smoke.XXXXXX")"
+trap 'rm -rf "$SMOKE_ROOT"' EXIT
+
+START_SECONDS="$(date +%s)"
+MUNIN_QUICKSTART_SKIP_INSTALL=1 \
+  "$PROJECT_ROOT/scripts/quickstart.sh" \
+  --data-dir "$SMOKE_ROOT/data" \
+  --config-dir "$SMOKE_ROOT/config" \
+  --json > "$SMOKE_ROOT/result.json"
+ELAPSED_SECONDS="$(( $(date +%s) - START_SECONDS ))"
+
+node - "$SMOKE_ROOT/result.json" "$ELAPSED_SECONDS" <<'NODE'
+const fs = require("node:fs");
+const [reportPath, elapsedRaw] = process.argv.slice(2);
+const result = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const elapsed = Number(elapsedRaw);
+if (!result.ok) throw new Error("quick-start result was not ok");
+if (elapsed >= 300) throw new Error(`quick-start exceeded five minutes: ${elapsed}s`);
+if (result.firstSuccess?.steps?.length !== 6) throw new Error("first-success flow was incomplete");
+for (const artifact of result.artifacts) {
+  const mode = fs.statSync(artifact).mode & 0o077;
+  if (mode !== 0) throw new Error(`artifact is not owner-only: ${artifact}`);
+}
+console.log(`Quick-start clean-environment smoke PASS (${elapsed}s)`);
+NODE

--- a/scripts/quickstart-smoke.sh
+++ b/scripts/quickstart-smoke.sh
@@ -7,7 +7,11 @@ SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/munin-quickstart-smoke.XXXXXX")"
 trap 'rm -rf "$SMOKE_ROOT"' EXIT
 
 START_SECONDS="$(date +%s)"
-MUNIN_QUICKSTART_SKIP_INSTALL=1 \
+SKIP_INSTALL=1
+if [[ "${MUNIN_QUICKSTART_SMOKE_FULL_INSTALL:-0}" == "1" ]]; then
+  SKIP_INSTALL=0
+fi
+MUNIN_QUICKSTART_SKIP_INSTALL="$SKIP_INSTALL" \
   "$PROJECT_ROOT/scripts/quickstart.sh" \
   --data-dir "$SMOKE_ROOT/data" \
   --config-dir "$SMOKE_ROOT/config" \
@@ -26,5 +30,10 @@ for (const artifact of result.artifacts) {
   const mode = fs.statSync(artifact).mode & 0o077;
   if (mode !== 0) throw new Error(`artifact is not owner-only: ${artifact}`);
 }
-console.log(`Quick-start clean-environment smoke PASS (${elapsed}s)`);
+const metrics = result.metrics;
+console.log(
+  `Quick-start clean-environment smoke PASS (${elapsed}s; arch=${process.arch}; ` +
+  `install=${metrics.installDurationMs}ms; cold=${metrics.coldStartMs}ms; ` +
+  `rss=${metrics.rssBytes}B; db=${metrics.databaseBytes}B; disk=${metrics.diskFootprintBytes}B)`,
+);
 NODE

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START_SECONDS="$(date +%s)"
+
+fail() {
+  printf 'Quick start preflight failed: %s\n' "$1" >&2
+  exit 1
+}
+
+case "$(uname -s)" in
+  Darwin|Linux) ;;
+  *) fail "supported platforms are macOS and Linux" ;;
+esac
+
+command -v node >/dev/null 2>&1 || fail "Node.js 20+ is required"
+command -v npm >/dev/null 2>&1 || fail "npm is required"
+
+NODE_MAJOR="$(node -p 'Number(process.versions.node.split(".")[0])')"
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  fail "Node.js 20+ is required (found $(node --version))"
+fi
+
+cd "$PROJECT_ROOT"
+if [[ "${MUNIN_QUICKSTART_SKIP_INSTALL:-0}" != "1" ]]; then
+  npm ci >&2
+fi
+npm run build >&2
+
+INSTALL_SECONDS="$(( $(date +%s) - START_SECONDS ))"
+export MUNIN_QUICKSTART_INSTALL_MS="$(( INSTALL_SECONDS * 1000 ))"
+exec node "$PROJECT_ROOT/dist/quickstart-cli.js" --project-root "$PROJECT_ROOT" "$@"

--- a/src/quickstart-cli.ts
+++ b/src/quickstart-cli.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  redactSensitiveText,
+  runPreflight,
+  runQuickstart,
+  type PreflightOptions,
+  type QuickstartOptions,
+  type QuickstartTransport,
+} from "./quickstart.js";
+
+interface CliOptions extends QuickstartOptions {
+  json: boolean;
+  preflightOnly: boolean;
+  help: boolean;
+}
+
+export interface QuickstartCliIo {
+  log: (message: string) => void;
+  error: (message: string) => void;
+}
+
+function usage(): string {
+  return `Munin Memory five-minute quick start
+
+Usage:
+  ./scripts/quickstart.sh [options]
+  munin-quickstart [options]
+
+Options:
+  --data-dir <path>       Database directory (default: ~/.munin-memory)
+  --config-dir <path>     Generated examples/report (default: ~/.config/munin-memory)
+  --project-root <path>   Built Munin checkout (normally detected)
+  --transport <mode>      stdio (default) or http
+  --server-url <url>      Generic HTTP client example URL
+  --profile <name>        zero-appliance, zero-plus, or full-node
+  --preflight-only        Check prerequisites without writing memory/config files
+  --json                  Machine-readable, secret-safe result
+  --help                  Show this help
+
+The default path is local stdio plus lexical search. It needs no bearer token,
+opens no network port, and enables embeddings only after first success.
+`;
+}
+
+function takeValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function defaultProjectRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+export function parseQuickstartArgs(args: string[], env: NodeJS.ProcessEnv = process.env): CliOptions {
+  let projectRoot = defaultProjectRoot();
+  let dataDir = join(homedir(), ".munin-memory");
+  let configDir = join(homedir(), ".config", "munin-memory");
+  let transport: QuickstartTransport = "stdio";
+  let serverUrl: string | undefined;
+  let profile = env.MUNIN_PROFILE || undefined;
+  let jsonOutput = false;
+  let preflightOnly = false;
+  let help = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--data-dir") dataDir = takeValue(args, index++, arg);
+    else if (arg === "--config-dir") configDir = takeValue(args, index++, arg);
+    else if (arg === "--project-root") projectRoot = takeValue(args, index++, arg);
+    else if (arg === "--transport") {
+      const value = takeValue(args, index++, arg);
+      if (value !== "stdio" && value !== "http") throw new Error("--transport must be stdio or http.");
+      transport = value;
+    } else if (arg === "--server-url") serverUrl = takeValue(args, index++, arg);
+    else if (arg === "--profile") profile = takeValue(args, index++, arg);
+    else if (arg === "--json") jsonOutput = true;
+    else if (arg === "--preflight-only") preflightOnly = true;
+    else if (arg === "--help" || arg === "-h") help = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+
+  const sensitiveValues = [
+    env.MUNIN_API_KEY,
+    env.MUNIN_API_KEY_DPA,
+    env.MUNIN_API_KEY_CONSUMER,
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+  const installDurationMs = Number.parseInt(env.MUNIN_QUICKSTART_INSTALL_MS ?? "0", 10);
+  return {
+    projectRoot: resolve(projectRoot),
+    dataDir: resolve(dataDir),
+    configDir: resolve(configDir),
+    transport,
+    embeddings: false,
+    profile,
+    embeddingModel: env.MUNIN_EMBEDDINGS_MODEL,
+    apiKeyPresent: sensitiveValues.length > 0,
+    port: Number.parseInt(env.MUNIN_HTTP_PORT ?? "3030", 10),
+    serverUrl,
+    installDurationMs: Number.isFinite(installDurationMs) ? installDurationMs : 0,
+    sensitiveValues,
+    json: jsonOutput,
+    preflightOnly,
+    help,
+  };
+}
+
+function printPreflight(
+  options: PreflightOptions,
+  result: Awaited<ReturnType<typeof runPreflight>>,
+  io: QuickstartCliIo,
+): void {
+  io.log(`Munin preflight: ${result.ok ? "PASS" : "FAIL"} (${result.mode})`);
+  for (const check of result.checks) {
+    const marker = check.status === "pass" ? "✓" : check.status === "warn" ? "!" : "✗";
+    io.log(`  ${marker} ${check.message}`);
+  }
+  if (!result.ok) io.log(`Fix the failed checks, then rerun from ${options.projectRoot}.`);
+}
+
+export async function runQuickstartCli(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  io: QuickstartCliIo = { log: console.log, error: console.error },
+): Promise<number> {
+  const sensitiveFromEnv = [
+    env.MUNIN_API_KEY,
+    env.MUNIN_API_KEY_DPA,
+    env.MUNIN_API_KEY_CONSUMER,
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+  try {
+    const options = parseQuickstartArgs(args, env);
+    if (options.help) {
+      io.log(usage());
+      return 0;
+    }
+    if (options.preflightOnly) {
+      const result = await runPreflight(options);
+      if (options.json) io.log(JSON.stringify(result, null, 2));
+      else printPreflight(options, result, io);
+      return result.ok ? 0 : 1;
+    }
+
+    const result = await runQuickstart(options);
+    if (options.json) {
+      io.log(JSON.stringify(result, null, 2));
+    } else {
+      printPreflight(options, result.preflight, io);
+      if (result.ok && result.firstSuccess) {
+        io.log("\nFirst-success flow: PASS");
+        for (const step of result.firstSuccess.steps) io.log(`  ✓ ${step.id}: ${step.message}`);
+        io.log(`\nGenerated placeholder-only client examples in ${options.configDir}`);
+        io.log(`Database: ${join(options.dataDir, "memory.db")}`);
+        io.log(`Total measured time: ${(result.metrics.totalDurationMs / 1000).toFixed(1)}s`);
+        io.log("Next: copy the matching client example, restart that client, and call memory_orient.");
+      }
+    }
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.error(redactSensitiveText(`Quick start failed: ${message}`, sensitiveFromEnv));
+    return 1;
+  }
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runQuickstartCli(process.argv.slice(2));
+}
+
+const isMainModule =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) void main();

--- a/src/quickstart-cli.ts
+++ b/src/quickstart-cli.ts
@@ -8,6 +8,7 @@ import {
   runPreflight,
   runQuickstart,
   type PreflightOptions,
+  type FirstSuccessResult,
   type QuickstartOptions,
   type QuickstartTransport,
 } from "./quickstart.js";
@@ -90,6 +91,7 @@ export function parseQuickstartArgs(args: string[], env: NodeJS.ProcessEnv = pro
     env.MUNIN_API_KEY_CONSUMER,
   ].filter((value): value is string => typeof value === "string" && value.length > 0);
   const installDurationMs = Number.parseInt(env.MUNIN_QUICKSTART_INSTALL_MS ?? "0", 10);
+  const httpPort = env.MUNIN_HTTP_PORT?.trim();
   return {
     projectRoot: resolve(projectRoot),
     dataDir: resolve(dataDir),
@@ -99,7 +101,8 @@ export function parseQuickstartArgs(args: string[], env: NodeJS.ProcessEnv = pro
     profile,
     embeddingModel: env.MUNIN_EMBEDDINGS_MODEL,
     apiKeyPresent: sensitiveValues.length > 0,
-    port: Number.parseInt(env.MUNIN_HTTP_PORT ?? "3030", 10),
+    host: env.MUNIN_HTTP_HOST?.trim() || "127.0.0.1",
+    port: httpPort ? Number.parseInt(httpPort, 10) : 3030,
     serverUrl,
     installDurationMs: Number.isFinite(installDurationMs) ? installDurationMs : 0,
     sensitiveValues,
@@ -107,6 +110,13 @@ export function parseQuickstartArgs(args: string[], env: NodeJS.ProcessEnv = pro
     preflightOnly,
     help,
   };
+}
+
+export function formatFirstSuccessLines(result: FirstSuccessResult): string[] {
+  return [
+    `First-success flow: ${result.ok ? "PASS" : "FAIL"}`,
+    ...result.steps.map((step) => `  ${step.ok ? "✓" : "✗"} ${step.id}: ${step.message}`),
+  ];
 }
 
 function printPreflight(
@@ -150,13 +160,17 @@ export async function runQuickstartCli(
       io.log(JSON.stringify(result, null, 2));
     } else {
       printPreflight(options, result.preflight, io);
+      if (result.firstSuccess) {
+        io.log("");
+        for (const line of formatFirstSuccessLines(result.firstSuccess)) io.log(line);
+      }
       if (result.ok && result.firstSuccess) {
-        io.log("\nFirst-success flow: PASS");
-        for (const step of result.firstSuccess.steps) io.log(`  ✓ ${step.id}: ${step.message}`);
         io.log(`\nGenerated placeholder-only client examples in ${options.configDir}`);
         io.log(`Database: ${join(options.dataDir, "memory.db")}`);
         io.log(`Total measured time: ${(result.metrics.totalDurationMs / 1000).toFixed(1)}s`);
         io.log("Next: copy the matching client example, restart that client, and call memory_orient.");
+      } else if (result.firstSuccess) {
+        io.log(`Inspect the failure report in ${join(options.configDir, "last-run.json")}, fix the failed step, and rerun.`);
       }
     }
     return result.ok ? 0 : 1;

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -19,6 +19,7 @@ import {
   constants as fsConstants,
 } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { PROFILE_NAMES } from "./profiles.js";
 
 export type QuickstartTransport = "stdio" | "http";
@@ -39,6 +40,7 @@ export interface PreflightOptions {
   profile?: string;
   embeddingModel?: string;
   apiKeyPresent?: boolean;
+  host?: string;
   port?: number;
   nodeVersion?: string;
   platform?: NodeJS.Platform | string;
@@ -71,6 +73,7 @@ export interface FirstSuccessStep {
 
 export interface FirstSuccessResult {
   ok: boolean;
+  transport: "stdio";
   namespace: string;
   entryId: string;
   coldStartMs: number;
@@ -113,7 +116,7 @@ function json(value: unknown): string {
 }
 
 function tomlString(value: string): string {
-  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+  return JSON.stringify(value);
 }
 
 function shellSingleQuote(value: string): string {
@@ -221,6 +224,8 @@ export function validateGeneratedClientConfigurations(configs: ClientConfigurati
 
 function ensurePrivateDirectory(path: string): void {
   if (!existsSync(path)) mkdirSync(path, { recursive: true, mode: 0o700 });
+  const check = permissionCheck("directory", path, "Directory");
+  if (check.status === "fail") throw new Error(check.message);
 }
 
 function permissionCheck(id: string, path: string, label: string): PreflightCheck {
@@ -242,40 +247,88 @@ function permissionCheck(id: string, path: string, label: string): PreflightChec
       };
     }
     return { id, status: "pass", message: `${label} is writable and owner-only.` };
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      let ancestor = dirname(resolve(path));
+      try {
+        while (!existsSync(ancestor)) {
+          const parent = dirname(ancestor);
+          if (parent === ancestor) throw new Error("No existing parent directory was found.");
+          ancestor = parent;
+        }
+        const ancestorStat = statSync(ancestor);
+        if (!ancestorStat.isDirectory()) {
+          return { id, status: "fail", message: `${label} cannot be created because ${ancestor} is not a directory.` };
+        }
+        accessSync(ancestor, fsConstants.W_OK | fsConstants.X_OK);
+        return {
+          id,
+          status: "pass",
+          message: `${label} does not exist and will be created owner-only (0700).`,
+        };
+      } catch (ancestorError) {
+        const code = (ancestorError as NodeJS.ErrnoException).code;
+        return {
+          id,
+          status: "fail",
+          message: `${label} cannot be created at ${path}${code ? ` (${code})` : ""}.`,
+        };
+      }
+    }
     return { id, status: "fail", message: `${label} is not readable and writable: ${path}.` };
   }
 }
 
 function databasePermissionCheck(dataDir: string): PreflightCheck {
-  const path = join(dataDir, "memory.db");
-  if (!existsSync(path)) {
-    return { id: "database-permissions", status: "pass", message: "New database will be created owner-only (0600)." };
-  }
-  try {
-    const stat = lstatSync(path);
-    if (stat.isSymbolicLink()) {
-      return { id: "database-permissions", status: "fail", message: `Database must not be a symbolic link: ${path}.` };
+  const paths = ["memory.db", "memory.db-wal", "memory.db-shm"].map((name) => join(dataDir, name));
+  let inspected = 0;
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    inspected += 1;
+    try {
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) {
+        return { id: "database-permissions", status: "fail", message: `Database artifact must not be a symbolic link: ${path}.` };
+      }
+      if (!stat.isFile()) {
+        return { id: "database-permissions", status: "fail", message: `Database artifact must be a regular file: ${path}.` };
+      }
+      const mode = stat.mode & 0o777;
+      if ((mode & 0o077) !== 0) {
+        return {
+          id: "database-permissions",
+          status: "fail",
+          message: `Database artifact permissions are ${mode.toString(8)}; run chmod 600 ${path}.`,
+        };
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      return {
+        id: "database-permissions",
+        status: "fail",
+        message: `Database artifact cannot be inspected: ${path}${code ? ` (${code})` : ""}.`,
+      };
     }
-    if (!stat.isFile()) {
-      return { id: "database-permissions", status: "fail", message: `Database path must be a regular file: ${path}.` };
-    }
-    const mode = stat.mode & 0o777;
-    return (mode & 0o077) === 0
-      ? { id: "database-permissions", status: "pass", message: "Existing database is owner-only." }
-      : { id: "database-permissions", status: "fail", message: `Existing database permissions are ${mode.toString(8)}; run chmod 600 ${path}.` };
-  } catch {
-    return { id: "database-permissions", status: "fail", message: `Existing database cannot be inspected: ${path}.` };
   }
+  return inspected === 0
+    ? { id: "database-permissions", status: "pass", message: "New database will be created owner-only (0600)." }
+    : { id: "database-permissions", status: "pass", message: "Existing database and SQLite sidecars are owner-only." };
 }
 
-async function checkPort(port: number): Promise<boolean> {
+interface PortProbeResult {
+  available: boolean;
+  errorCode?: string;
+}
+
+async function checkPort(host: string, port: number): Promise<PortProbeResult> {
   return new Promise((resolvePort) => {
     const server = createServer();
     server.unref();
-    server.once("error", () => resolvePort(false));
-    server.listen(port, "127.0.0.1", () => {
-      server.close(() => resolvePort(true));
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      resolvePort({ available: false, errorCode: error.code });
+    });
+    server.listen(port, host, () => {
+      server.close(() => resolvePort({ available: true }));
     });
   });
 }
@@ -303,8 +356,6 @@ function checkSqlite(): PreflightCheck {
 }
 
 export async function runPreflight(options: PreflightOptions): Promise<PreflightResult> {
-  ensurePrivateDirectory(options.dataDir);
-  ensurePrivateDirectory(options.configDir);
   const checks: PreflightCheck[] = [];
   const platform = options.platform ?? process.platform;
   checks.push(
@@ -365,14 +416,24 @@ export async function runPreflight(options: PreflightOptions): Promise<Preflight
         : { id: "http-auth", status: "fail", message: "HTTP mode requires MUNIN_API_KEY or a scoped bearer credential." },
     );
     const port = options.port ?? 3030;
+    const host = options.host ?? "127.0.0.1";
     if (!Number.isInteger(port) || port < 1 || port > 65_535) {
       checks.push({ id: "port", status: "fail", message: `Invalid HTTP port ${String(port)}; use an integer from 1 to 65535.` });
     } else {
-      checks.push(
-        (await checkPort(port))
-          ? { id: "port", status: "pass", message: `127.0.0.1:${port} is available.` }
-          : { id: "port", status: "fail", message: `127.0.0.1:${port} is already in use.` },
-      );
+      const probe = await checkPort(host, port);
+      if (probe.available) {
+        checks.push({ id: "port", status: "pass", message: `${host}:${port} is available.` });
+      } else if (probe.errorCode === "EADDRINUSE") {
+        checks.push({ id: "port", status: "fail", message: `${host}:${port} is already in use.` });
+      } else if (probe.errorCode === "EACCES") {
+        checks.push({ id: "port", status: "fail", message: `Permission denied while binding ${host}:${port}.` });
+      } else {
+        checks.push({
+          id: "port",
+          status: "fail",
+          message: `${host}:${port} cannot be bound (${probe.errorCode ?? "unknown error"}).`,
+        });
+      }
     }
   } else {
     checks.push({ id: "http-auth", status: "pass", message: "Local stdio mode does not require a bearer credential." });
@@ -386,10 +447,11 @@ export async function runPreflight(options: PreflightOptions): Promise<Preflight
   };
 }
 
-function parseToolResponse(raw: unknown): Record<string, unknown> {
-  const response = raw as { content?: Array<{ type?: string; text?: string }> };
+export function parseQuickstartToolResponse(raw: unknown): Record<string, unknown> {
+  const response = raw as { isError?: boolean; content?: Array<{ type?: string; text?: string }> };
   const text = response.content?.find((item) => item.type === "text")?.text;
   if (!text) throw new Error("MCP tool returned no text result.");
+  if (response.isError) throw new Error(`MCP tool failed: ${text}`);
   return JSON.parse(text) as Record<string, unknown>;
 }
 
@@ -401,7 +463,8 @@ export async function runFirstSuccess(options: { dbPath: string; serverPath?: st
   const startedAt = Date.now();
   const namespace = "onboarding/quickstart";
   const key = `first-success-${randomUUID()}`;
-  const serverPath = options.serverPath ?? join(resolve("."), "dist/index.js");
+  const serverPath = options.serverPath ?? join(resolve(dirname(fileURLToPath(import.meta.url)), ".."), "dist/index.js");
+  if (!existsSync(serverPath)) throw new Error(`Built Munin server not found at ${serverPath}; run npm run build first.`);
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: [serverPath],
@@ -425,7 +488,7 @@ export async function runFirstSuccess(options: { dbPath: string; serverPath?: st
   const connectStartedAt = Date.now();
   let coldStartMs = 0;
   const call = async (name: string, args: Record<string, unknown> = {}) =>
-    parseToolResponse(await client.callTool({ name, arguments: args }));
+    parseQuickstartToolResponse(await client.callTool({ name, arguments: args }));
   const steps: FirstSuccessStep[] = [];
   let entryId = "";
   const record = (id: FirstSuccessStep["id"], result: Record<string, unknown>, message: string) => {
@@ -475,6 +538,7 @@ export async function runFirstSuccess(options: { dbPath: string; serverPath?: st
 
   return {
     ok: steps.length === 6 && steps.every((step) => step.ok) && entryId.length > 0,
+    transport: "stdio",
     namespace,
     entryId,
     coldStartMs,
@@ -557,20 +621,32 @@ export async function runQuickstart(options: QuickstartOptions): Promise<Quickst
 
   const configs = generateClientConfigurations(options);
   const configErrors = validateGeneratedClientConfigurations(configs);
+  for (const value of sensitiveValues) {
+    if (value.length > 0 && Object.values(configs).some((content) => content.includes(value))) {
+      configErrors.push("Generated client configuration contains configured credential material.");
+      break;
+    }
+  }
   if (configErrors.length > 0) throw new Error(configErrors.join(" "));
+  ensurePrivateDirectory(options.dataDir);
+  ensurePrivateDirectory(options.configDir);
+
+  const dbPath = join(options.dataDir, "memory.db");
+  const firstSuccess = await runFirstSuccess({ dbPath, serverPath: join(options.projectRoot, "dist/index.js") });
   const artifacts = [
     join(options.configDir, "codex.toml"),
     join(options.configDir, "claude-code.txt"),
     join(options.configDir, "claude-desktop.json"),
     join(options.configDir, "streamable-http.json"),
   ];
-  privateWrite(artifacts[0], configs.codexToml, sensitiveValues);
-  privateWrite(artifacts[1], configs.claudeCodeCommand, sensitiveValues);
-  privateWrite(artifacts[2], configs.claudeDesktopJson, sensitiveValues);
-  privateWrite(artifacts[3], configs.streamableHttpJson, sensitiveValues);
-
-  const dbPath = join(options.dataDir, "memory.db");
-  const firstSuccess = await runFirstSuccess({ dbPath, serverPath: join(options.projectRoot, "dist/index.js") });
+  if (firstSuccess.ok) {
+    privateWrite(artifacts[0], configs.codexToml, []);
+    privateWrite(artifacts[1], configs.claudeCodeCommand, []);
+    privateWrite(artifacts[2], configs.claudeDesktopJson, []);
+    privateWrite(artifacts[3], configs.streamableHttpJson, []);
+  } else {
+    artifacts.splice(0);
+  }
   const setupDurationMs = Date.now() - startedAt;
   const databaseBytes = statSync(dbPath).size;
   const metrics: QuickstartMetrics = {
@@ -593,6 +669,7 @@ export async function runQuickstart(options: QuickstartOptions): Promise<Quickst
       ok: firstSuccess.ok,
       mode: preflight.mode,
       transport: options.transport,
+      verifiedTransport: firstSuccess.transport,
       profile: options.profile ?? null,
       preflight,
       firstSuccess,

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -1,0 +1,569 @@
+import Database from "better-sqlite3";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport, getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:net";
+import {
+  accessSync,
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  constants as fsConstants,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { PROFILE_NAMES } from "./profiles.js";
+
+export type QuickstartTransport = "stdio" | "http";
+export type CheckStatus = "pass" | "warn" | "fail";
+
+export interface PreflightCheck {
+  id: string;
+  status: CheckStatus;
+  message: string;
+}
+
+export interface PreflightOptions {
+  projectRoot: string;
+  dataDir: string;
+  configDir: string;
+  transport: QuickstartTransport;
+  embeddings: boolean;
+  profile?: string;
+  embeddingModel?: string;
+  apiKeyPresent?: boolean;
+  port?: number;
+  nodeVersion?: string;
+  platform?: NodeJS.Platform | string;
+}
+
+export interface PreflightResult {
+  ok: boolean;
+  mode: "lexical-first" | "semantic";
+  checks: PreflightCheck[];
+}
+
+export interface ClientConfigurations {
+  codexToml: string;
+  claudeCodeCommand: string;
+  claudeDesktopJson: string;
+  streamableHttpJson: string;
+}
+
+export interface ClientConfigurationOptions {
+  projectRoot: string;
+  dataDir: string;
+  serverUrl?: string;
+}
+
+export interface FirstSuccessStep {
+  id: "orient" | "status" | "write" | "log" | "resume" | "inspect";
+  ok: boolean;
+  message: string;
+}
+
+export interface FirstSuccessResult {
+  ok: boolean;
+  namespace: string;
+  entryId: string;
+  coldStartMs: number;
+  durationMs: number;
+  steps: FirstSuccessStep[];
+}
+
+export interface QuickstartOptions extends PreflightOptions {
+  serverUrl?: string;
+  installDurationMs?: number;
+  sensitiveValues?: string[];
+}
+
+export interface QuickstartMetrics {
+  installDurationMs: number;
+  coldStartMs: number;
+  setupDurationMs: number;
+  totalDurationMs: number;
+  rssBytes: number;
+  databaseBytes: number;
+  diskFootprintBytes: number;
+}
+
+export interface QuickstartResult {
+  ok: boolean;
+  preflight: PreflightResult;
+  firstSuccess?: FirstSuccessResult;
+  artifacts: string[];
+  metrics: QuickstartMetrics;
+}
+
+const LOCAL_ENV = {
+  MUNIN_EMBEDDINGS_ENABLED: "false",
+  MUNIN_SEMANTIC_ENABLED: "false",
+  MUNIN_HYBRID_ENABLED: "false",
+} as const;
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function tomlString(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function localMcpDefinition(projectRoot: string, dataDir: string) {
+  return {
+    type: "stdio",
+    command: "node",
+    args: [join(resolve(projectRoot), "dist/index.js")],
+    env: {
+      MUNIN_MEMORY_DB_PATH: join(resolve(dataDir), "memory.db"),
+      ...LOCAL_ENV,
+    },
+  };
+}
+
+export function generateClientConfigurations(options: ClientConfigurationOptions): ClientConfigurations {
+  const definition = localMcpDefinition(options.projectRoot, options.dataDir);
+  const envLines = Object.entries(definition.env)
+    .map(([key, value]) => `${key} = ${tomlString(value)}`)
+    .join("\n");
+  const codexToml = [
+    "[mcp_servers.munin-memory]",
+    `command = ${tomlString(definition.command)}`,
+    `args = [${definition.args.map(tomlString).join(", ")}]`,
+    "",
+    "[mcp_servers.munin-memory.env]",
+    envLines,
+    "",
+  ].join("\n");
+
+  const claudePayload = JSON.stringify(definition);
+  const claudeDesktopJson = json({
+    mcpServers: {
+      "munin-memory": {
+        command: definition.command,
+        args: definition.args,
+        env: definition.env,
+      },
+    },
+  });
+  const streamableHttpJson = json({
+    transport: "streamable-http",
+    url: options.serverUrl ?? "http://127.0.0.1:3030/mcp",
+    headers: {
+      Authorization: "Bearer <MUNIN_API_KEY>",
+    },
+  });
+
+  return {
+    codexToml,
+    claudeCodeCommand: `claude mcp add-json munin-memory ${shellSingleQuote(claudePayload)} -s user\n`,
+    claudeDesktopJson,
+    streamableHttpJson,
+  };
+}
+
+export function validateGeneratedClientConfigurations(configs: ClientConfigurations): string[] {
+  const errors: string[] = [];
+  if (!configs.codexToml.includes("[mcp_servers.munin-memory]")) {
+    errors.push("Codex configuration is missing the MCP server table.");
+  }
+  if (!configs.codexToml.includes("MUNIN_MEMORY_DB_PATH")) {
+    errors.push("Codex configuration is missing the database path.");
+  }
+  if (!configs.claudeCodeCommand.startsWith("claude mcp add-json munin-memory ")) {
+    errors.push("Claude Code command is not an add-json command.");
+  }
+  try {
+    const parsed = JSON.parse(configs.claudeDesktopJson) as {
+      mcpServers?: Record<string, { command?: unknown; args?: unknown; env?: unknown }>;
+    };
+    const server = parsed.mcpServers?.["munin-memory"];
+    if (server?.command !== "node" || !Array.isArray(server.args) || typeof server.env !== "object") {
+      errors.push("Claude Desktop configuration has an invalid stdio server shape.");
+    }
+  } catch {
+    errors.push("Claude Desktop configuration is not valid JSON.");
+  }
+  try {
+    const parsed = JSON.parse(configs.streamableHttpJson) as {
+      transport?: unknown;
+      url?: unknown;
+      headers?: { Authorization?: unknown };
+    };
+    if (
+      parsed.transport !== "streamable-http" ||
+      typeof parsed.url !== "string" ||
+      parsed.headers?.Authorization !== "Bearer <MUNIN_API_KEY>"
+    ) {
+      errors.push("Streamable HTTP configuration has an invalid or unsafe shape.");
+    }
+  } catch {
+    errors.push("Streamable HTTP configuration is not valid JSON.");
+  }
+  return errors;
+}
+
+function ensurePrivateDirectory(path: string): void {
+  if (!existsSync(path)) mkdirSync(path, { recursive: true, mode: 0o700 });
+}
+
+function permissionCheck(id: string, path: string, label: string): PreflightCheck {
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      return { id, status: "fail", message: `${label} must not be a symbolic link: ${path}.` };
+    }
+    if (!stat.isDirectory()) {
+      return { id, status: "fail", message: `${label} must be a directory: ${path}.` };
+    }
+    accessSync(path, fsConstants.R_OK | fsConstants.W_OK);
+    const mode = stat.mode & 0o777;
+    if ((mode & 0o077) !== 0) {
+      return {
+        id,
+        status: "fail",
+        message: `${label} is accessible by group/other (${mode.toString(8)}); run chmod 700 ${path}.`,
+      };
+    }
+    return { id, status: "pass", message: `${label} is writable and owner-only.` };
+  } catch {
+    return { id, status: "fail", message: `${label} is not readable and writable: ${path}.` };
+  }
+}
+
+function databasePermissionCheck(dataDir: string): PreflightCheck {
+  const path = join(dataDir, "memory.db");
+  if (!existsSync(path)) {
+    return { id: "database-permissions", status: "pass", message: "New database will be created owner-only (0600)." };
+  }
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      return { id: "database-permissions", status: "fail", message: `Database must not be a symbolic link: ${path}.` };
+    }
+    if (!stat.isFile()) {
+      return { id: "database-permissions", status: "fail", message: `Database path must be a regular file: ${path}.` };
+    }
+    const mode = stat.mode & 0o777;
+    return (mode & 0o077) === 0
+      ? { id: "database-permissions", status: "pass", message: "Existing database is owner-only." }
+      : { id: "database-permissions", status: "fail", message: `Existing database permissions are ${mode.toString(8)}; run chmod 600 ${path}.` };
+  } catch {
+    return { id: "database-permissions", status: "fail", message: `Existing database cannot be inspected: ${path}.` };
+  }
+}
+
+async function checkPort(port: number): Promise<boolean> {
+  return new Promise((resolvePort) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", () => resolvePort(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolvePort(true));
+    });
+  });
+}
+
+function checkSqlite(): PreflightCheck {
+  let db: Database.Database | undefined;
+  try {
+    db = new Database(":memory:");
+    const version = db.prepare("SELECT sqlite_version() AS version").get() as { version: string };
+    db.exec("CREATE VIRTUAL TABLE quickstart_fts USING fts5(content)");
+    return {
+      id: "sqlite-fts5",
+      status: "pass",
+      message: `SQLite ${version.version} and FTS5 are available.`,
+    };
+  } catch {
+    return {
+      id: "sqlite-fts5",
+      status: "fail",
+      message: "SQLite or FTS5 is unavailable; reinstall dependencies for this platform.",
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+export async function runPreflight(options: PreflightOptions): Promise<PreflightResult> {
+  ensurePrivateDirectory(options.dataDir);
+  ensurePrivateDirectory(options.configDir);
+  const checks: PreflightCheck[] = [];
+  const platform = options.platform ?? process.platform;
+  checks.push(
+    platform === "darwin" || platform === "linux"
+      ? { id: "platform", status: "pass", message: `${platform} is supported.` }
+      : { id: "platform", status: "fail", message: `${platform} is not a supported quick-start platform.` },
+  );
+
+  const nodeVersion = options.nodeVersion ?? process.version;
+  const nodeMajor = Number(nodeVersion.match(/^v?(\d+)/)?.[1]);
+  checks.push(
+    Number.isInteger(nodeMajor) && nodeMajor >= 20
+      ? { id: "node", status: "pass", message: `Node ${nodeVersion} satisfies Node 20+.` }
+      : { id: "node", status: "fail", message: `Node ${nodeVersion} is unsupported; install Node 20 or newer.` },
+  );
+
+  const packagePath = join(options.projectRoot, "package.json");
+  const serverPath = join(options.projectRoot, "dist/index.js");
+  checks.push(
+    existsSync(packagePath) && existsSync(serverPath)
+      ? { id: "build", status: "pass", message: "Built Munin server entrypoint is present." }
+      : { id: "build", status: "fail", message: "Munin is not built; run npm ci and npm run build." },
+  );
+
+  const validProfile = options.profile === undefined || (PROFILE_NAMES as readonly string[]).includes(options.profile);
+  checks.push(
+    validProfile
+      ? { id: "profile", status: "pass", message: options.profile ? `Profile ${options.profile} is valid.` : "No hardware profile override is set." }
+      : { id: "profile", status: "fail", message: `Unknown profile ${options.profile}; use ${PROFILE_NAMES.join(", ")}.` },
+  );
+  checks.push(permissionCheck("data-permissions", options.dataDir, "Data directory"));
+  checks.push(permissionCheck("config-permissions", options.configDir, "Configuration directory"));
+  checks.push(databasePermissionCheck(options.dataDir));
+  checks.push(checkSqlite());
+
+  if (options.embeddings) {
+    const model = options.embeddingModel?.trim();
+    checks.push({
+      id: "embedding-mode",
+      status: model === "" ? "fail" : "warn",
+      message:
+        model === ""
+          ? "Embeddings were requested but the model identifier is empty."
+          : `Semantic mode requested${model ? ` with ${model}` : ""}; first start may download model data.`,
+    });
+  } else {
+    checks.push({
+      id: "embedding-mode",
+      status: "pass",
+      message: "First success deliberately uses lexical mode; enable embeddings after verification.",
+    });
+  }
+
+  if (options.transport === "http") {
+    checks.push(
+      options.apiKeyPresent
+        ? { id: "http-auth", status: "pass", message: "An HTTP bearer credential is configured (value not displayed)." }
+        : { id: "http-auth", status: "fail", message: "HTTP mode requires MUNIN_API_KEY or a scoped bearer credential." },
+    );
+    const port = options.port ?? 3030;
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+      checks.push({ id: "port", status: "fail", message: `Invalid HTTP port ${String(port)}; use an integer from 1 to 65535.` });
+    } else {
+      checks.push(
+        (await checkPort(port))
+          ? { id: "port", status: "pass", message: `127.0.0.1:${port} is available.` }
+          : { id: "port", status: "fail", message: `127.0.0.1:${port} is already in use.` },
+      );
+    }
+  } else {
+    checks.push({ id: "http-auth", status: "pass", message: "Local stdio mode does not require a bearer credential." });
+    checks.push({ id: "port", status: "pass", message: "Local stdio mode does not open a network port." });
+  }
+
+  return {
+    ok: checks.every((check) => check.status !== "fail"),
+    mode: options.embeddings ? "semantic" : "lexical-first",
+    checks,
+  };
+}
+
+function parseToolResponse(raw: unknown): Record<string, unknown> {
+  const response = raw as { content?: Array<{ type?: string; text?: string }> };
+  const text = response.content?.find((item) => item.type === "text")?.text;
+  if (!text) throw new Error("MCP tool returned no text result.");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+function toolSucceeded(value: Record<string, unknown>): boolean {
+  return value.ok === true && value.error === undefined;
+}
+
+export async function runFirstSuccess(options: { dbPath: string; serverPath?: string }): Promise<FirstSuccessResult> {
+  const startedAt = Date.now();
+  const namespace = "onboarding/quickstart";
+  const key = `first-success-${randomUUID()}`;
+  const serverPath = options.serverPath ?? join(resolve("."), "dist/index.js");
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverPath],
+    cwd: dirname(dirname(serverPath)),
+    env: {
+      ...getDefaultEnvironment(),
+      MUNIN_TRANSPORT: "stdio",
+      MUNIN_MEMORY_DB_PATH: options.dbPath,
+      MUNIN_EMBEDDINGS_ENABLED: "false",
+      MUNIN_SEMANTIC_ENABLED: "false",
+      MUNIN_HYBRID_ENABLED: "false",
+      MUNIN_CONSOLIDATION_ENABLED: "false",
+    },
+    stderr: "pipe",
+  });
+  let serverStderr = "";
+  transport.stderr?.on("data", (chunk: Buffer | string) => {
+    if (serverStderr.length < 8_000) serverStderr += chunk.toString();
+  });
+  const client = new Client({ name: "munin-quickstart", version: "0.5.0" });
+  const connectStartedAt = Date.now();
+  let coldStartMs = 0;
+  const call = async (name: string, args: Record<string, unknown> = {}) =>
+    parseToolResponse(await client.callTool({ name, arguments: args }));
+  const steps: FirstSuccessStep[] = [];
+  let entryId = "";
+  const record = (id: FirstSuccessStep["id"], result: Record<string, unknown>, message: string) => {
+    steps.push({ id, ok: toolSucceeded(result), message });
+  };
+
+  try {
+    await client.connect(transport);
+    coldStartMs = Date.now() - connectStartedAt;
+    const orient = await call("memory_orient", { detail: "compact", include_namespaces: false });
+    record("orient", orient, "Session handshake returned conventions and dashboard context.");
+    const status = await call("memory_status");
+    record("status", status, "Server capability status is available.");
+    const write = await call("memory_write", {
+      namespace,
+      key,
+      content: "Munin quick-start write-to-resume verification succeeded.",
+      tags: ["milestone", "topic:quickstart"],
+      create_if_absent: true,
+    });
+    entryId = typeof write.id === "string" ? write.id : "";
+    record("write", write, "Created an isolated first-success state entry.");
+    const log = await call("memory_log", {
+      namespace,
+      content: "Completed the canonical Munin quick-start verification flow.",
+      tags: ["milestone", "topic:quickstart"],
+    });
+    record("log", log, "Appended a first-success milestone log.");
+    const resume = await call("memory_resume", { namespace, limit: 6, include_history: true });
+    record("resume", resume, "Resume returned the new onboarding context.");
+    const inspect = await call("memory_read", { namespace, key });
+    const inspectedContent = typeof inspect.content === "string" ? inspect.content : "";
+    const inspectOk = toolSucceeded(inspect) && inspectedContent.includes("write-to-resume verification succeeded");
+    steps.push({ id: "inspect", ok: inspectOk, message: "Read-back matched the created state entry." });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const diagnostic = serverStderr.trim().slice(-2_000);
+    throw new Error(`MCP stdio verification failed: ${message}${diagnostic ? `\nServer diagnostics:\n${diagnostic}` : ""}`);
+  } finally {
+    await client.close();
+  }
+
+  return {
+    ok: steps.length === 6 && steps.every((step) => step.ok) && entryId.length > 0,
+    namespace,
+    entryId,
+    coldStartMs,
+    durationMs: Date.now() - startedAt,
+    steps,
+  };
+}
+
+export function redactSensitiveText(text: string, sensitiveValues: string[] = []): string {
+  let redacted = text.replace(/Bearer\s+[A-Za-z0-9._~+\/-]{12,}/gi, "Bearer [REDACTED]");
+  for (const value of sensitiveValues) {
+    if (value.length >= 8) redacted = redacted.replaceAll(value, "[REDACTED]");
+  }
+  return redacted;
+}
+
+function privateWrite(path: string, content: string, sensitiveValues: string[]): void {
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
+    throw new Error(`Refusing to overwrite symbolic-link artifact: ${path}`);
+  }
+  writeFileSync(path, redactSensitiveText(content, sensitiveValues), { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+function directorySize(path: string): number {
+  if (!existsSync(path)) return 0;
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) return stat.size;
+  if (!stat.isDirectory()) return stat.size;
+  let total = 0;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.name === ".git") continue;
+    total += directorySize(join(path, entry.name));
+  }
+  return total;
+}
+
+function emptyMetrics(installDurationMs: number): QuickstartMetrics {
+  return {
+    installDurationMs,
+    coldStartMs: 0,
+    setupDurationMs: 0,
+    totalDurationMs: installDurationMs,
+    rssBytes: process.memoryUsage().rss,
+    databaseBytes: 0,
+    diskFootprintBytes: 0,
+  };
+}
+
+export async function runQuickstart(options: QuickstartOptions): Promise<QuickstartResult> {
+  const startedAt = Date.now();
+  const installDurationMs = Math.max(0, options.installDurationMs ?? 0);
+  const sensitiveValues = (options.sensitiveValues ?? []).filter(Boolean);
+  const preflight = await runPreflight(options);
+  if (!preflight.ok) {
+    return { ok: false, preflight, artifacts: [], metrics: emptyMetrics(installDurationMs) };
+  }
+
+  const configs = generateClientConfigurations(options);
+  const configErrors = validateGeneratedClientConfigurations(configs);
+  if (configErrors.length > 0) throw new Error(configErrors.join(" "));
+  const artifacts = [
+    join(options.configDir, "codex.toml"),
+    join(options.configDir, "claude-code.txt"),
+    join(options.configDir, "claude-desktop.json"),
+    join(options.configDir, "streamable-http.json"),
+  ];
+  privateWrite(artifacts[0], configs.codexToml, sensitiveValues);
+  privateWrite(artifacts[1], configs.claudeCodeCommand, sensitiveValues);
+  privateWrite(artifacts[2], configs.claudeDesktopJson, sensitiveValues);
+  privateWrite(artifacts[3], configs.streamableHttpJson, sensitiveValues);
+
+  const dbPath = join(options.dataDir, "memory.db");
+  const firstSuccess = await runFirstSuccess({ dbPath, serverPath: join(options.projectRoot, "dist/index.js") });
+  const setupDurationMs = Date.now() - startedAt;
+  const databaseBytes = statSync(dbPath).size;
+  const metrics: QuickstartMetrics = {
+    installDurationMs,
+    coldStartMs: firstSuccess.coldStartMs,
+    setupDurationMs,
+    totalDurationMs: installDurationMs + setupDurationMs,
+    rssBytes: process.memoryUsage().rss,
+    databaseBytes,
+    diskFootprintBytes:
+      directorySize(options.projectRoot) + directorySize(options.dataDir) + directorySize(options.configDir),
+  };
+  const reportPath = join(options.configDir, "last-run.json");
+  artifacts.push(reportPath);
+  privateWrite(
+    reportPath,
+    json({
+      schema: "munin-quickstart/v1",
+      generatedAt: new Date().toISOString(),
+      ok: firstSuccess.ok,
+      mode: preflight.mode,
+      transport: options.transport,
+      profile: options.profile ?? null,
+      preflight,
+      firstSuccess,
+      metrics,
+      artifacts,
+    }),
+    sensitiveValues,
+  );
+  return { ok: firstSuccess.ok, preflight, firstSuccess, artifacts, metrics };
+}

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -5,10 +5,14 @@ import { randomUUID } from "node:crypto";
 import { createServer } from "node:net";
 import {
   accessSync,
-  chmodSync,
+  closeSync,
   existsSync,
+  fchmodSync,
+  fstatSync,
+  ftruncateSync,
   lstatSync,
   mkdirSync,
+  openSync,
   readdirSync,
   statSync,
   writeFileSync,
@@ -491,11 +495,30 @@ export function redactSensitiveText(text: string, sensitiveValues: string[] = []
 }
 
 function privateWrite(path: string, content: string, sensitiveValues: string[]): void {
-  if (existsSync(path) && lstatSync(path).isSymbolicLink()) {
-    throw new Error(`Refusing to overwrite symbolic-link artifact: ${path}`);
+  let descriptor: number;
+  try {
+    descriptor = openSync(
+      path,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new Error(`Refusing to overwrite symbolic-link artifact: ${path}`);
+    }
+    throw error;
   }
-  writeFileSync(path, redactSensitiveText(content, sensitiveValues), { mode: 0o600 });
-  chmodSync(path, 0o600);
+  try {
+    const stat = fstatSync(descriptor);
+    if (!stat.isFile() || stat.nlink !== 1) {
+      throw new Error(`Refusing to overwrite non-regular or multiply linked artifact: ${path}`);
+    }
+    fchmodSync(descriptor, 0o600);
+    ftruncateSync(descriptor, 0);
+    writeFileSync(descriptor, redactSensitiveText(content, sensitiveValues), "utf8");
+  } finally {
+    closeSync(descriptor);
+  }
 }
 
 function directorySize(path: string): number {

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -14,7 +14,7 @@ import {
   writeFileSync,
   constants as fsConstants,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { PROFILE_NAMES } from "./profiles.js";
 
 export type QuickstartTransport = "stdio" | "http";
@@ -119,7 +119,7 @@ function shellSingleQuote(value: string): string {
 function localMcpDefinition(projectRoot: string, dataDir: string) {
   return {
     type: "stdio",
-    command: "node",
+    command: process.execPath,
     args: [join(resolve(projectRoot), "dist/index.js")],
     env: {
       MUNIN_MEMORY_DB_PATH: join(resolve(dataDir), "memory.db"),
@@ -185,7 +185,12 @@ export function validateGeneratedClientConfigurations(configs: ClientConfigurati
       mcpServers?: Record<string, { command?: unknown; args?: unknown; env?: unknown }>;
     };
     const server = parsed.mcpServers?.["munin-memory"];
-    if (server?.command !== "node" || !Array.isArray(server.args) || typeof server.env !== "object") {
+    if (
+      typeof server?.command !== "string" ||
+      !isAbsolute(server.command) ||
+      !Array.isArray(server.args) ||
+      typeof server.env !== "object"
+    ) {
       errors.push("Claude Desktop configuration has an invalid stdio server shape.");
     }
   } catch {
@@ -429,7 +434,12 @@ export async function runFirstSuccess(options: { dbPath: string; serverPath?: st
     const orient = await call("memory_orient", { detail: "compact", include_namespaces: false });
     record("orient", orient, "Session handshake returned conventions and dashboard context.");
     const status = await call("memory_status");
-    record("status", status, "Server capability status is available.");
+    const health = await call("memory_health");
+    steps.push({
+      id: "status",
+      ok: toolSucceeded(status) && toolSucceeded(health),
+      message: "Server capability status and owner health snapshot are available.",
+    });
     const write = await call("memory_write", {
       namespace,
       key,
@@ -470,9 +480,12 @@ export async function runFirstSuccess(options: { dbPath: string; serverPath?: st
 }
 
 export function redactSensitiveText(text: string, sensitiveValues: string[] = []): string {
-  let redacted = text.replace(/Bearer\s+[A-Za-z0-9._~+\/-]{12,}/gi, "Bearer [REDACTED]");
+  let redacted = text.replace(
+    /Bearer\s+(<MUNIN_API_KEY>|[^\s"',}\]]+)/gi,
+    (match, credential: string) => credential === "<MUNIN_API_KEY>" ? match : "Bearer [REDACTED]",
+  );
   for (const value of sensitiveValues) {
-    if (value.length >= 8) redacted = redacted.replaceAll(value, "[REDACTED]");
+    if (value.length > 0) redacted = redacted.replaceAll(value, "[REDACTED]");
   }
   return redacted;
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -212,13 +212,16 @@ function consumeDeleteToken(token: string, namespace: string, key?: string): boo
   return true;
 }
 
-// Clean expired tokens periodically
-setInterval(() => {
+// Clean expired tokens periodically. The timer must not keep one-shot consumers
+// (admin/quick-start tooling and focused test processes) alive after their work
+// is complete.
+const deleteTokenCleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [token, entry] of deleteTokens) {
     if (entry.expiresAt < now) deleteTokens.delete(token);
   }
 }, 30_000);
+deleteTokenCleanupTimer.unref();
 
 // --- Display timestamp formatting ---
 

--- a/tests/quickstart-cli.test.ts
+++ b/tests/quickstart-cli.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseQuickstartArgs, runQuickstartCli, type QuickstartCliIo } from "../src/quickstart-cli.js";
+
+const tempRoots: string[] = [];
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function makeRoot(): { root: string; project: string; data: string; config: string } {
+  const root = mkdtempSync(join(tmpdir(), "munin-quickstart-cli-test-"));
+  tempRoots.push(root);
+  const project = join(root, "project");
+  mkdirSync(join(project, "dist"), { recursive: true, mode: 0o700 });
+  writeFileSync(join(project, "package.json"), '{"name":"munin-memory"}\n');
+  writeFileSync(join(project, "dist/index.js"), "// built\n");
+  return { root, project, data: join(root, "data"), config: join(root, "config") };
+}
+
+function captureIo(): { io: QuickstartCliIo; output: string[]; errors: string[] } {
+  const output: string[] = [];
+  const errors: string[] = [];
+  return {
+    io: { log: (message) => output.push(message), error: (message) => errors.push(message) },
+    output,
+    errors,
+  };
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("quickstart CLI", () => {
+  it("parses supported options and environment without exposing credentials", () => {
+    const paths = makeRoot();
+    const options = parseQuickstartArgs(
+      [
+        "--project-root", paths.project,
+        "--data-dir", paths.data,
+        "--config-dir", paths.config,
+        "--transport", "http",
+        "--server-url", "https://munin.example/mcp",
+        "--profile", "full-node",
+        "--json",
+      ],
+      {
+        MUNIN_API_KEY: "sensitive-owner-key",
+        MUNIN_HTTP_PORT: "4040",
+        MUNIN_QUICKSTART_INSTALL_MS: "900",
+      },
+    );
+
+    expect(options.transport).toBe("http");
+    expect(options.profile).toBe("full-node");
+    expect(options.embeddings).toBe(false);
+    expect(options.apiKeyPresent).toBe(true);
+    expect(options.port).toBe(4040);
+    expect(options.installDurationMs).toBe(900);
+    expect(options.sensitiveValues).toEqual(["sensitive-owner-key"]);
+  });
+
+  it("prints help successfully", async () => {
+    const captured = captureIo();
+    expect(await runQuickstartCli(["--help"], {}, captured.io)).toBe(0);
+    expect(captured.output.join("\n")).toContain("five-minute quick start");
+    expect(captured.errors).toEqual([]);
+  });
+
+  it("runs JSON preflight and a complete human-readable first success", async () => {
+    const paths = makeRoot();
+    const preflight = captureIo();
+    const common = [
+      "--project-root", repoRoot,
+      "--data-dir", paths.data,
+      "--config-dir", paths.config,
+    ];
+    expect(await runQuickstartCli([...common, "--preflight-only", "--json"], {}, preflight.io)).toBe(0);
+    expect(JSON.parse(preflight.output[0]) as { ok: boolean }).toMatchObject({ ok: true });
+
+    const run = captureIo();
+    expect(await runQuickstartCli(common, {}, run.io)).toBe(0);
+    expect(run.output.join("\n")).toContain("First-success flow: PASS");
+    expect(run.output.join("\n")).toContain("memory_orient");
+  });
+
+  it("returns a secret-safe actionable error for invalid input", async () => {
+    const secret = "sensitive-owner-key";
+    const captured = captureIo();
+    expect(await runQuickstartCli([`--${secret}`], { MUNIN_API_KEY: secret }, captured.io)).toBe(1);
+    expect(captured.errors[0]).toContain("[REDACTED]");
+    expect(captured.errors[0]).not.toContain(secret);
+
+    const transport = captureIo();
+    expect(await runQuickstartCli(["--transport", "tcp"], {}, transport.io)).toBe(1);
+    expect(transport.errors[0]).toContain("stdio or http");
+  });
+});

--- a/tests/quickstart-cli.test.ts
+++ b/tests/quickstart-cli.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseQuickstartArgs, runQuickstartCli, type QuickstartCliIo } from "../src/quickstart-cli.js";
+import { formatFirstSuccessLines, parseQuickstartArgs, runQuickstartCli, type QuickstartCliIo } from "../src/quickstart-cli.js";
 
 const tempRoots: string[] = [];
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -47,6 +47,7 @@ describe("quickstart CLI", () => {
       ],
       {
         MUNIN_API_KEY: "sensitive-owner-key",
+        MUNIN_HTTP_HOST: "0.0.0.0",
         MUNIN_HTTP_PORT: "4040",
         MUNIN_QUICKSTART_INSTALL_MS: "900",
       },
@@ -57,8 +58,32 @@ describe("quickstart CLI", () => {
     expect(options.embeddings).toBe(false);
     expect(options.apiKeyPresent).toBe(true);
     expect(options.port).toBe(4040);
+    expect(options.host).toBe("0.0.0.0");
     expect(options.installDurationMs).toBe(900);
     expect(options.sensitiveValues).toEqual(["sensitive-owner-key"]);
+  });
+
+  it("uses the default HTTP port when the environment value is empty", () => {
+    const options = parseQuickstartArgs([], { MUNIN_HTTP_PORT: "  " });
+    expect(options.port).toBe(3030);
+    expect(options.host).toBe("127.0.0.1");
+  });
+
+  it("formats failed first-success steps for human-readable output", () => {
+    const lines = formatFirstSuccessLines({
+      ok: false,
+      transport: "stdio",
+      namespace: "onboarding/quickstart",
+      entryId: "",
+      coldStartMs: 10,
+      durationMs: 20,
+      steps: [
+        { id: "orient", ok: true, message: "orient worked" },
+        { id: "status", ok: false, message: "health failed" },
+      ],
+    });
+    expect(lines.join("\n")).toContain("First-success flow: FAIL");
+    expect(lines.join("\n")).toContain("✗ status: health failed");
   });
 
   it("prints help successfully", async () => {

--- a/tests/quickstart-contract.test.ts
+++ b/tests/quickstart-contract.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const quickstart = readFileSync(join(repoRoot, "scripts/quickstart.sh"), "utf8");
+const smoke = readFileSync(join(repoRoot, "scripts/quickstart-smoke.sh"), "utf8");
+const ci = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+const guide = readFileSync(join(repoRoot, "docs/quickstart.md"), "utf8");
+
+describe("canonical quick-start contract", () => {
+  it("ships executable fail-fast install and smoke entry points", () => {
+    for (const path of ["scripts/quickstart.sh", "scripts/quickstart-smoke.sh"]) {
+      expect(statSync(join(repoRoot, path)).mode & 0o111).not.toBe(0);
+    }
+    expect(quickstart).toContain("set -euo pipefail");
+    expect(quickstart).toContain("npm ci");
+    expect(quickstart).toContain("npm run build");
+    expect(quickstart).toContain("dist/quickstart-cli.js");
+  });
+
+  it("runs the actual entry point in an isolated five-minute CI smoke lane", () => {
+    expect(smoke).toContain("mktemp -d");
+    expect(smoke).toContain("MUNIN_QUICKSTART_SKIP_INSTALL=1");
+    expect(smoke).toContain("elapsed >= 300");
+    expect(smoke).not.toMatch(/\bHOME=/);
+    expect(ci).toContain("run: npm run quickstart:smoke");
+  });
+
+  it("documents rollback boundaries and deliberate data retention", () => {
+    expect(guide).toContain("## Upgrade, rollback, and uninstall");
+    expect(guide).toContain("Forward-only migrations");
+    expect(guide).toContain("Retain `~/.munin-memory`");
+    expect(guide).toContain("<MUNIN_API_KEY>");
+  });
+});

--- a/tests/quickstart-contract.test.ts
+++ b/tests/quickstart-contract.test.ts
@@ -40,5 +40,6 @@ describe("canonical quick-start contract", () => {
     expect(guide).toContain("Forward-only migrations");
     expect(guide).toContain("Retain `~/.munin-memory`");
     expect(guide).toContain("<MUNIN_API_KEY>");
+    expect(guide).toContain("Ubuntu 24.04 ARM64");
   });
 });

--- a/tests/quickstart-contract.test.ts
+++ b/tests/quickstart-contract.test.ts
@@ -29,10 +29,12 @@ describe("canonical quick-start contract", () => {
   });
 
   it("runs the full canonical install on a native Linux ARM64 runner", () => {
+    const armJob = ci.split("  quickstart-arm64:")[1]?.split("\n  test:")[0] ?? "";
     expect(ci).toContain("runs-on: ubuntu-24.04-arm");
     expect(ci).toContain('MUNIN_QUICKSTART_SMOKE_FULL_INSTALL: "1"');
     expect(smoke).toContain("MUNIN_QUICKSTART_SMOKE_FULL_INSTALL");
     expect(smoke).toContain("arch=${process.arch}");
+    expect(armJob).not.toContain("cache: npm");
   });
 
   it("documents rollback boundaries and deliberate data retention", () => {
@@ -41,5 +43,6 @@ describe("canonical quick-start contract", () => {
     expect(guide).toContain("Retain `~/.munin-memory`");
     expect(guide).toContain("<MUNIN_API_KEY>");
     expect(guide).toContain("Ubuntu 24.04 ARM64");
+    expect(guide).toContain("verifiedTransport");
   });
 });

--- a/tests/quickstart-contract.test.ts
+++ b/tests/quickstart-contract.test.ts
@@ -22,10 +22,17 @@ describe("canonical quick-start contract", () => {
 
   it("runs the actual entry point in an isolated five-minute CI smoke lane", () => {
     expect(smoke).toContain("mktemp -d");
-    expect(smoke).toContain("MUNIN_QUICKSTART_SKIP_INSTALL=1");
+    expect(smoke).toContain('MUNIN_QUICKSTART_SKIP_INSTALL="$SKIP_INSTALL"');
     expect(smoke).toContain("elapsed >= 300");
     expect(smoke).not.toMatch(/\bHOME=/);
     expect(ci).toContain("run: npm run quickstart:smoke");
+  });
+
+  it("runs the full canonical install on a native Linux ARM64 runner", () => {
+    expect(ci).toContain("runs-on: ubuntu-24.04-arm");
+    expect(ci).toContain('MUNIN_QUICKSTART_SMOKE_FULL_INSTALL: "1"');
+    expect(smoke).toContain("MUNIN_QUICKSTART_SMOKE_FULL_INSTALL");
+    expect(smoke).toContain("arch=${process.arch}");
   });
 
   it("documents rollback boundaries and deliberate data retention", () => {

--- a/tests/quickstart.test.ts
+++ b/tests/quickstart.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -206,9 +206,8 @@ describe("quickstart first success", () => {
     ];
     for (const file of expectedFiles) {
       const path = join(configDir, file);
-      expect(existsSync(path)).toBe(true);
-      expect(statSync(path).mode & 0o077).toBe(0);
       expect(readFileSync(path, "utf8")).not.toContain(secret);
+      expect(statSync(path).mode & 0o077).toBe(0);
     }
     const report = JSON.parse(readFileSync(join(configDir, "last-run.json"), "utf8")) as { artifacts: string[] };
     expect(report.artifacts).toEqual(result.artifacts);
@@ -232,6 +231,26 @@ describe("quickstart first success", () => {
       transport: "stdio",
       embeddings: false,
     })).rejects.toThrow("Refusing to overwrite symbolic-link artifact");
+    expect(readFileSync(target, "utf8")).toBe("original");
+  });
+
+  it("refuses to overwrite a generated artifact through a hard link", async () => {
+    const root = makeTempRoot();
+    const projectRoot = makeProjectRoot(root);
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
+    mkdirSync(configDir, { mode: 0o700 });
+    const target = join(root, "must-not-change");
+    writeFileSync(target, "original");
+    linkSync(target, join(configDir, "codex.toml"));
+
+    await expect(runQuickstart({
+      projectRoot,
+      dataDir,
+      configDir,
+      transport: "stdio",
+      embeddings: false,
+    })).rejects.toThrow("multiply linked artifact");
     expect(readFileSync(target, "utf8")).toBe("original");
   });
 });

--- a/tests/quickstart.test.ts
+++ b/tests/quickstart.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  generateClientConfigurations,
+  runFirstSuccess,
+  runPreflight,
+  runQuickstart,
+  validateGeneratedClientConfigurations,
+} from "../src/quickstart.js";
+
+const tempRoots: string[] = [];
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "munin-quickstart-test-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function makeProjectRoot(root: string): string {
+  const projectRoot = join(root, "project");
+  const distDir = join(projectRoot, "dist");
+  mkdirSync(distDir, { recursive: true, mode: 0o700 });
+  writeFileSync(join(projectRoot, "package.json"), '{"name":"munin-memory"}\n');
+  writeFileSync(join(distDir, "index.js"), "// built server\n");
+  return projectRoot;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("quickstart client configuration", () => {
+  it("generates schema-checked local and HTTP examples with placeholders only", () => {
+    const root = makeTempRoot();
+    const projectRoot = repoRoot;
+    const dataDir = join(root, "data");
+    const configs = generateClientConfigurations({
+      projectRoot,
+      dataDir,
+      serverUrl: "https://munin.example.test/mcp",
+    });
+
+    expect(validateGeneratedClientConfigurations(configs)).toEqual([]);
+    expect(configs.codexToml).toContain("[mcp_servers.munin-memory]");
+    expect(configs.codexToml).toContain(join(projectRoot, "dist/index.js"));
+    expect(configs.claudeCodeCommand).toContain("claude mcp add-json");
+
+    const desktop = JSON.parse(configs.claudeDesktopJson) as {
+      mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+    };
+    expect(desktop.mcpServers["munin-memory"].command).toBe("node");
+    expect(desktop.mcpServers["munin-memory"].env.MUNIN_EMBEDDINGS_ENABLED).toBe("false");
+
+    const http = JSON.parse(configs.streamableHttpJson) as {
+      url: string;
+      headers: Record<string, string>;
+    };
+    expect(http.url).toBe("https://munin.example.test/mcp");
+    expect(http.headers.Authorization).toBe("Bearer <MUNIN_API_KEY>");
+
+    const combined = Object.values(configs).join("\n");
+    expect(combined).not.toContain("real-sensitive-token");
+    expect(combined).not.toMatch(/Bearer (?!<MUNIN_API_KEY>)[A-Za-z0-9._-]{16,}/);
+  });
+});
+
+describe("quickstart preflight", () => {
+  it("passes the supported lexical-first local path and verifies SQLite FTS5", async () => {
+    const root = makeTempRoot();
+    const projectRoot = repoRoot;
+    const result = await runPreflight({
+      projectRoot,
+      dataDir: join(root, "data"),
+      configDir: join(root, "config"),
+      transport: "stdio",
+      embeddings: false,
+      nodeVersion: "v20.19.0",
+      platform: "linux",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((check) => check.id === "sqlite-fts5")?.status).toBe("pass");
+    expect(result.checks.find((check) => check.id === "embedding-mode")?.message).toContain("lexical");
+  });
+
+  it("fails before startup for unsupported runtime, profile, insecure paths, and missing HTTP auth", async () => {
+    const root = makeTempRoot();
+    const projectRoot = makeProjectRoot(root);
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
+    mkdirSync(dataDir, { mode: 0o755 });
+    mkdirSync(configDir, { mode: 0o755 });
+    chmodSync(dataDir, 0o755);
+    chmodSync(configDir, 0o755);
+    writeFileSync(join(dataDir, "memory.db"), "unsafe");
+    chmodSync(join(dataDir, "memory.db"), 0o644);
+
+    const result = await runPreflight({
+      projectRoot,
+      dataDir,
+      configDir,
+      transport: "http",
+      embeddings: true,
+      embeddingModel: "",
+      profile: "imaginary-profile",
+      nodeVersion: "v18.20.0",
+      platform: "win32",
+      apiKeyPresent: false,
+      port: 70_000,
+    });
+
+    expect(result.ok).toBe(false);
+    for (const id of ["platform", "node", "profile", "data-permissions", "config-permissions", "database-permissions", "embedding-mode", "http-auth", "port"]) {
+      expect(result.checks.find((check) => check.id === id)?.status).toBe("fail");
+    }
+  });
+
+  it("rejects non-directory roots and symbolic-link data paths before startup", async () => {
+    const root = makeTempRoot();
+    const projectRoot = makeProjectRoot(root);
+    const realData = join(root, "real-data");
+    const dataLink = join(root, "data-link");
+    const configFile = join(root, "config-file");
+    mkdirSync(realData, { mode: 0o700 });
+    symlinkSync(realData, dataLink);
+    writeFileSync(configFile, "not a directory", { mode: 0o600 });
+
+    const result = await runPreflight({
+      projectRoot,
+      dataDir: dataLink,
+      configDir: configFile,
+      transport: "stdio",
+      embeddings: false,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((check) => check.id === "data-permissions")?.message).toContain("symbolic link");
+    expect(result.checks.find((check) => check.id === "config-permissions")?.message).toContain("must be a directory");
+  });
+});
+
+describe("quickstart first success", () => {
+  it("performs orient, status, write, log, resume, and inspect against a fresh database", async () => {
+    const root = makeTempRoot();
+    const result = await runFirstSuccess({ dbPath: join(root, "memory.db") });
+
+    expect(result.ok).toBe(true);
+    expect(result.steps.map((step) => step.id)).toEqual([
+      "orient",
+      "status",
+      "write",
+      "log",
+      "resume",
+      "inspect",
+    ]);
+    expect(result.steps.every((step) => step.ok)).toBe(true);
+    expect(result.namespace).toBe("onboarding/quickstart");
+    expect(result.entryId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("creates an isolated secret-safe setup report and client artifacts", async () => {
+    const root = makeTempRoot();
+    const projectRoot = repoRoot;
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
+    const secret = "real-sensitive-token-that-must-never-print";
+
+    const result = await runQuickstart({
+      projectRoot,
+      dataDir,
+      configDir,
+      transport: "stdio",
+      embeddings: false,
+      installDurationMs: 1234,
+      sensitiveValues: [secret],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.metrics.installDurationMs).toBe(1234);
+    expect(result.metrics.totalDurationMs).toBeLessThan(300_000);
+    expect(result.metrics.rssBytes).toBeGreaterThan(0);
+    expect(result.metrics.databaseBytes).toBeGreaterThan(0);
+
+    const expectedFiles = [
+      "codex.toml",
+      "claude-code.txt",
+      "claude-desktop.json",
+      "streamable-http.json",
+      "last-run.json",
+    ];
+    for (const file of expectedFiles) {
+      const path = join(configDir, file);
+      expect(existsSync(path)).toBe(true);
+      expect(statSync(path).mode & 0o077).toBe(0);
+      expect(readFileSync(path, "utf8")).not.toContain(secret);
+    }
+    const report = JSON.parse(readFileSync(join(configDir, "last-run.json"), "utf8")) as { artifacts: string[] };
+    expect(report.artifacts).toEqual(result.artifacts);
+    expect(statSync(join(dataDir, "memory.db")).mode & 0o077).toBe(0);
+  });
+
+  it("refuses to overwrite a generated artifact through a symbolic link", async () => {
+    const root = makeTempRoot();
+    const projectRoot = makeProjectRoot(root);
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
+    mkdirSync(configDir, { mode: 0o700 });
+    const target = join(root, "must-not-change");
+    writeFileSync(target, "original");
+    symlinkSync(target, join(configDir, "codex.toml"));
+
+    await expect(runQuickstart({
+      projectRoot,
+      dataDir,
+      configDir,
+      transport: "stdio",
+      embeddings: false,
+    })).rejects.toThrow("Refusing to overwrite symbolic-link artifact");
+    expect(readFileSync(target, "utf8")).toBe("original");
+  });
+});

--- a/tests/quickstart.test.ts
+++ b/tests/quickstart.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   generateClientConfigurations,
+  redactSensitiveText,
   runFirstSuccess,
   runPreflight,
   runQuickstart,
@@ -52,7 +53,7 @@ describe("quickstart client configuration", () => {
     const desktop = JSON.parse(configs.claudeDesktopJson) as {
       mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
     };
-    expect(desktop.mcpServers["munin-memory"].command).toBe("node");
+    expect(isAbsolute(desktop.mcpServers["munin-memory"].command)).toBe(true);
     expect(desktop.mcpServers["munin-memory"].env.MUNIN_EMBEDDINGS_ENABLED).toBe("false");
 
     const http = JSON.parse(configs.streamableHttpJson) as {
@@ -65,6 +66,16 @@ describe("quickstart client configuration", () => {
     const combined = Object.values(configs).join("\n");
     expect(combined).not.toContain("real-sensitive-token");
     expect(combined).not.toMatch(/Bearer (?!<MUNIN_API_KEY>)[A-Za-z0-9._-]{16,}/);
+  });
+});
+
+describe("quickstart secret redaction", () => {
+  it("redacts bearer material regardless of length while retaining the documented placeholder", () => {
+    expect(redactSensitiveText("Authorization: Bearer short")).toBe("Authorization: Bearer [REDACTED]");
+    expect(redactSensitiveText("Authorization: Bearer <MUNIN_API_KEY>")).toBe(
+      "Authorization: Bearer <MUNIN_API_KEY>",
+    );
+    expect(redactSensitiveText("failed with tiny", ["tiny"])).toBe("failed with [REDACTED]");
   });
 });
 
@@ -158,6 +169,7 @@ describe("quickstart first success", () => {
       "inspect",
     ]);
     expect(result.steps.every((step) => step.ok)).toBe(true);
+    expect(result.steps.find((step) => step.id === "status")?.message).toContain("health");
     expect(result.namespace).toBe("onboarding/quickstart");
     expect(result.entryId).toMatch(/^[0-9a-f-]{36}$/);
   });

--- a/tests/quickstart.test.ts
+++ b/tests/quickstart.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { chmodSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   generateClientConfigurations,
+  parseQuickstartToolResponse,
   redactSensitiveText,
   runFirstSuccess,
   runPreflight,
@@ -21,21 +22,12 @@ function makeTempRoot(): string {
   return root;
 }
 
-function makeProjectRoot(root: string): string {
-  const projectRoot = join(root, "project");
-  const distDir = join(projectRoot, "dist");
-  mkdirSync(distDir, { recursive: true, mode: 0o700 });
-  writeFileSync(join(projectRoot, "package.json"), '{"name":"munin-memory"}\n');
-  writeFileSync(join(distDir, "index.js"), "// built server\n");
-  return projectRoot;
-}
-
 afterEach(() => {
   for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe("quickstart client configuration", () => {
-  it("generates schema-checked local and HTTP examples with placeholders only", () => {
+  it("generates format-checked local and HTTP examples with placeholders only", () => {
     const root = makeTempRoot();
     const projectRoot = repoRoot;
     const dataDir = join(root, "data");
@@ -67,6 +59,17 @@ describe("quickstart client configuration", () => {
     expect(combined).not.toContain("real-sensitive-token");
     expect(combined).not.toMatch(/Bearer (?!<MUNIN_API_KEY>)[A-Za-z0-9._-]{16,}/);
   });
+
+  it("escapes control characters in generated TOML paths", () => {
+    const root = makeTempRoot();
+    const configs = generateClientConfigurations({
+      projectRoot: repoRoot,
+      dataDir: join(root, "data\nnewline"),
+    });
+
+    expect(configs.codexToml).toContain("data\\nnewline");
+    expect(validateGeneratedClientConfigurations(configs)).toEqual([]);
+  });
 });
 
 describe("quickstart secret redaction", () => {
@@ -77,16 +80,40 @@ describe("quickstart secret redaction", () => {
     );
     expect(redactSensitiveText("failed with tiny", ["tiny"])).toBe("failed with [REDACTED]");
   });
+
+  it("rejects a generated config that contains a configured credential value", async () => {
+    const root = makeTempRoot();
+    const secret = "credential-collision";
+    await expect(runQuickstart({
+      projectRoot: repoRoot,
+      dataDir: join(root, secret),
+      configDir: join(root, "config"),
+      transport: "stdio",
+      embeddings: false,
+      sensitiveValues: [secret],
+    })).rejects.toThrow("contains configured credential material");
+  });
+});
+
+describe("quickstart MCP response parsing", () => {
+  it("preserves tool-level error text", () => {
+    expect(() => parseQuickstartToolResponse({
+      isError: true,
+      content: [{ type: "text", text: "specific tool failure" }],
+    })).toThrow("specific tool failure");
+  });
 });
 
 describe("quickstart preflight", () => {
   it("passes the supported lexical-first local path and verifies SQLite FTS5", async () => {
     const root = makeTempRoot();
     const projectRoot = repoRoot;
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
     const result = await runPreflight({
       projectRoot,
-      dataDir: join(root, "data"),
-      configDir: join(root, "config"),
+      dataDir,
+      configDir,
       transport: "stdio",
       embeddings: false,
       nodeVersion: "v20.19.0",
@@ -96,11 +123,13 @@ describe("quickstart preflight", () => {
     expect(result.ok).toBe(true);
     expect(result.checks.find((check) => check.id === "sqlite-fts5")?.status).toBe("pass");
     expect(result.checks.find((check) => check.id === "embedding-mode")?.message).toContain("lexical");
+    expect(existsSync(dataDir)).toBe(false);
+    expect(existsSync(configDir)).toBe(false);
   });
 
   it("fails before startup for unsupported runtime, profile, insecure paths, and missing HTTP auth", async () => {
     const root = makeTempRoot();
-    const projectRoot = makeProjectRoot(root);
+    const projectRoot = repoRoot;
     const dataDir = join(root, "data");
     const configDir = join(root, "config");
     mkdirSync(dataDir, { mode: 0o755 });
@@ -132,7 +161,7 @@ describe("quickstart preflight", () => {
 
   it("rejects non-directory roots and symbolic-link data paths before startup", async () => {
     const root = makeTempRoot();
-    const projectRoot = makeProjectRoot(root);
+    const projectRoot = repoRoot;
     const realData = join(root, "real-data");
     const dataLink = join(root, "data-link");
     const configFile = join(root, "config-file");
@@ -152,6 +181,46 @@ describe("quickstart preflight", () => {
     expect(result.checks.find((check) => check.id === "data-permissions")?.message).toContain("symbolic link");
     expect(result.checks.find((check) => check.id === "config-permissions")?.message).toContain("must be a directory");
   });
+
+  it("rejects insecure SQLite sidecars", async () => {
+    const root = makeTempRoot();
+    const dataDir = join(root, "data");
+    const configDir = join(root, "config");
+    mkdirSync(dataDir, { mode: 0o700 });
+    mkdirSync(configDir, { mode: 0o700 });
+    writeFileSync(join(dataDir, "memory.db"), "db", { mode: 0o600 });
+    writeFileSync(join(dataDir, "memory.db-wal"), "live rows", { mode: 0o644 });
+
+    const result = await runPreflight({
+      projectRoot: repoRoot,
+      dataDir,
+      configDir,
+      transport: "stdio",
+      embeddings: false,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((check) => check.id === "database-permissions")?.message).toContain("memory.db-wal");
+  });
+
+  it("distinguishes an unavailable HTTP bind host from a busy port", async () => {
+    const root = makeTempRoot();
+    const result = await runPreflight({
+      projectRoot: repoRoot,
+      dataDir: join(root, "data"),
+      configDir: join(root, "config"),
+      transport: "http",
+      embeddings: false,
+      apiKeyPresent: true,
+      host: "203.0.113.1",
+      port: 3030,
+    });
+
+    const portCheck = result.checks.find((check) => check.id === "port");
+    expect(portCheck?.status).toBe("fail");
+    expect(portCheck?.message).toContain("cannot be bound");
+    expect(portCheck?.message).not.toContain("already in use");
+  });
 });
 
 describe("quickstart first success", () => {
@@ -169,6 +238,7 @@ describe("quickstart first success", () => {
       "inspect",
     ]);
     expect(result.steps.every((step) => step.ok)).toBe(true);
+    expect(result.transport).toBe("stdio");
     expect(result.steps.find((step) => step.id === "status")?.message).toContain("health");
     expect(result.namespace).toBe("onboarding/quickstart");
     expect(result.entryId).toMatch(/^[0-9a-f-]{36}$/);
@@ -209,14 +279,20 @@ describe("quickstart first success", () => {
       expect(readFileSync(path, "utf8")).not.toContain(secret);
       expect(statSync(path).mode & 0o077).toBe(0);
     }
-    const report = JSON.parse(readFileSync(join(configDir, "last-run.json"), "utf8")) as { artifacts: string[] };
+    const report = JSON.parse(readFileSync(join(configDir, "last-run.json"), "utf8")) as {
+      artifacts: string[];
+      transport: string;
+      verifiedTransport: string;
+    };
     expect(report.artifacts).toEqual(result.artifacts);
+    expect(report.transport).toBe("stdio");
+    expect(report.verifiedTransport).toBe("stdio");
     expect(statSync(join(dataDir, "memory.db")).mode & 0o077).toBe(0);
   });
 
   it("refuses to overwrite a generated artifact through a symbolic link", async () => {
     const root = makeTempRoot();
-    const projectRoot = makeProjectRoot(root);
+    const projectRoot = repoRoot;
     const dataDir = join(root, "data");
     const configDir = join(root, "config");
     mkdirSync(configDir, { mode: 0o700 });
@@ -236,7 +312,7 @@ describe("quickstart first success", () => {
 
   it("refuses to overwrite a generated artifact through a hard link", async () => {
     const root = makeTempRoot();
-    const projectRoot = makeProjectRoot(root);
+    const projectRoot = repoRoot;
     const dataDir = join(root, "data");
     const configDir = join(root, "config");
     mkdirSync(configDir, { mode: 0o700 });


### PR DESCRIPTION
Closes #225.

## What changed

- adds one canonical macOS/Linux quick-start entry point that installs locked dependencies, builds, and runs fail-fast environment checks
- defaults to local stdio and lexical search, then verifies the real MCP path from `memory_orient` through status/health, write/log, resume, and read-back
- generates owner-only, placeholder-only configuration examples for Codex, Claude Code, Claude Desktop, and generic Streamable HTTP clients
- adds isolated x64 and native Linux ARM64 smoke lanes; ARM64 runs the complete user-facing install, including its own cold-cache `npm ci`
- documents client connection, post-success semantic enablement, measured resource use, upgrades, rollback, and deliberate data retention
- releases the delete-token cleanup timer from the event loop so one-shot MCP clients terminate normally

## Why

The previous onboarding path required users to assemble install, transport, credential, profile, and client-configuration knowledge before proving the server worked. This gives new operators one safe lexical-first path with actionable, secret-safe failures.

## Review fixes

Direct Codex review fixed absolute Node-path handling for GUI clients, complete bearer redaction, and the missing owner health snapshot. GitHub CodeQL then identified a check/use race in artifact writes; the final implementation uses `O_NOFOLLOW`, validates the opened inode and hard-link count, and chmods/truncates/writes through that descriptor. Symlink and hard-link regressions are covered and both CodeQL threads are resolved.

Independent cross-model review ran twice through Claude Fable 5 (`claude-fable-5`), diff-only with tools disabled. The final pass returned **Ready** and confirmed all five moderate findings from the first pass were resolved: explicit human failure output, honest requested-vs-verified transport reporting, correct host/port diagnostics, exact config-byte credential safety/TOML escaping, and side-effect-free preflight. Its one requested confirmation was checked against `src/index.ts` and the HTTP transport tests: `MUNIN_API_KEY_DPA` and `MUNIN_API_KEY_CONSUMER` are valid server credentials.

## Verification

- focused quick-start suite: 24 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tools`
- `npm run build`
- `npm run quickstart:smoke`
- full coverage ratchets: 70 files passed, 1 skipped; 2470 tests passed, 4 skipped
- lexical benchmark gate: PASS
- hybrid/vector frozen-vector benchmark gate with `--require-vec`: PASS
- GitHub CI run 442: Node 20, Node 22, and native ARM64 jobs all green
- GitHub CodeQL run 239: green
- review threads: 2/2 resolved
- diff whitespace and secret-pattern checks passed

## Measurement

- macOS ARM64 / Node 26.5.0 / warm npm cache: 4.0 s install, 265 ms cold start, 4.29 s total, 80.0 MiB verifier RSS, 432 KiB database, 502 MiB footprint
- Ubuntu 24.04 ARM64 / Node 22.23.1 / empty npm cache: 12.0 s install, 306 ms cold start, 13 s wall time, 89.5 MiB verifier RSS, 432 KiB database, 520.4 MiB footprint
