### PR TITLE
fix: bound memory status telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ changelog is the canonical record of what moved.
 
 ### Changed
 
+- **`memory_status` telemetry is now explicitly bounded (#242).** Owner calls
+  aggregate at most the 5,000 most recent tool calls from the seven-day window
+  instead of synchronously scanning and sorting the entire window. The existing
+  per-tool `telemetry` row shape is preserved, while the new owner-only
+  `telemetry_meta` field reports the window, sampling order, row limit, sampled
+  call count, and whether older calls were truncated.
 - **Explicit correction/supersession and temporal validity (#192).** `memory_write`
   and `memory_log` now accept `supersedes` with mandatory compare-and-swap, creating
   a fresh revision while preserving the original UUID as historical evidence. State

--- a/docs/usage-model.md
+++ b/docs/usage-model.md
@@ -75,6 +75,12 @@ one place. If a host or deferred tool-discovery layer does not expose `memory_or
 `memory_status` to inspect available tools or `memory_resume` for targeted context as the
 fallback.
 
+For owner callers, `memory_status.telemetry` is calculated from at most the 5,000 most
+recent tool calls in its seven-day window so capability discovery remains responsive at
+production volume. Read `telemetry_meta` alongside the per-tool rows: it reports the
+sampling order and limit, how many calls were sampled, and whether older calls were
+truncated. Non-owner callers receive neither telemetry field.
+
 Use `memory_resume` after that when you already have a likely direction — a project
 name, a namespace, or a user opener such as "continue grimnir parser rollout." It
 returns a compact continuation pack: the most relevant current status, recent decision

--- a/src/db.ts
+++ b/src/db.ts
@@ -2931,6 +2931,19 @@ export interface ToolCallAggregateRow {
   p95_response_size_bytes: number | null;
 }
 
+export const TOOL_CALL_TELEMETRY_SAMPLE_LIMIT = 5_000;
+
+export interface ToolCallTelemetrySnapshot {
+  telemetry: ToolCallAggregateRow[];
+  telemetry_meta: {
+    window_days: number;
+    sampling: "most_recent";
+    sample_limit: number;
+    sampled_calls: number;
+    truncated: boolean;
+  };
+}
+
 /**
  * Nearest-rank 95th percentile over an ascending-sorted array of finite
  * numbers. Returns null for an empty array. Index is
@@ -2946,53 +2959,118 @@ function computeP95(sortedAsc: number[]): number | null {
   return sortedAsc[idx];
 }
 
+/**
+ * Build owner telemetry from a bounded sample of the most recent calls.
+ *
+ * Fetching one row beyond the limit makes truncation explicit without an
+ * unbounded COUNT/GROUP BY scan. The timestamp index can satisfy the ordered
+ * LIMIT, and all aggregation/sorting work is capped by sampleLimit.
+ */
+export function getToolCallTelemetrySnapshot(
+  db: Database.Database,
+  days: number = 7,
+  sampleLimit: number = TOOL_CALL_TELEMETRY_SAMPLE_LIMIT,
+): ToolCallTelemetrySnapshot {
+  const normalizedDays = Number.isFinite(days) && days > 0 ? days : 7;
+  const normalizedLimit = Math.max(
+    1,
+    Math.min(
+      TOOL_CALL_TELEMETRY_SAMPLE_LIMIT,
+      Number.isFinite(sampleLimit) ? Math.floor(sampleLimit) : TOOL_CALL_TELEMETRY_SAMPLE_LIMIT,
+    ),
+  );
+  const cutoff = new Date(
+    Date.now() - normalizedDays * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const emptySnapshot = (): ToolCallTelemetrySnapshot => ({
+    telemetry: [],
+    telemetry_meta: {
+      window_days: normalizedDays,
+      sampling: "most_recent",
+      sample_limit: normalizedLimit,
+      sampled_calls: 0,
+      truncated: false,
+    },
+  });
+
+  try {
+    const fetched = db
+      .prepare(
+        `SELECT tool_name, success, response_size_bytes, duration_ms
+         FROM tool_calls
+         WHERE timestamp >= ?
+         ORDER BY timestamp DESC
+         LIMIT ?`,
+      )
+      .all(cutoff, normalizedLimit + 1) as Array<{
+        tool_name: string;
+        success: number;
+        response_size_bytes: number | null;
+        duration_ms: number | null;
+      }>;
+    const truncated = fetched.length > normalizedLimit;
+    const sampled = truncated ? fetched.slice(0, normalizedLimit) : fetched;
+    const aggregates = new Map<string, {
+      totalCalls: number;
+      errorCount: number;
+      durationTotal: number;
+      durationCount: number;
+      responseSizes: number[];
+    }>();
+
+    for (const row of sampled) {
+      const aggregate = aggregates.get(row.tool_name) ?? {
+        totalCalls: 0,
+        errorCount: 0,
+        durationTotal: 0,
+        durationCount: 0,
+        responseSizes: [],
+      };
+      aggregate.totalCalls += 1;
+      if (row.success === 0) aggregate.errorCount += 1;
+      if (row.duration_ms !== null) {
+        aggregate.durationTotal += row.duration_ms;
+        aggregate.durationCount += 1;
+      }
+      if (row.response_size_bytes !== null) {
+        aggregate.responseSizes.push(row.response_size_bytes);
+      }
+      aggregates.set(row.tool_name, aggregate);
+    }
+
+    const telemetry = Array.from(aggregates, ([toolName, aggregate]) => {
+      aggregate.responseSizes.sort((a, b) => a - b);
+      return {
+        tool_name: toolName,
+        total_calls: aggregate.totalCalls,
+        error_count: aggregate.errorCount,
+        avg_duration_ms: aggregate.durationCount > 0
+          ? aggregate.durationTotal / aggregate.durationCount
+          : null,
+        p95_response_size_bytes: computeP95(aggregate.responseSizes),
+      };
+    }).sort((a, b) => b.total_calls - a.total_calls || a.tool_name.localeCompare(b.tool_name));
+
+    return {
+      telemetry,
+      telemetry_meta: {
+        window_days: normalizedDays,
+        sampling: "most_recent",
+        sample_limit: normalizedLimit,
+        sampled_calls: sampled.length,
+        truncated,
+      },
+    };
+  } catch {
+    return emptySnapshot();
+  }
+}
+
 export function getToolCallAggregates(
   db: Database.Database,
   days: number = 7,
 ): ToolCallAggregateRow[] {
-  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-  try {
-    // Header aggregates (counts, errors, avg duration). p95 is computed
-    // in JS below: easier to unit-test than a SQL window function, and
-    // independent of whichever SQLite build ships with the host driver.
-    const headers = db
-      .prepare(
-        `SELECT
-           tool_name,
-           COUNT(*) AS total_calls,
-           SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count,
-           AVG(duration_ms) AS avg_duration_ms
-         FROM tool_calls
-         WHERE timestamp >= ?
-         GROUP BY tool_name
-         ORDER BY total_calls DESC`,
-      )
-      .all(cutoff) as Array<Omit<ToolCallAggregateRow, "p95_response_size_bytes">>;
-
-    // Per-tool ordered fetch of non-null response sizes. Same cutoff as the
-    // header query so counts and p95 see the same window. Bounded by analytics
-    // retention (MUNIN_ANALYTICS_RETENTION_DAYS, default 90).
-    const sizeStmt = db.prepare(
-      `SELECT response_size_bytes
-         FROM tool_calls
-         WHERE tool_name = ?
-           AND timestamp >= ?
-           AND response_size_bytes IS NOT NULL
-         ORDER BY response_size_bytes ASC`,
-    );
-
-    return headers.map((row) => {
-      const sizes = (sizeStmt.all(row.tool_name, cutoff) as Array<{
-        response_size_bytes: number;
-      }>).map((r) => r.response_size_bytes);
-      return {
-        ...row,
-        p95_response_size_bytes: computeP95(sizes),
-      };
-    });
-  } catch {
-    return [];
-  }
+  return getToolCallTelemetrySnapshot(db, days).telemetry;
 }
 
 export function pruneRetrievalAnalytics(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -67,7 +67,7 @@ import {
   logRetrievalFeedback,
   getRetrievalAggregates,
   logToolCall,
-  getToolCallAggregates,
+  getToolCallTelemetrySnapshot,
   getAuditHistoryPage,
   insertRedactionLog,
   getOtherKeysInNamespaceByClassification,
@@ -8230,7 +8230,9 @@ export function registerTools(
                 librarian,
               };
               if (ctx.principalType === "owner") {
-                statusResponse.telemetry = getToolCallAggregates(db, 7);
+                const telemetrySnapshot = getToolCallTelemetrySnapshot(db, 7);
+                statusResponse.telemetry = telemetrySnapshot.telemetry;
+                statusResponse.telemetry_meta = telemetrySnapshot.telemetry_meta;
                 // Detailed health breakdown (owner-only) — includes circuit breaker
                 // state, failure count, and last error so failures are never silent.
                 statusResponse.consolidation_health = getConsolidationHealth();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -33,6 +33,7 @@ import {
   rebuildFTS,
   logToolCall,
   getToolCallAggregates,
+  getToolCallTelemetrySnapshot,
   queryEntriesSemanticScored,
   storeEmbedding,
   vecLoaded,
@@ -1218,6 +1219,51 @@ describe("getToolCallAggregates p95_response_size_bytes", () => {
       "tool_name",
       "total_calls",
     ]);
+  });
+
+  it("bounds telemetry to the deterministic most-recent sample and reports truncation (#242)", () => {
+    const insertAt = (
+      id: string,
+      timestamp: string,
+      toolName: string,
+      success: boolean,
+      sizeBytes: number,
+      durationMs: number,
+    ) => {
+      db.prepare(
+        `INSERT INTO tool_calls (
+           id, timestamp, session_id, principal_id, tool_name, success,
+           error_type, response_size_bytes, duration_ms
+         ) VALUES (?, ?, NULL, NULL, ?, ?, NULL, ?, ?)`,
+      ).run(id, timestamp, toolName, success ? 1 : 0, sizeBytes, durationMs);
+    };
+
+    const now = Date.now();
+    insertAt("oldest", new Date(now - 4_000).toISOString(), "excluded_tool", true, 999, 999);
+    insertAt("recent-1", new Date(now - 3_000).toISOString(), "memory_read", true, 10, 10);
+    insertAt("recent-2", new Date(now - 2_000).toISOString(), "memory_read", false, 20, 20);
+    insertAt("newest", new Date(now - 1_000).toISOString(), "memory_write", true, 30, 30);
+
+    const snapshot = getToolCallTelemetrySnapshot(db, 7, 3);
+
+    expect(snapshot.telemetry_meta).toEqual({
+      window_days: 7,
+      sampling: "most_recent",
+      sample_limit: 3,
+      sampled_calls: 3,
+      truncated: true,
+    });
+    expect(snapshot.telemetry.map((row) => row.tool_name)).toEqual([
+      "memory_read",
+      "memory_write",
+    ]);
+    expect(snapshot.telemetry.find((row) => row.tool_name === "excluded_tool")).toBeUndefined();
+    expect(snapshot.telemetry.find((row) => row.tool_name === "memory_read")).toMatchObject({
+      total_calls: 2,
+      error_count: 1,
+      avg_duration_ms: 15,
+      p95_response_size_bytes: 20,
+    });
   });
 });
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -7144,9 +7144,15 @@ describe("memory_status", () => {
     };
 
     const raw = await agentCallTool("memory_status", {});
-    const result = parseToolResponse(raw) as { principal: { id: string; type: string } };
+    const result = parseToolResponse(raw) as {
+      principal: { id: string; type: string };
+      telemetry?: unknown;
+      telemetry_meta?: unknown;
+    };
     expect(result.principal.id).toBe("agent:test");
     expect(result.principal.type).toBe("agent");
+    expect(result.telemetry).toBeUndefined();
+    expect(result.telemetry_meta).toBeUndefined();
   });
 
   it("includes telemetry aggregates for owner (#28)", async () => {
@@ -7163,9 +7169,23 @@ describe("memory_status", () => {
         avg_duration_ms: number | null;
         p95_response_size_bytes: number | null;
       }>;
+      telemetry_meta: {
+        window_days: number;
+        sampling: string;
+        sample_limit: number;
+        sampled_calls: number;
+        truncated: boolean;
+      };
     };
 
     expect(Array.isArray(result.telemetry)).toBe(true);
+    expect(result.telemetry_meta).toEqual({
+      window_days: 7,
+      sampling: "most_recent",
+      sample_limit: 5000,
+      sampled_calls: expect.any(Number),
+      truncated: false,
+    });
     // At minimum, the memory_write and memory_read we just did should show up
     const writeRow = result.telemetry.find((r) => r.tool_name === "memory_write");
     const readRow = result.telemetry.find((r) => r.tool_name === "memory_read");


### PR DESCRIPTION
## Summary

- bound owner `memory_status` telemetry to the 5,000 most recent calls in its seven-day window
- expose sample limit/count/order/truncation through owner-only `telemetry_meta`
- preserve the existing per-tool telemetry row shape and non-owner secrecy
- document sampled semantics and add regression coverage for the hard row ceiling

Closes #242.

## Why

Production had 476,128 telemetry rows in the seven-day window. The previous synchronous grouped scan plus per-tool response-size sorts blocked the Node event loop for 80–106 seconds and caused the bridge and `/health` to time out.

The replacement performs one timestamp-indexed query with `LIMIT sample_limit + 1`, aggregates at most 5,000 rows in memory, and uses the extra row only to report truncation.

## Verification

- red/green focused regression: 526 database/tool tests
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tools`
- `npm run build`
- `npm test` — 2,484 passed, 4 skipped
- `npm run test:coverage` — 89.22% statements, 90.39% lines
- `npm run benchmark:ci-gate` — pass, no metric regression
- production `EXPLAIN QUERY PLAN` uses `idx_tool_calls_timestamp (timestamp>?)`

## Independent review

Reviewed by the M5 `Qwen3-Coder-Next-Q4_K_M.gguf` model. Proposed findings were validated against the patch and production schema; no actionable finding remained. In particular, the existing timestamp index, owner gate, positive limit clamp, and `truncated: true` regression were all confirmed directly.
