### PR TITLE
chore(deps): ignore better-sqlite3 majors until Node 20 support is dropped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      # better-sqlite3 13.x declares `node >=22` while this project still
+      # supports Node 20 (the v13 bump crashed the Node 20 CI workers 36× on
+      # #215). Taking v13 is a deliberate drop-Node-20 decision, not a routine
+      # bump. The #215 comment-command decline did not stick because grouped
+      # PRs ignore per-PR commands (see #246). Lift this when Node 20 support
+      # is dropped.
+      - dependency-name: "better-sqlite3"
+        update-types:
+          - version-update:semver-major
     groups:
       dev-dependencies:
         dependency-type: development


### PR DESCRIPTION
## What changed

Adds a Dependabot ignore rule for `better-sqlite3` semver-major updates.

## Why

`better-sqlite3@13` declares `node >=22` while this project still supports Node 20 (the v13 bump crashed the Node 20 CI workers 36 times on #215). Taking v13 is a deliberate drop-Node-20 decision, not a routine bump.

The #215 decline via `@dependabot ignore this major version` did not persist because grouped PRs ignore per-PR commands — Dependabot re-proposed v13.0.1 in #246. This encodes the decision at the config level, as Dependabot itself recommends for grouped updates. Lift the rule when Node 20 support is dropped.

Closes nothing automatically; #246 will be closed manually with reference to this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)