### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-24
+
 ### Added
 
 - Added the publication-grade Phase A agent-memory scorecard (#227). The pinned
@@ -981,7 +983,8 @@ Initial public release (commit `c40c127`). Core MCP tool surface
 `memory_list`, `memory_delete`), SQLite + FTS5 storage, Bearer token auth,
 stdio transport, and the first HTTP transport for Raspberry Pi deployment.
 
-[Unreleased]: https://github.com/Magnus-Gille/munin-memory/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Magnus-Gille/munin-memory/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Magnus-Gille/munin-memory/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Magnus-Gille/munin-memory/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/Magnus-Gille/munin-memory/compare/v0.3.3...v0.3.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munin-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munin-memory",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munin-memory",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server providing persistent memory across conversations",
   "author": "Magnus Gille",
   "license": "MIT",


### PR DESCRIPTION
Release metadata for v0.6.0: moves `[Unreleased]` to `[0.6.0] — 2026-07-24`, bumps `package.json` and both `package-lock.json` version fields, and updates the changelog comparison links.

Highlights since v0.5.0 (full details in CHANGELOG):
- Publication-grade LongMemEval-S scorecard with fail-closed publisher (#227)
- Durable review inbox + `memory_review` tool, migration 22 (#223)
- Advisory write-time intake quality gate, migration 21 (#181)
- Five-minute quickstart install (#225)
- Explicit correction/supersession and temporal reads (#192)
- `valid_until` review horizons (#217) · atomic create-if-absent writes (#211)
- Untrusted-content boundary hardening beyond delimiters (#198)
- Per-caller MCP admission buckets (#231) · bounded `memory_status` telemetry (#242)
- Unified, verified backup destination models (#219/#220) · namespace write-target validation (#215/#216)

Local gates on this branch: lint, both typechecks, build, 2,531 tests / 4 skipped.

After merge: annotated `v0.6.0` tag on the squash commit + GitHub release, then server-only deploy to `huginmunin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)