### PR TITLE
fix(security): reject Anthropic and other hyphen-prefixed vendor keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Security
+
+- **The secret scanner now rejects Anthropic, Google, Hugging Face, and OpenAI
+  service-account keys (found by multi-model user testing, 2026-07-24).** The
+  generic `sk-` rule cannot match across a hyphen — it requires 20+
+  *alphanumeric* characters after `sk-` — so every hyphenated vendor prefix
+  escaped it. `sk-ant-api03-…` keys were therefore **accepted and stored in
+  plaintext**, violating the documented "reject common API keys before storage"
+  invariant on the format this ecosystem is most likely to encounter, while
+  lesser formats were correctly blocked. Two independent test agents hit this
+  within minutes of each other. The pre-existing test was named "rejects
+  OpenAI/Anthropic API keys" but only exercised the generic form, so it
+  asserted coverage that never existed; it is now one table-driven case per
+  vendor format, and `SECRET_PATTERNS` documents that hyphenated prefixes
+  require their own entry.
+
 ### Added
 
 - **Scorecard contract v3: reranker recency pinned to zero (#248).** The #248

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,10 +1,25 @@
 import type { SecurityResult } from "./types.js";
 import { resolveOwnerAliases } from "./owner-config.js";
 
+/**
+ * Credential formats rejected before storage.
+ *
+ * **Vendor prefixes need their own entry.** The generic `sk-` rule below cannot
+ * match across a hyphen — after `sk-` it requires 20+ *alphanumeric* characters
+ * — so every vendor whose prefix is itself hyphenated (`sk-ant-`, `sk-proj-`,
+ * `sk-or-v1-`, `sk-svcacct-`) escapes it and must be listed explicitly. A
+ * user-testing pass on 2026-07-24 found `sk-ant-api03-…` keys being accepted
+ * and stored precisely because of this gap. When a new provider appears, add a
+ * pattern here *and* a row to the table-driven test in `tests/security.test.ts`.
+ */
 const SECRET_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
   { pattern: /sk-or-v1-[a-zA-Z0-9_-]{20,}/, label: "OpenRouter API key" },
+  { pattern: /sk-ant-[a-zA-Z0-9_-]{20,}/, label: "Anthropic API key (sk-ant-...)" },
+  { pattern: /sk-svcacct-[a-zA-Z0-9_-]{20,}/, label: "OpenAI service-account key (sk-svcacct-...)" },
   { pattern: /sk-[a-zA-Z0-9]{20,}/, label: "API key (sk-...)" },
   { pattern: /sk-proj-[a-zA-Z0-9]{20,}/, label: "OpenAI project API key (sk-proj-...)" },
+  { pattern: /AIza[0-9A-Za-z_-]{35}/, label: "Google API key" },
+  { pattern: /hf_[a-zA-Z0-9]{20,}/, label: "Hugging Face access token" },
   { pattern: /ghp_[a-zA-Z0-9]{36,}/, label: "GitHub personal access token" },
   { pattern: /gho_[a-zA-Z0-9]{36,}/, label: "GitHub OAuth token" },
   { pattern: /github_pat_[a-zA-Z0-9_]{22,}/, label: "GitHub fine-grained PAT" },

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -14,10 +14,34 @@ import {
 } from "../src/security.js";
 
 describe("scanForSecrets", () => {
-  it("rejects OpenAI/Anthropic API keys", () => {
+  it("rejects generic sk- API keys", () => {
     const result = scanForSecrets("my key is sk-abc123def456ghi789jkl012mno345");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("API key");
+  });
+
+  /**
+   * One representative (fake) key per supported vendor format.
+   *
+   * Hyphenated vendor prefixes do NOT fall through to the generic `sk-` rule —
+   * it cannot match across a hyphen. `sk-ant-` was accepted and stored in
+   * production until 2026-07-24 for exactly that reason, while the test above
+   * was named "OpenAI/Anthropic" and asserted coverage it never had. Add a row
+   * here whenever a pattern is added to SECRET_PATTERNS.
+   */
+  it.each([
+    ["Anthropic", "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-AbCdEfGhIjKl", "Anthropic API key"],
+    ["OpenRouter", "sk-or-v1-0123456789abcdef0123456789abcdef0123456789abcdef", "OpenRouter API key"],
+    ["OpenAI project", "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "OpenAI project API key"],
+    ["OpenAI service account", "sk-svcacct-ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghij", "OpenAI service-account key"],
+    ["Google", "AIzaSyA1234567890abcdefghijklmnopqrstuvw", "Google API key"],
+    ["Hugging Face", "hf_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", "Hugging Face access token"],
+    ["GitHub PAT", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "GitHub personal access token"],
+    ["AWS", "AKIAIOSFODNN7EXAMPLE", "AWS access key"],
+  ])("rejects a %s key before storage", (_vendor, key, label) => {
+    const result = scanForSecrets(`here is the credential: ${key}`);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(label);
   });
 
   it("rejects OpenAI project API keys (sk-proj-)", () => {


### PR DESCRIPTION
Found by multi-model user testing (session `test-20260724-2235`) — reported independently by the Opus and Fable testers within minutes of each other, then verified against `origin/main` source.

## The bug

```js
{ pattern: /sk-[a-zA-Z0-9]{20,}/, label: "API key (sk-...)" }
```

This requires 20+ **alphanumeric** characters immediately after `sk-`, so it stops at the first hyphen. `sk-ant-api03-…` sees only `ant` (3 chars) and never matches. The codebase already knew this — it special-cases `sk-or-v1-` and `sk-proj-` — but Anthropic was missed.

Result: `sk-ant-` keys were **accepted and stored in plaintext** while `ghp_`, `AKIA`, and generic `sk-` keys were correctly rejected. That violates the documented invariant *"Reject common API keys, bearer tokens, private keys/certificates, and inline secrets before storage"* — on the format Munin is most likely to encounter, given its own consolidation worker uses Anthropic models.

The pre-existing test was named `rejects OpenAI/Anthropic API keys` but only exercised the generic `sk-` form, so it asserted coverage that never existed.

## The fix

- Explicit patterns for **Anthropic** (`sk-ant-`), **OpenAI service-account** (`sk-svcacct-`), **Google** (`AIza`), and **Hugging Face** (`hf_`).
- `SECRET_PATTERNS` now documents that hyphenated vendor prefixes cannot fall through to the generic rule and need their own entry plus a test row.
- Table-driven regression: one representative fake key per vendor format (8 rows). Mutation-verified — removing the Anthropic pattern fails exactly that row.

## Validation

lint, typecheck, full suite **2,546 passed / 4 skipped**.

## Follow-up

Fake `sk-ant-` probes written by the testers are being purged from the `testing/*` sandboxes as part of session cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)