### PR TITLE
fix(commitments): treat a reworded next step as a revision, not a completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ changelog is the canonical record of what moved.
   connection committing between check and DELETE cannot reopen the same
   window.
 
+- **A reworded next step no longer reads as a completed commitment (#253).** A
+  commitment's identity was its normalized text, so editing a `## Next Steps`
+  line changed its fingerprint. Reconciliation then resolved the old row
+  `done` while inserting the reworded successor as `open`, so one live item
+  appeared in both buckets. An unambiguous, meaningfully similar rewording now
+  revises the existing row in place; issue references constrain matches but
+  cannot alone identify a step, and different non-empty reference sets never
+  pair. A genuinely removed step still resolves.
+
 ## [0.6.1] — 2026-07-25
 
 ### Changed

--- a/src/db.ts
+++ b/src/db.ts
@@ -1400,6 +1400,107 @@ export interface DerivedCommitmentInput {
   confidence: number;
 }
 
+/** Minimum token overlap for two commitment texts to count as the same work. */
+const COMMITMENT_REVISION_SIMILARITY = 0.5;
+
+/** Tokens for similarity comparison: words of 3+ chars, deduplicated. */
+function commitmentTokens(text: string): Set<string> {
+  return new Set(
+    text.toLowerCase().match(/[a-z0-9#][a-z0-9#_-]{2,}/g) ?? [],
+  );
+}
+
+/** Issue-style references (`#248`) are a stable identity across rewording. */
+function issueReferences(text: string): Set<string> {
+  return new Set(text.match(/#\d+/g) ?? []);
+}
+
+function equalSets(a: Set<string>, b: Set<string>): boolean {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let shared = 0;
+  for (const token of a) if (b.has(token)) shared += 1;
+  return shared / (a.size + b.size - shared);
+}
+
+/**
+ * Pair commitments that vanished from a source with newly derived ones that are
+ * the *same work item reworded*.
+ *
+ * A commitment's fingerprint is its normalized text, so editing a next step —
+ * fixing a typo, appending an issue number — changes its identity. Without this
+ * pairing the old row is resolved `done` (with `resolved_at`) while the reworded
+ * successor is inserted `open`, so `memory_commitments` reports one live item as
+ * both open and completed in a single response, and a rewording silently reads
+ * as delivery. We only carry identity over when the texts have meaningful token
+ * overlap. Issue references constrain that match: distinct non-empty reference
+ * sets are different work, even if the prose overlaps. Ambiguous candidates are
+ * left unpaired rather than guessing, while a step that truly disappears still
+ * resolves.
+ *
+ * Exported for tests.
+ */
+export function pairRevisedCommitments(
+  orphans: Array<{ id: string; source_type: string; text: string }>,
+  fresh: DerivedCommitmentInput[],
+): Map<string, DerivedCommitmentInput> {
+  const pairs = new Map<string, DerivedCommitmentInput>();
+  const claimed = new Set<string>();
+
+  const scored: Array<{ score: number; orphanId: string; commitment: DerivedCommitmentInput }> = [];
+  for (const orphan of orphans) {
+    const orphanTokens = commitmentTokens(orphan.text);
+    const orphanIssues = issueReferences(orphan.text);
+    for (const commitment of fresh) {
+      // Never merge across derivation kinds: a tracked next step and an ad-hoc
+      // dated commitment are different objects even when worded alike.
+      if (commitment.sourceType !== orphan.source_type) continue;
+      const freshIssues = issueReferences(commitment.text);
+      // An issue reference is useful negative evidence, not a shortcut to
+      // identity: multiple sequential tasks can legitimately share one issue.
+      // If both sides name issue references, their sets must agree exactly.
+      if (orphanIssues.size > 0 && freshIssues.size > 0 && !equalSets(orphanIssues, freshIssues)) continue;
+      const score = jaccard(orphanTokens, commitmentTokens(commitment.text));
+      if (score < COMMITMENT_REVISION_SIMILARITY) continue;
+      scored.push({ score, orphanId: orphan.id, commitment });
+    }
+  }
+
+  // Only carry identity through an unambiguous best match on both sides. A
+  // deterministic but arbitrary tie would silently merge distinct next steps.
+  const bestByOrphan = new Map<string, { score: number; count: number }>();
+  const bestByFresh = new Map<string, { score: number; count: number }>();
+  for (const candidate of scored) {
+    for (const [key, scores] of [[candidate.orphanId, bestByOrphan], [candidate.commitment.fingerprint, bestByFresh]] as const) {
+      const current = scores.get(key);
+      if (!current || candidate.score > current.score) {
+        scores.set(key, { score: candidate.score, count: 1 });
+      } else if (candidate.score === current.score) {
+        current.count += 1;
+      }
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  for (const candidate of scored) {
+    const orphanBest = bestByOrphan.get(candidate.orphanId);
+    const freshBest = bestByFresh.get(candidate.commitment.fingerprint);
+    if (
+      !orphanBest || !freshBest
+      || orphanBest.score !== candidate.score || orphanBest.count !== 1
+      || freshBest.score !== candidate.score || freshBest.count !== 1
+    ) continue;
+    if (pairs.has(candidate.orphanId)) continue;
+    if (claimed.has(candidate.commitment.fingerprint)) continue;
+    pairs.set(candidate.orphanId, candidate.commitment);
+    claimed.add(candidate.commitment.fingerprint);
+  }
+  return pairs;
+}
+
 export function computeCommitmentConfidence(
   sourceType: string,
   semanticRevisionAt: string,
@@ -1537,6 +1638,24 @@ export function syncCommitmentsForEntry(
      SET status = ?, updated_at = ?, resolved_at = COALESCE(resolved_at, ?)
      WHERE id = ? AND status = 'open'`,
   );
+  // A rewording carries the row's identity forward: same id and created_at,
+  // new fingerprint/text, and a refreshed semantic-revision timestamp.
+  const reviseCommitment = db.prepare(
+    `UPDATE commitments
+     SET namespace = ?, source_fingerprint = ?, text = ?, due_at = ?, confidence = ?,
+         status = 'open', updated_at = ?, resolved_at = NULL, source_classification = ?
+     WHERE id = ?`,
+  );
+
+  // Pair vanished commitments with newly derived ones that are the same work
+  // reworded, so an edit is a revision rather than a completion plus an insert.
+  const revisionPairs = pairRevisedCommitments(
+    existingRows.filter(
+      (row) => row.status === "open" && !nextFingerprints.has(row.source_fingerprint),
+    ),
+    derivedCommitments.filter((commitment) => !existingByFingerprint.has(commitment.fingerprint)),
+  );
+  const revisedFingerprints = new Set([...revisionPairs.values()].map((c) => c.fingerprint));
 
   const txn = db.transaction(() => {
     if (sourceClassification === "client-restricted") {
@@ -1592,6 +1711,10 @@ export function syncCommitmentsForEntry(
         continue;
       }
 
+      // Reworded successors are applied through the revision pass below, which
+      // keeps the original row's id and created_at instead of inserting a twin.
+      if (revisedFingerprints.has(commitment.fingerprint)) continue;
+
       insertCommitment.run(
         randomUUID(),
         source.namespace,
@@ -1607,8 +1730,22 @@ export function syncCommitmentsForEntry(
       );
     }
 
+    for (const [orphanId, commitment] of revisionPairs) {
+      reviseCommitment.run(
+        source.namespace,
+        commitment.fingerprint,
+        commitment.text,
+        commitment.dueAt ?? null,
+        commitment.confidence,
+        now,
+        sourceClassification,
+        orphanId,
+      );
+    }
+
     for (const existing of existingRows) {
       if (nextFingerprints.has(existing.source_fingerprint)) continue;
+      if (revisionPairs.has(existing.id)) continue;
       const resolvedStatus: CommitmentStatus = existing.source_type === "tracked_next_step"
         ? "done"
         : "cancelled";

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -475,6 +475,102 @@ describe("appendLog", () => {
   });
 });
 
+describe("commitment revision identity (#253)", () => {
+  const trackedStep = (text: string) => ({
+    sourceType: "tracked_next_step",
+    fingerprint: `tracked_next_step:${text.toLowerCase()}`,
+    text,
+    dueAt: null,
+    confidence: 0.8,
+  });
+
+  it("treats a reworded next step as the same commitment, not a completion plus a twin", () => {
+    const { id } = writeState(db, "projects/test", "status", "## Next Steps\n- placeholder", ["active"]);
+
+    syncCommitmentsForEntry(db, id, [
+      trackedStep("Produce the privacy-safe dogfood/TCO case study (#222)"),
+    ]);
+    const before = listCommitments(db, { namespace: "projects/test" });
+    expect(before).toHaveLength(1);
+    const originalId = before[0].id;
+
+    // Same work item, reworded — exactly what happens when a status is edited.
+    syncCommitmentsForEntry(db, id, [
+      trackedStep("Produce the privacy-safe dogfood and TCO case study (#222), including restore evidence"),
+    ]);
+
+    const after = listCommitments(db, { namespace: "projects/test" });
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe(originalId);
+    expect(after[0].status).toBe("open");
+    expect(after[0].resolved_at).toBeNull();
+    expect(after[0].text).toContain("restore evidence");
+    // The bug this guards: live work reported as delivered.
+    expect(after.some((row) => row.status === "done")).toBe(false);
+  });
+
+  it("still resolves a next step that genuinely disappears", () => {
+    const { id } = writeState(db, "projects/gone", "status", "## Next Steps\n- placeholder", ["active"]);
+
+    syncCommitmentsForEntry(db, id, [trackedStep("Ship the release notes")]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Investigate an entirely unrelated telemetry regression")]);
+
+    const rows = listCommitments(db, { namespace: "projects/gone" });
+    const shipped = rows.find((row) => row.text === "Ship the release notes");
+    expect(shipped?.status).toBe("done");
+    expect(shipped?.resolved_at).not.toBeNull();
+    expect(rows.filter((row) => row.status === "open")).toHaveLength(1);
+  });
+
+  it("never reports one commitment as both open and recently resolved", () => {
+    const { id } = writeState(db, "projects/dual", "status", "## Next Steps\n- placeholder", ["active"]);
+
+    syncCommitmentsForEntry(db, id, [trackedStep("Run the second-principal household onboarding pilot (#5)")]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Run the real second-principal household pilot (#5)")]);
+
+    const rows = listCommitments(db, { namespace: "projects/dual" });
+    const open = rows.filter((row) => row.status === "open");
+    const done = rows.filter((row) => row.status === "done");
+    expect(open).toHaveLength(1);
+    expect(done).toHaveLength(0);
+  });
+
+  it("does not conflate distinct sequential steps that share an issue reference", () => {
+    const { id } = writeState(db, "projects/shared-issue", "status", "## Next Steps\n- placeholder", ["active"]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Write the incident recovery runbook for #222")]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Run the production restore exercise for #222")]);
+
+    const rows = listCommitments(db, { namespace: "projects/shared-issue" });
+    expect(rows.find((row) => row.text.includes("recovery runbook"))?.status).toBe("done");
+    expect(rows.find((row) => row.text.includes("production restore exercise"))?.status).toBe("open");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("leaves ambiguous multiple rewording candidates unpaired instead of guessing", () => {
+    const { id } = writeState(db, "projects/ambiguous", "status", "## Next Steps\n- placeholder", ["active"]);
+    syncCommitmentsForEntry(db, id, [
+      trackedStep("Draft the migration plan for the platform"),
+      trackedStep("Draft the migration plan for the database"),
+    ]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Draft the migration plan for the service")]);
+
+    const rows = listCommitments(db, { namespace: "projects/ambiguous" });
+    expect(rows.filter((row) => row.status === "done")).toHaveLength(2);
+    expect(rows.filter((row) => row.status === "open")).toHaveLength(1);
+    expect(rows.find((row) => row.status === "open")?.text).toContain("service");
+  });
+
+  it("does not pair steps with different nonempty issue-reference sets", () => {
+    const { id } = writeState(db, "projects/different-issues", "status", "## Next Steps\n- placeholder", ["active"]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Draft the recovery plan for #222")]);
+    syncCommitmentsForEntry(db, id, [trackedStep("Draft the recovery plan for #223")]);
+
+    const rows = listCommitments(db, { namespace: "projects/different-issues" });
+    expect(rows.filter((row) => row.status === "done")).toHaveLength(1);
+    expect(rows.filter((row) => row.status === "open")).toHaveLength(1);
+  });
+});
+
 describe("commitment classification lifecycle", () => {
   it("propagates source classification and scrubs client-restricted derivatives", () => {
     const { id } = appendLog(


### PR DESCRIPTION
Closes #253.

## Problem
Commitment fingerprints are normalized text. Rewording a live Next Steps line therefore resolved the old row as done and inserted a new open row, making ordinary status editing look like delivery and exposing one logical item in open and completed buckets.

## Fix
- pair only same-source-type old/new steps with Jaccard token similarity >= 0.5
- treat issue references as negative constraints: differing nonempty sets cannot pair, but a shared issue never forces identity
- require a unique best match on both sides; ambiguous candidates remain separate
- revise a matched row in place, preserving id/created_at and clearing resolved_at
- keep genuine disappearance behavior unchanged

## Verification
- reported #222 and #5 rewording regressions
- genuine disappearance
- distinct sequential steps sharing one issue
- ambiguous multiple candidates
- differing issue references
- lint, both typechecks, build
- focused 172/172; full 2,573 passed / 4 skipped
- independent root M5 mellum review: APPROVED

The separate memory_handoff/open_loops observation could not be reproduced because both tools now share the same parser; follow-up #287 records that evidence gap.