### PR TITLE
fix: positive_outcome_rate, history patch filter, and silent limit clamping (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memory_insights.positive_outcome_rate` is a rate again (#255).** It divided
+  the *count of positive outcomes* by the *number of retrieval events*, but one
+  query routinely yields several opened results, so the value exceeded 1.0
+  (3.457 observed in production) while sibling fields were normalised 0–1. It
+  now counts events that produced at least one positive outcome. Raw outcome
+  volume remains available as `total_outcomes`.
+- **`memory_history` can filter for `patch` (#255).** Partial writes are audited
+  as `patch`, but the `action` enum offered only `update`, so filtering for a
+  just-audited patch returned zero rows and the published vocabulary was wrong.
+- **`memory_query` says when it clamps an over-limit request (#255).** A `limit`
+  above the documented maximum of 50 was silently clamped by the storage layer,
+  so a truncated page was indistinguishable from an exhausted result set. The
+  response now carries an explicit warning, and the maximum is a single exported
+  `MAX_QUERY_LIMIT` constant rather than a magic number repeated across clamps.
+
 ### Security
 
 - **The secret scanner now rejects Anthropic, Google, Hugging Face, and OpenAI

--- a/src/db.ts
+++ b/src/db.ts
@@ -1031,7 +1031,7 @@ export function queryEntriesLexicalScored(
   options: QueryOptions,
 ): LexicalQueryResult[] {
   const { query, namespace, entryType, tags, limit = 10, includeExpired = false, since, until, rawFts5 = false } = options;
-  const clampedLimit = Math.min(Math.max(limit, 1), 50);
+  const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
   const now = nowUTC();
 
   let sql = `
@@ -1152,7 +1152,7 @@ export function queryEntriesByFilter(
   options: FilterOptions,
 ): Entry[] {
   const { namespace, entryType, tags, limit = 10, includeExpired = false, since, until } = options;
-  const clampedLimit = Math.min(Math.max(limit, 1), 50);
+  const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
   const now = nowUTC();
 
   let sql = "SELECT * FROM entries WHERE is_current = 1";
@@ -1384,6 +1384,13 @@ export function listEntriesForDerivation(
   sql += " ORDER BY updated_at DESC";
   return db.prepare(sql).all(...params) as Entry[];
 }
+
+/**
+ * Maximum results any single retrieval query may return. The storage layer
+ * clamps to this; `memory_query` warns when a caller asks for more so a
+ * truncated page is never mistaken for an exhausted result set.
+ */
+export const MAX_QUERY_LIMIT = 50;
 
 export interface DerivedCommitmentInput {
   sourceType: string;
@@ -2231,7 +2238,7 @@ export function queryEntriesSemanticScored(
   options: SemanticQueryOptions,
 ): SemanticQueryResult[] {
   const { queryEmbedding, namespace, entryType, tags, limit = 10, includeExpired = false, since, until, maxDistance, queryEmbeddingModel } = options;
-  const clampedLimit = Math.min(Math.max(limit, 1), 50);
+  const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
   const now = nowUTC();
 
   // Exact namespace-local scan (benchmark-only).
@@ -2784,7 +2791,7 @@ export function getInsightsByEntry(
   restrictToTracked?: boolean,
   trackedPatterns: readonly string[] = DEFAULT_TRACKED_PATTERNS,
 ): EntryInsightRow[] {
-  const clampedLimit = Math.min(Math.max(limit, 1), 50);
+  const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
 
   // Build namespace filter clause (applies to e.namespace from LEFT JOIN entries)
   let nsFilter = "";
@@ -3222,10 +3229,16 @@ export function getRetrievalAggregates(
       .get(periodStart, periodEnd) as { cnt: number }
   ).cnt;
 
+  // Count *events that produced at least one* positive outcome, not raw
+  // outcomes: a single query routinely yields several opens, so COUNT(*) over
+  // outcomes divided by total_events is not a rate and exceeded 1.0 in
+  // production (observed 3.457). DISTINCT keeps positive_outcome_rate a true
+  // 0–1 fraction and comparable with reformulation_rate. Raw outcome volume
+  // remains available as `total_outcomes`.
   const positiveOutcomeCount = (
     db
       .prepare(
-        `SELECT COUNT(*) as cnt FROM retrieval_outcomes ro
+        `SELECT COUNT(DISTINCT ro.retrieval_event_id) as cnt FROM retrieval_outcomes ro
          JOIN retrieval_events re ON re.id = ro.retrieval_event_id
          WHERE ro.outcome_type IN (
            'opened_result', 'opened_namespace_context',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -52,6 +52,7 @@ import {
   listCommitments,
   syncCommitmentsForEntry,
   type DerivedCommitmentInput,
+  MAX_QUERY_LIMIT,
   type CommitmentRow,
   computeCommitmentConfidence,
   getOtherKeysInNamespace,
@@ -5356,8 +5357,8 @@ const TOOL_DEFINITIONS = [
         },
         action: {
           type: "string",
-          enum: ["write", "update", "supersede", "delete", "delete_namespace", "log", "cross_zone_block"],
-          description: "Optional. Filter by action type. 'cross_zone_block' surfaces containment-guard security events.",
+          enum: ["write", "update", "patch", "supersede", "delete", "delete_namespace", "log", "cross_zone_block"],
+          description: "Optional. Filter by action type. 'patch' covers partial writes (content_append/prepend, tags_add/remove), which are audited separately from full-content 'update'. 'cross_zone_block' surfaces containment-guard security events.",
         },
         cursor: {
           type: "integer",
@@ -8791,6 +8792,12 @@ export function registerTools(
               const requestedMode: SearchMode = search_mode ?? "hybrid";
               let actualMode: SearchMode = requestedMode;
               let warning: string | undefined;
+              // The storage layer clamps to MAX_QUERY_LIMIT, so an over-limit
+              // request used to return fewer rows than asked for with no signal
+              // — indistinguishable from "that is all there was". Say so.
+              if (typeof limit === "number" && Number.isFinite(limit) && limit > MAX_QUERY_LIMIT) {
+                warning = `Requested limit ${limit} exceeds the maximum of ${MAX_QUERY_LIMIT}; returning at most ${MAX_QUERY_LIMIT} results. Narrow with filters or since/until rather than paging.`;
+              }
               let fallbackReason: string | null = null;
               let relaxedLexical = false;
               let expiredFilteredCount = 0;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -9,6 +9,9 @@ import { fileURLToPath } from "node:url";
 import {
   initDatabase,
   parsePragmaInt,
+  logRetrievalEvent,
+  logRetrievalOutcome,
+  getRetrievalAggregates,
   writeState,
   patchState,
   readState,
@@ -2259,5 +2262,38 @@ describe("getLastSynthesisAt / getAvgConsolidationLatencyMs", () => {
   it("throws for a non-owner caller (owner-only defense-in-depth)", () => {
     expect(() => getLastSynthesisAt(db, false)).toThrow(/owner-only/);
     expect(() => getAvgConsolidationLatencyMs(db, false)).toThrow(/owner-only/);
+  });
+});
+
+describe("retrieval aggregates (#255)", () => {
+  it("reports positive_outcome_rate as a 0-1 fraction of events, not outcomes per event", () => {
+    const { id: a } = writeState(db, "projects/rate", "alpha", "Alpha entry", []);
+    const { id: b } = writeState(db, "projects/rate", "beta", "Beta entry", []);
+    const { id: c } = writeState(db, "projects/rate", "gamma", "Gamma entry", []);
+
+    // One query that the caller followed up on three times — the ordinary case
+    // of opening several results from a single search.
+    logRetrievalEvent(db, {
+      sessionId: "s-rate",
+      toolName: "memory_query",
+      queryText: "rate probe",
+      resultIds: [a, b, c],
+      resultNamespaces: ["projects/rate", "projects/rate", "projects/rate"],
+      resultRanks: [1, 2, 3],
+    });
+    for (const entryId of [a, b, c]) {
+      logRetrievalOutcome(db, "s-rate", {
+        outcomeType: "opened_result",
+        entryId,
+        namespace: "projects/rate",
+      });
+    }
+
+    const agg = getRetrievalAggregates(db);
+    const rate = agg.positive_outcome_count / agg.total_events;
+    // Pre-fix this was 3 outcomes / 1 event = 3.0 — a "rate" above 1.
+    expect(rate).toBeLessThanOrEqual(1);
+    expect(agg.positive_outcome_count).toBe(1);
+    expect(agg.total_outcomes).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
Three of the six items in #255, each independently verifiable. Found by multi-model user testing (`test-20260724-2235`).

## 1. `positive_outcome_rate` exceeded 1.0

```sql
SELECT COUNT(*) FROM retrieval_outcomes ro JOIN retrieval_events re ...
```
divided by `total_events`. A single query commonly produces several `opened_result` outcomes, so this was *outcomes per event*, not a rate — 3.457 in production, alongside siblings correctly normalised to 0–1.

Now `COUNT(DISTINCT ro.retrieval_event_id)`: the fraction of retrievals that led to at least one positive outcome, bounded 0–1 and comparable with `reformulation_rate`. Raw volume is still exposed as `total_outcomes`. Mutation-verified — restoring `COUNT(*)` fails the new test.

## 2. `memory_history` could not filter for `patch`

Partial writes are audited as `"action": "patch"` (`src/db.ts`), but the enum offered only `update`, so filtering a namespace with a freshly audited patch returned **0 rows**. Added `patch` to the enum and documented how it differs from full-content `update`.

## 3. `memory_query` clamped over-limit requests silently

`limit: 51` was accepted and quietly clamped to 50 by the storage layer, so a truncated page was indistinguishable from "that is all there was". The response now carries an explicit warning through the existing `warning` channel. While here, the max is a single exported `MAX_QUERY_LIMIT` rather than a literal `50` repeated across three clamps.

## Not in this PR

The remaining #255 items — silent classification escalation, intake tag-inconsistency noise, and consolidation running on ephemeral `testing/*` namespaces — need design decisions rather than mechanical fixes, so they stay open on the issue.

## Validation

lint, both typechecks, build, **2,548 passed / 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)