### PR TITLE
fix(orient): bound the mandatory first call in every detail mode (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Changed
+
+- **`memory_orient` is bounded by default in every detail mode (#254).** It is
+  the mandatory first call, and on a mature estate it had grown large enough to
+  exceed MCP client tool-output limits — three of four independent test agents
+  hit the failure on their very first call. Measured on a 424-namespace
+  production corpus: `standard` returned **85,792 bytes** (dominated by the
+  complete namespace list, which had no default cap) and `compact` — documented
+  as the token-sensitive mode — returned **31,933 bytes** from 108 uncapped
+  dashboard one-liners. The per-group dashboard cap of 10 now applies in every
+  mode, and the namespace overview defaults to 50 outside `compact` (which keeps
+  20), bringing the same corpus to **17,791 bytes compact / 40,982 standard**
+  (−44% / −52%). Nothing is hidden silently: `dashboard_meta.counts` /
+  `truncated_groups` and `namespaces_meta.total` / `truncated` still describe the
+  full estate, and both caps remain caller-overridable.
+
 ### Security
 
 - **The secret scanner now rejects Anthropic, Google, Hugging Face, and OpenAI

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4677,12 +4677,12 @@ const TOOL_DEFINITIONS = [
         dashboard_limit_per_group: {
           type: "integer",
           description:
-            "Optional. Maximum entries to return per lifecycle group in the dashboard. `standard`/`full` default to 10 (bounds output size); `compact` returns all groups (already one-liners). Set explicitly to override. `dashboard_meta.truncated_groups` lists groups that were capped.",
+            "Optional. Maximum entries to return per lifecycle group in the dashboard. Defaults to 10 in every detail mode so the mandatory first call stays bounded as an estate grows. Raise it explicitly when you can afford the tokens. `dashboard_meta.counts` reports the true size of each group and `dashboard_meta.truncated_groups` lists the ones that were capped.",
         },
         namespace_limit: {
           type: "integer",
           description:
-            "Optional. Maximum namespaces to return in the namespace overview. `compact` defaults to 20; other detail levels return all namespaces unless this is set.",
+            "Optional. Maximum namespaces to return in the namespace overview. Defaults to 20 in `compact` and 50 otherwise; on a large estate the full list is the single biggest contributor to orient's response size. `namespaces_meta` reports `total`, `returned`, and `truncated` so a capped list is never mistaken for the whole estate — use `memory_list` to page through all of them.",
         },
         include_namespaces: {
           type: "boolean",
@@ -5837,13 +5837,22 @@ export function registerTools(
               const { include_demo, include_completed_tasks } = orientArgs;
               const detail = resolveOrientDetail(orientArgs);
               const includeNamespaces = orientArgs.include_namespaces ?? detail !== "compact";
-              // Default a sensible per-group cap in non-compact modes so
-              // standard/full output can't grow unbounded (#78). Compact already
-              // emits one-liners and is bounded by namespace_limit. Callers can
-              // override explicitly.
+              // Every branch of orient is capped by default: it is the mandatory
+              // first call, so an estate that has grown for months must not make
+              // it fail (#254). Measured on a 424-namespace production corpus,
+              // the uncapped forms produced 85,792 bytes (standard, dominated by
+              // the full namespace list) and 31,933 bytes (compact, 108
+              // dashboard one-liners) — enough to exceed MCP client tool-output
+              // limits on the very first handshake.
+              //
+              // Truncation is never silent: `dashboard_meta.counts` /
+              // `truncated_groups` and `namespaces_meta.total` / `truncated`
+              // report the full picture, and callers can raise either cap
+              // explicitly when they know they can afford it.
               const dashboardLimit = clampOptionalLimit(orientArgs.dashboard_limit_per_group, 50)
-                ?? (detail === "compact" ? undefined : 10);
-              const namespaceLimit = clampOptionalLimit(orientArgs.namespace_limit, 200) ?? (detail === "compact" ? 20 : undefined);
+                ?? 10;
+              const namespaceLimit = clampOptionalLimit(orientArgs.namespace_limit, 200)
+                ?? (detail === "compact" ? 20 : 50);
               // Namespace list and tracked statuses (conventions resolved below)
               const namespaces = listVisibleNamespaces(db, ctx).filter(ns => canRead(ctx, ns.namespace));
               const visibleTrackedStatuses = getVisibleTrackedStatusAssessments(db, ctx, "memory_orient", sessionId);

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -8437,3 +8437,44 @@ describe("memory_health", () => {
     }
   });
 });
+
+describe("memory_orient default output caps (#254)", () => {
+  it("bounds the dashboard and namespace list in every detail mode, and says so", async () => {
+    // A mature estate: more tracked projects than the per-group cap, and more
+    // namespaces than the overview cap.
+    for (let i = 0; i < 14; i++) {
+      writeState(db, `projects/capped-${i}`, "status", `## Phase\nProject ${i}`, ["active"]);
+    }
+    for (let i = 0; i < 60; i++) {
+      writeState(db, `notes/filler-${i}`, "note", `Filler ${i}`, []);
+    }
+
+    const compact = parseToolResponse(await callTool("memory_orient", { detail: "compact" })) as {
+      dashboard: Record<string, unknown[]>;
+      dashboard_meta: { counts: Record<string, number>; truncated_groups: string[] };
+    };
+    // Pre-fix, compact returned every active row — the largest branch of the
+    // one call clients are told to make first.
+    expect(compact.dashboard.active.length).toBe(10);
+    expect(compact.dashboard_meta.counts.active).toBeGreaterThanOrEqual(14);
+    expect(compact.dashboard_meta.truncated_groups).toContain("active");
+
+    const standard = parseToolResponse(await callTool("memory_orient", { detail: "standard" })) as {
+      namespaces: unknown[];
+      namespaces_meta: { total: number; returned: number; truncated: boolean };
+    };
+    // Pre-fix, standard returned the entire namespace list (424 on production).
+    expect(standard.namespaces.length).toBe(50);
+    expect(standard.namespaces_meta.total).toBeGreaterThan(50);
+    expect(standard.namespaces_meta.truncated).toBe(true);
+
+    // The caps are defaults, not ceilings — an informed caller can still opt in.
+    const wide = parseToolResponse(await callTool("memory_orient", {
+      detail: "standard",
+      dashboard_limit_per_group: 50,
+      namespace_limit: 200,
+    })) as { dashboard: Record<string, unknown[]>; namespaces: unknown[] };
+    expect(wide.dashboard.active.length).toBeGreaterThan(10);
+    expect(wide.namespaces.length).toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
Closes #254. Found by multi-model user testing (`test-20260724-2235`) — **3 of 4 testers failed on their very first call**, and server telemetry independently reports `memory_orient` p95 at 85,400 bytes / ~4.6 s.

## Measured on a real 424-namespace production snapshot

| detail | before | after | dashboard rows | namespaces |
|---|---:|---:|---:|---:|
| `compact` | 31,933 B | **17,791 B** (−44%) | 108 → 50 | 0 → 0 |
| `standard` | 85,792 B | **40,982 B** (−52%) | 50 → 50 | 424 → 50 |

## What was actually wrong

Two separate uncapped paths, and neither was the one the tool description implied:

1. **`standard`/`full` returned every namespace.** `namespace_limit` defaulted to `undefined` outside compact, so all 424 namespaces were inlined — this, not the dashboard, was the bulk of the 85 KB.
2. **`compact` had no dashboard cap at all.** `dashboard_limit_per_group` explicitly did not apply in compact mode, so the mode sold as "the default for token-sensitive handshakes" emitted all 108 lifecycle rows. Its comment claimed compact was "bounded by namespace_limit" — but that bounds a section compact does not even emit.

## The change

- The per-group dashboard cap of 10 applies in **every** detail mode.
- The namespace overview defaults to **50** outside compact (compact keeps 20).
- Both remain caller-overridable, and the tool descriptions now state the real defaults and point at `memory_list` for full enumeration.

Truncation was already reported and stays that way — `dashboard_meta.counts` / `truncated_groups` and `namespaces_meta.total` / `returned` / `truncated` describe the whole estate, so a capped view is never mistaken for a complete one.

## Tests

One regression test builds an estate larger than both caps and asserts: compact truncates the dashboard and reports it, standard caps namespaces with `truncated: true`, and explicit overrides still widen both. Mutation-verified — restoring either uncapped default fails it.

## Validation

lint, typecheck, build, **2,548 passed / 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
