### PR TITLE
fix(retrieval): keep a uniquely-named entry at the top of its own lookup (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A uniquely-named entry is no longer buried by structural ranking bonuses
+  (#252, partial).** `getQueryHeuristicScore` is purely structural — it rewards
+  tracked statuses, entry type and freshness, and never looks at how well an
+  entry matches the query — so relevance survived only as the final tie-break.
+  User testing found a globally unique token that ranked `lexical_rank: 1` with
+  the highest fusion score returned *seventh*, behind six unrelated entries
+  scoring 26 on "tracked status, recently updated" against its -3. An identifier
+  lookup now keeps its answer first, gated tightly: a non-orientation query of
+  at most three distinctive terms where **exactly one** candidate contains all
+  of them and is not a tombstone. Replaying 258 distinct real production queries
+  showed the gate firing zero times — only 25 are identifier-shaped and none had
+  a unique match — so ordinary topical ranking, including the #74 recency
+  tie-break parity, is provably unchanged. The broader issue that structural
+  score can outweigh relevance on multi-term queries remains open in #252.
+
 ### Security
 
 - **The secret scanner now rejects Anthropic, Google, Hugging Face, and OpenAI

--- a/src/internal/reranker.ts
+++ b/src/internal/reranker.ts
@@ -499,6 +499,92 @@ export function injectAttentionQueryEntries(
   return merged;
 }
 
+/** Heuristic at or below this marks deliberately demoted content (tombstones). */
+const DEMOTED_HEURISTIC_CEILING = -10;
+
+/** Longest query, in searchable terms, still treated as an identifier lookup. */
+const ANCHOR_MAX_TERMS = 3;
+
+/** Shortest term considered distinctive enough to anchor on. */
+const ANCHOR_MIN_TERM_LENGTH = 4;
+
+/**
+ * Terms worth anchoring on: distinctive enough that a caller typing them is
+ * naming a specific thing rather than describing a topic.
+ */
+function anchorTerms(queryLower: string): string[] {
+  return (queryLower.match(/[a-z0-9][a-z0-9_-]*/g) ?? []).filter(
+    (term) => term.length >= ANCHOR_MIN_TERM_LENGTH || /\d/.test(term),
+  );
+}
+
+function entryContainsAllTerms(entry: Entry, terms: string[]): boolean {
+  const haystack = `${entry.namespace} ${entry.key ?? ""} ${entry.content}`.toLowerCase();
+  return terms.every((term) => haystack.includes(term));
+}
+
+/**
+ * Keep an unambiguous identifier hit at the top.
+ *
+ * The heuristic score is structural — it rewards tracked statuses, freshness
+ * and entry type, and never looks at how well an entry matches the query — so
+ * on a short, distinctive lookup it could bury the one entry the caller
+ * literally named. Observed in user testing: a globally unique token ranked
+ * `lexical_rank: 1` with the highest fusion score came back **seventh**, behind
+ * six unrelated entries scoring 26 on "tracked status, recently updated"
+ * against its -3 (#252).
+ *
+ * Deliberately narrow, because the structural heuristic is right for the
+ * operational queries it was built for. This only fires when all of:
+ *   - the caller supplied a query that is not a broad orientation/triage ask;
+ *   - it is at most a few distinctive terms — an identifier lookup, not a topic;
+ *   - **exactly one** candidate contains every one of those terms verbatim, so
+ *     the caller has named a specific thing rather than described a subject;
+ *   - that candidate is the best-relevance result and is not deliberately
+ *     demoted (a tombstone).
+ *
+ * The uniqueness requirement is what keeps this from hijacking ordinary
+ * queries: when several candidates match the terms there is no single thing
+ * being named, so structural score and recency continue to decide — including
+ * the recency tie-break parity guarantees from #74.
+ *
+ * Everything below position one keeps the existing structural order.
+ */
+function applyExactAnchorFloor(
+  ranked: Array<{ entry: Entry; heuristic: number }>,
+  bestRelevance: Entry | undefined,
+  queryLower: string,
+  params: QueryParams,
+): Array<{ entry: Entry; heuristic: number }> {
+  if (!bestRelevance || ranked.length < 2) return ranked;
+  if (!queryLower.trim()) return ranked;
+  if (isBroadOrientationQuery(queryLower, params) || isAttentionTriageQuery(queryLower, params)) {
+    return ranked;
+  }
+
+  const terms = anchorTerms(queryLower);
+  if (terms.length === 0 || terms.length > ANCHOR_MAX_TERMS) return ranked;
+  if (!entryContainsAllTerms(bestRelevance, terms)) return ranked;
+
+  // Unique anchor only: if more than one candidate carries every term, the
+  // caller described a subject rather than naming one entry, and the existing
+  // structural/recency ordering is the right answer.
+  let matchCount = 0;
+  for (const item of ranked) {
+    if (entryContainsAllTerms(item.entry, terms)) {
+      matchCount += 1;
+      if (matchCount > 1) return ranked;
+    }
+  }
+
+  const currentIndex = ranked.findIndex((item) => item.entry.id === bestRelevance.id);
+  if (currentIndex <= 0) return ranked;
+  if (ranked[currentIndex]!.heuristic <= DEMOTED_HEURISTIC_CEILING) return ranked;
+
+  const promoted = ranked[currentIndex]!;
+  return [promoted, ...ranked.slice(0, currentIndex), ...ranked.slice(currentIndex + 1)];
+}
+
 /**
  * Rerank query results by heuristic score + freshness, applying the
  * default suppression filter when appropriate.
@@ -522,7 +608,7 @@ export function rerankQueryResults(
     return true;
   });
 
-  return filtered
+  const scored = filtered
     .map((entry, index) => ({
       entry,
       index,
@@ -545,7 +631,12 @@ export function rerankQueryResults(
       }
       return a.index - b.index;
     })
-    .map((item) => item.entry);
+    .map((item) => ({ entry: item.entry, heuristic: item.heuristic }));
+
+  // `filtered[0]` is the best-relevance candidate: the retrieval layer hands
+  // results over in fusion/lexical rank order, and the structural sort below
+  // preserves that order only as its final tie-break.
+  return applyExactAnchorFloor(scored, filtered[0], queryLower, params).map((item) => item.entry);
 }
 
 export function resolveSearchRecencyWeight(params: QueryParams): { ok: true; value: number } | { ok: false; error: string } {

--- a/tests/reranker.test.ts
+++ b/tests/reranker.test.ts
@@ -967,3 +967,58 @@ function makeSimpleEntry(namespace: string, key: string | null, content: string)
   }
   return row;
 }
+
+/**
+ * Regression guard for #252: a structural heuristic that never looks at the
+ * query must not bury the one entry the caller literally named.
+ *
+ * Found in user testing — a globally unique token that ranked `lexical_rank: 1`
+ * with the highest fusion score was returned *seventh*, behind six unrelated
+ * entries scoring 26 on "tracked status, recently updated" against its -3.
+ */
+describe("rerankQueryResults exact-anchor floor (#252)", () => {
+  function noiseEntries(count: number): Entry[] {
+    const entries: Entry[] = [];
+    for (let i = 0; i < count; i++) {
+      // Tracked statuses: the shape that earns the big structural bonuses.
+      writeState(db, `projects/noise-${i}`, "status", `## Phase\nActive work ${i}`, ["active"]);
+      const id = (db.prepare("SELECT id FROM entries WHERE namespace=?").get(`projects/noise-${i}`) as { id: string }).id;
+      entries.push(getById(db, id)!);
+    }
+    return entries;
+  }
+
+  it("keeps a uniquely-named entry first instead of letting structural bonuses bury it", () => {
+    // A plain log entry — heuristic-poor, exactly like the canary in the report.
+    appendLog(db, "testing/canary", "Milestone: the canary token is zarquon-flimflam-42.", []);
+    const anchorId = (db.prepare("SELECT id FROM entries WHERE namespace='testing/canary'").get() as { id: string }).id;
+    const anchor = getById(db, anchorId)!;
+    const noise = noiseEntries(6);
+
+    // Retrieval hands the best fusion hit over first; the ranker must not sink it.
+    const order = rerankQueryResults(
+      [anchor, ...noise],
+      { query: "zarquon-flimflam-42" } as Parameters<typeof rerankQueryResults>[1],
+      new Set(),
+    );
+    expect(order[0]!.id).toBe(anchor.id);
+  });
+
+  it("leaves ordinary topical queries to the structural heuristic", () => {
+    // Several entries carry the term, so nothing is uniquely named and the
+    // existing tracked-status/recency ordering must still win.
+    appendLog(db, "testing/topic-a", "Notes about deployment planning.", []);
+    appendLog(db, "testing/topic-b", "More deployment planning notes.", []);
+    const a = getById(db, (db.prepare("SELECT id FROM entries WHERE namespace='testing/topic-a'").get() as { id: string }).id)!;
+    const b = getById(db, (db.prepare("SELECT id FROM entries WHERE namespace='testing/topic-b'").get() as { id: string }).id)!;
+    const noise = noiseEntries(3);
+
+    const order = rerankQueryResults(
+      [a, b, ...noise],
+      { query: "deployment planning" } as Parameters<typeof rerankQueryResults>[1],
+      new Set(),
+    );
+    // A tracked status still outranks a bare log on a topical query.
+    expect(order[0]!.key).toBe("status");
+  });
+});


### PR DESCRIPTION
Partial fix for #252 — deliberately narrow, and **measured against real production traffic before shipping**.

## The failure

`getQueryHeuristicScore` is purely structural: it rewards tracked statuses, entry type, and freshness, and never looks at how well an entry matches the query. Relevance survived only as the *last* tie-break, so structure could outrank the entry a caller literally named.

User testing reproduced it cleanly: a globally unique token, `lexical_rank: 1`, `semantic_rank: 1`, highest `hybrid_score` (0.0328 vs 0.0163) — returned at **position 7 of 10**, behind six unrelated entries scoring `heuristic_score: 26` on *"tracked status, recently updated"* against its `-3`.

## The gate

An identifier lookup keeps its answer first, but only when **all** hold:

- the query is not a broad orientation/triage ask;
- it is at most three distinctive terms — naming a thing, not describing a topic;
- **exactly one** candidate contains every term verbatim;
- that candidate is the best-relevance result and is not a tombstone.

The uniqueness requirement is the load-bearing part. My first attempt omitted it and immediately broke two #74 recency-parity tests: the query `"decision"` matched *both* `decisions/older` and `decisions/newer`, so the floor hijacked a tie-break that was working correctly. When several candidates match, nothing is being named and the existing ordering is right.

## Evidence it is safe

Replayed **258 distinct real production queries** (from `retrieval_events`, with behavioural `opened_result` labels) against a snapshot of the production corpus. Results were **identical to four decimal places** before and after — R@5 0.0930/0.1047, MRR 0.0652/0.0716, 41 targets in candidates.

The gate fired **zero times**. Only 25 of 258 real queries are identifier-shaped at all (median query: 7 distinctive terms), and none of those had a unique all-terms match. So this is provably neutral on the real query distribution while fixing the demonstrated case.

## What this does *not* fix

The general problem — structural score outweighing relevance on the ~90% of queries that are multi-term and topical — is untouched, and #252 stays open for it. That needs relevance to become a scored term rather than a tie-break, which is a larger design change I would not want to make unmeasured at this hour.

## Tests

Two cases in `tests/reranker.test.ts`, mutation-verified (removing the floor fails the first): a heuristic-poor log entry named by a unique token stays first ahead of six tracked statuses; a topical two-term query still lets the tracked status win. Plus all 89 pre-existing reranker tests, including #74 parity.

## Validation

lint, typecheck, build, **2,549 passed / 4 skipped**, benchmark CI gate PASS (no metric regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
