### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-07-25
+
 ### Changed
 
 - **`memory_orient` is bounded by default in every detail mode (#254).** It is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "munin-memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "munin-memory",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "munin-memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP server providing persistent memory across conversations",
   "author": "Magnus Gille",
   "license": "MIT",


### PR DESCRIPTION
Cuts v0.6.1 over the fixes merged today.

**Contents (already on main):**
- `#260`/`#254` — `memory_orient` bounded in every detail mode. The mandatory first call of every agent session was unbounded in `compact`, the mode documented as token-sensitive. Independently re-measured at 8,997 B → 2,717 B on a synthetic 460-namespace estate.
- `#261`/`#252` — exact-anchor floor so a uniquely-named entry is not buried by structural ranking bonuses. 258-query production replay showed the gate firing zero times; benchmark CI gate `+0.00%` on all five metrics.
- `#255` — `positive_outcome_rate` normalisation, `memory_history` `patch` filter, and explicit query-limit clamp warning.

**Release metadata only** — no functional change in this PR. Per `AGENTS.md` §Release and Git hygiene: `CHANGELOG.md`, `package.json`, and both relevant `package-lock.json` version fields (root + `packages[""]`; the four other `0.6.0` occurrences are dependencies and were left alone). Annotated tag and GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)