### PR TITLE
fix(delete): bind preview tokens to the entries they previewed (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ changelog is the canonical record of what moved.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`memory_delete` preview tokens are bound to the entries they previewed
+  (#266).** A token carried only `{namespace, key, expiresAt}`, so a preview
+  taken before an update still authorised the delete afterwards: preview an
+  entry, let anything rewrite it, confirm with the old token, and the newer
+  revision the caller never saw was destroyed with `ok:true` and no warning.
+  Found by an independent user-test agent that reproduced it live against
+  production. The preview now computes a digest over the id, `updated_at` and
+  content of every row in scope — content included because `updated_at` has
+  only millisecond resolution, and a same-millisecond rewrite would otherwise
+  be invisible — and confirmation recomputes it from the same queries. A
+  mismatch returns the new `preview_stale` error with the previewed and current
+  counts, and spends the token so a fresh preview is required. This covers the
+  namespace-wide path too: an entry appearing in the namespace after the
+  preview now blocks the confirm rather than being swept up silently.
+
 ## [0.6.1] — 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ changelog is the canonical record of what moved.
   namespace-wide path too: an entry appearing in the namespace after the
   preview now blocks the confirm rather than being swept up silently.
 
+  Cross-model review tightened two details before merge. The digest covers
+  `tags`, `classification` and `valid_until` as well as content, because a
+  metadata-only patch (say `tags_add`) sharing a millisecond with the preview
+  would otherwise leave the fingerprint unchanged. And the comparison now runs
+  *inside* the delete transaction rather than just before it, so a second
+  connection committing between check and DELETE cannot reopen the same
+  window.
+
 ## [0.6.1] — 2026-07-25
 
 ### Changed

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
-import { randomUUID, createHash } from "node:crypto";
+import { randomUUID, createHash, type Hash } from "node:crypto";
 import { mkdirSync, chmodSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
@@ -1851,27 +1851,45 @@ export interface DeleteInfo {
   fingerprint: string;
 }
 
-type DeleteTargetRow = { id: string; updated_at: string; content: string };
+/**
+ * Raised when a delete confirmation's fingerprint no longer matches the rows in
+ * scope. Thrown from inside the delete transaction so the check and the DELETE
+ * observe one snapshot — a second connection committing between an outside check
+ * and the DELETE would otherwise reopen the very window this closes (#266).
+ */
+export class DeletePreviewStaleError extends Error {
+  constructor(readonly current: DeleteInfo) {
+    super("Delete target changed since the preview was generated.");
+    this.name = "DeletePreviewStaleError";
+  }
+}
+
+type DeleteTargetRow = {
+  id: string;
+  updated_at: string;
+  content: string;
+  tags: string | null;
+  classification: string | null;
+  valid_until: string | null;
+};
+
+/** Columns every delete-target query must select so the digest sees the whole row. */
+const DELETE_TARGET_COLUMNS = "id, updated_at, content, tags, classification, valid_until";
 
 /**
- * Digest of a delete target set, hashed in the caller's SQL-ordered sequence.
+ * Fold one delete-target row into a digest.
  *
- * Content is part of the digest because `updated_at` only has millisecond
- * resolution: a rewrite landing in the same millisecond as the preview would
- * otherwise be invisible, and the stale token would delete it (#266).
+ * Every mutable, caller-visible field is hashed, not just `updated_at`: that
+ * column has only millisecond resolution, so a rewrite — including a tags-only
+ * or classification-only patch — landing in the same millisecond as the preview
+ * would otherwise be invisible and a stale token would delete it (#266).
  */
-function fingerprintDeleteRows(rows: Iterable<DeleteTargetRow>): string {
-  const hash = createHash("sha256");
-  for (const row of rows) {
-    // Escaped-NUL separators so no field value can forge a record boundary.
-    hash.update(row.id);
-    hash.update("\u0000");
-    hash.update(row.updated_at ?? "");
-    hash.update("\u0000");
-    hash.update(row.content ?? "");
+function hashDeleteRow(hash: Hash, row: DeleteTargetRow): void {
+  // Escaped-NUL separators so no field value can forge a record boundary.
+  for (const field of [row.id, row.updated_at, row.content, row.tags, row.classification, row.valid_until]) {
+    hash.update(field ?? "");
     hash.update("\u0000");
   }
-  return hash.digest("hex");
 }
 
 function classificationInClause(levels: ClassificationLevel[]): string {
@@ -2014,37 +2032,51 @@ export function previewDelete(
   agentId = "default",
   allowGlobalNamespaceDelete = false,
 ): DeleteInfo {
+  const hash = createHash("sha256");
+
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1"
-      : "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?";
+      ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1`
+      : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?`;
     const params = allowGlobalNamespaceDelete ? [namespace, key] : [namespace, key, agentId];
     const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
+    if (entry) hashDeleteRow(hash, entry);
     return {
       stateCount: entry ? 1 : 0,
       logCount: 0,
       keys: entry ? [key] : [],
-      fingerprint: fingerprintDeleteRows(entry ? [entry] : []),
+      fingerprint: hash.digest("hex"),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? "SELECT key, id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 ORDER BY key, id"
-    : "SELECT key, id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key, id";
+    ? `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 ORDER BY key, id`
+    : `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key, id`;
   const stateParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
-  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string } & DeleteTargetRow>;
 
   const logSql = allowGlobalNamespaceDelete
-    ? "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 ORDER BY id"
-    : "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id";
+    ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 ORDER BY id`
+    : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id`;
   const logParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
-  const logRows = db.prepare(logSql).all(...logParams) as DeleteTargetRow[];
+
+  // Streamed, not materialised: a namespace delete may cover thousands of rows
+  // and the digest needs their content, which we never want to hold at once.
+  const keys: string[] = [];
+  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string } & DeleteTargetRow>) {
+    keys.push(row.key);
+    hashDeleteRow(hash, row);
+  }
+  let logCount = 0;
+  for (const row of db.prepare(logSql).iterate(...logParams) as Iterable<DeleteTargetRow>) {
+    logCount += 1;
+    hashDeleteRow(hash, row);
+  }
 
   return {
-    stateCount: stateKeys.length,
-    logCount: logRows.length,
-    keys: stateKeys.map((r) => r.key),
-    fingerprint: fingerprintDeleteRows([...stateKeys, ...logRows]),
+    stateCount: keys.length,
+    logCount,
+    keys,
+    fingerprint: hash.digest("hex"),
   };
 }
 
@@ -2058,14 +2090,15 @@ export function previewDeleteByClassification(
 ): DeleteInfo {
   const visibleLevels = getVisibleClassificationLevels(maxClassification);
   const placeholders = classificationInClause(visibleLevels);
+  const hash = createHash("sha256");
 
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? `SELECT id, updated_at, content FROM entries
+      ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
            AND is_current = 1
            AND classification IN (${placeholders})`
-      : `SELECT id, updated_at, content FROM entries
+      : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
            AND is_current = 1
            AND COALESCE(owner_principal_id, agent_id) = ?
@@ -2074,21 +2107,22 @@ export function previewDeleteByClassification(
       ? [namespace, key, ...visibleLevels]
       : [namespace, key, agentId, ...visibleLevels];
     const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
+    if (entry) hashDeleteRow(hash, entry);
     return {
       stateCount: entry ? 1 : 0,
       logCount: 0,
       keys: entry ? [key] : [],
-      fingerprint: fingerprintDeleteRows(entry ? [entry] : []),
+      fingerprint: hash.digest("hex"),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? `SELECT key, id, updated_at, content FROM entries
+    ? `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'state'
          AND is_current = 1
          AND classification IN (${placeholders})
        ORDER BY key, id`
-    : `SELECT key, id, updated_at, content FROM entries
+    : `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'state'
          AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
@@ -2097,15 +2131,14 @@ export function previewDeleteByClassification(
   const stateParams = allowGlobalNamespaceDelete
     ? [namespace, ...visibleLevels]
     : [namespace, agentId, ...visibleLevels];
-  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string } & DeleteTargetRow>;
 
   const logSql = allowGlobalNamespaceDelete
-    ? `SELECT id, updated_at, content FROM entries
+    ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'log'
          AND is_current = 1
          AND classification IN (${placeholders})
        ORDER BY id`
-    : `SELECT id, updated_at, content FROM entries
+    : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'log'
          AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
@@ -2114,13 +2147,23 @@ export function previewDeleteByClassification(
   const logParams = allowGlobalNamespaceDelete
     ? [namespace, ...visibleLevels]
     : [namespace, agentId, ...visibleLevels];
-  const logRows = db.prepare(logSql).all(...logParams) as DeleteTargetRow[];
+
+  const keys: string[] = [];
+  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string } & DeleteTargetRow>) {
+    keys.push(row.key);
+    hashDeleteRow(hash, row);
+  }
+  let logCount = 0;
+  for (const row of db.prepare(logSql).iterate(...logParams) as Iterable<DeleteTargetRow>) {
+    logCount += 1;
+    hashDeleteRow(hash, row);
+  }
 
   return {
-    stateCount: stateKeys.length,
-    logCount: logRows.length,
-    keys: stateKeys.map((r) => r.key),
-    fingerprint: fingerprintDeleteRows([...stateKeys, ...logRows]),
+    stateCount: keys.length,
+    logCount,
+    keys,
+    fingerprint: hash.digest("hex"),
   };
 }
 
@@ -2131,12 +2174,17 @@ export function executeDeleteByClassification(
   key?: string,
   agentId = "default",
   allowGlobalNamespaceDelete = false,
+  expectedFingerprint?: string,
 ): number {
   const now = nowUTC();
   const visibleLevels = getVisibleClassificationLevels(maxClassification);
   const placeholders = classificationInClause(visibleLevels);
 
   const txn = db.transaction(() => {
+    if (expectedFingerprint !== undefined) {
+      const current = previewDeleteByClassification(db, namespace, maxClassification, key, agentId, allowGlobalNamespaceDelete);
+      if (current.fingerprint !== expectedFingerprint) throw new DeletePreviewStaleError(current);
+    }
     // App-level vec cleanup (no SQL trigger — extension may not be loaded)
     if (_vecLoaded) {
       const owner = buildOwnerClause(allowGlobalNamespaceDelete, agentId);
@@ -2164,10 +2212,15 @@ export function executeDelete(
   key?: string,
   agentId = "default",
   allowGlobalNamespaceDelete = false,
+  expectedFingerprint?: string,
 ): number {
   const now = nowUTC();
 
   const txn = db.transaction(() => {
+    if (expectedFingerprint !== undefined) {
+      const current = previewDelete(db, namespace, key, agentId, allowGlobalNamespaceDelete);
+      if (current.fingerprint !== expectedFingerprint) throw new DeletePreviewStaleError(current);
+    }
     // App-level vec cleanup (no SQL trigger — extension may not be loaded)
     if (_vecLoaded) {
       const owner = buildOwnerClause(allowGlobalNamespaceDelete, agentId);

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
 import { mkdirSync, chmodSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
@@ -1841,6 +1841,37 @@ export interface DeleteInfo {
   stateCount: number;
   logCount: number;
   keys: string[];
+  /**
+   * Digest of the exact rows this preview covers. The delete token is bound to it,
+   * so a confirmation whose target moved since the preview is refused instead of
+   * destroying a revision the caller never saw (#266). Computed from the same
+   * queries that produce the counts above, so the fingerprint and the preview can
+   * never describe different row sets.
+   */
+  fingerprint: string;
+}
+
+type DeleteTargetRow = { id: string; updated_at: string; content: string };
+
+/**
+ * Digest of a delete target set, hashed in the caller's SQL-ordered sequence.
+ *
+ * Content is part of the digest because `updated_at` only has millisecond
+ * resolution: a rewrite landing in the same millisecond as the preview would
+ * otherwise be invisible, and the stale token would delete it (#266).
+ */
+function fingerprintDeleteRows(rows: Iterable<DeleteTargetRow>): string {
+  const hash = createHash("sha256");
+  for (const row of rows) {
+    // Escaped-NUL separators so no field value can forge a record boundary.
+    hash.update(row.id);
+    hash.update("\u0000");
+    hash.update(row.updated_at ?? "");
+    hash.update("\u0000");
+    hash.update(row.content ?? "");
+    hash.update("\u0000");
+  }
+  return hash.digest("hex");
 }
 
 function classificationInClause(levels: ClassificationLevel[]): string {
@@ -1985,33 +2016,35 @@ export function previewDelete(
 ): DeleteInfo {
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? "SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1"
-      : "SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?";
+      ? "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1"
+      : "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?";
     const params = allowGlobalNamespaceDelete ? [namespace, key] : [namespace, key, agentId];
-    const entry = db.prepare(sql).get(...params) as { id: string } | undefined;
+    const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
     return {
       stateCount: entry ? 1 : 0,
       logCount: 0,
       keys: entry ? [key] : [],
+      fingerprint: fingerprintDeleteRows(entry ? [entry] : []),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? "SELECT key FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 ORDER BY key"
-    : "SELECT key FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key";
+    ? "SELECT key, id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 ORDER BY key, id"
+    : "SELECT key, id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key, id";
   const stateParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
-  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string }>;
+  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string } & DeleteTargetRow>;
 
   const logSql = allowGlobalNamespaceDelete
-    ? "SELECT COUNT(*) as cnt FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1"
-    : "SELECT COUNT(*) as cnt FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?";
+    ? "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 ORDER BY id"
+    : "SELECT id, updated_at, content FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id";
   const logParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
-  const logCount = (db.prepare(logSql).get(...logParams) as { cnt: number }).cnt;
+  const logRows = db.prepare(logSql).all(...logParams) as DeleteTargetRow[];
 
   return {
     stateCount: stateKeys.length,
-    logCount,
+    logCount: logRows.length,
     keys: stateKeys.map((r) => r.key),
+    fingerprint: fingerprintDeleteRows([...stateKeys, ...logRows]),
   };
 }
 
@@ -2028,11 +2061,11 @@ export function previewDeleteByClassification(
 
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? `SELECT id FROM entries
+      ? `SELECT id, updated_at, content FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
            AND is_current = 1
            AND classification IN (${placeholders})`
-      : `SELECT id FROM entries
+      : `SELECT id, updated_at, content FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
            AND is_current = 1
            AND COALESCE(owner_principal_id, agent_id) = ?
@@ -2040,50 +2073,54 @@ export function previewDeleteByClassification(
     const params = allowGlobalNamespaceDelete
       ? [namespace, key, ...visibleLevels]
       : [namespace, key, agentId, ...visibleLevels];
-    const entry = db.prepare(sql).get(...params) as { id: string } | undefined;
+    const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
     return {
       stateCount: entry ? 1 : 0,
       logCount: 0,
       keys: entry ? [key] : [],
+      fingerprint: fingerprintDeleteRows(entry ? [entry] : []),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? `SELECT key FROM entries
+    ? `SELECT key, id, updated_at, content FROM entries
        WHERE namespace = ? AND entry_type = 'state'
          AND is_current = 1
          AND classification IN (${placeholders})
-       ORDER BY key`
-    : `SELECT key FROM entries
+       ORDER BY key, id`
+    : `SELECT key, id, updated_at, content FROM entries
        WHERE namespace = ? AND entry_type = 'state'
          AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
          AND classification IN (${placeholders})
-       ORDER BY key`;
+       ORDER BY key, id`;
   const stateParams = allowGlobalNamespaceDelete
     ? [namespace, ...visibleLevels]
     : [namespace, agentId, ...visibleLevels];
-  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string }>;
+  const stateKeys = db.prepare(stateSql).all(...stateParams) as Array<{ key: string } & DeleteTargetRow>;
 
   const logSql = allowGlobalNamespaceDelete
-    ? `SELECT COUNT(*) as cnt FROM entries
+    ? `SELECT id, updated_at, content FROM entries
        WHERE namespace = ? AND entry_type = 'log'
          AND is_current = 1
-         AND classification IN (${placeholders})`
-    : `SELECT COUNT(*) as cnt FROM entries
+         AND classification IN (${placeholders})
+       ORDER BY id`
+    : `SELECT id, updated_at, content FROM entries
        WHERE namespace = ? AND entry_type = 'log'
          AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
-         AND classification IN (${placeholders})`;
+         AND classification IN (${placeholders})
+       ORDER BY id`;
   const logParams = allowGlobalNamespaceDelete
     ? [namespace, ...visibleLevels]
     : [namespace, agentId, ...visibleLevels];
-  const logCount = (db.prepare(logSql).get(...logParams) as { cnt: number }).cnt;
+  const logRows = db.prepare(logSql).all(...logParams) as DeleteTargetRow[];
 
   return {
     stateCount: stateKeys.length,
-    logCount,
+    logCount: logRows.length,
     keys: stateKeys.map((r) => r.key),
+    fingerprint: fingerprintDeleteRows([...stateKeys, ...logRows]),
   };
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -47,6 +47,7 @@ import {
   summarizeNamespaceLogsByClassification,
   previewDelete,
   previewDeleteByClassification,
+  type DeleteInfo,
   executeDelete,
   executeDeleteByClassification,
   listCommitments,
@@ -213,28 +214,50 @@ import type {
 } from "./types.js";
 
 // In-memory delete token store (debate resolution #9)
-const deleteTokens = new Map<string, { namespace: string; key?: string; expiresAt: number }>();
+type DeleteTokenRecord = {
+  namespace: string;
+  key?: string;
+  expiresAt: number;
+  /** Digest of the rows the preview showed; a confirm whose targets moved is refused (#266). */
+  fingerprint: string;
+  stateCount: number;
+  logCount: number;
+};
+const deleteTokens = new Map<string, DeleteTokenRecord>();
 const DELETE_TOKEN_TTL_MS = 60_000; // 1 minute
 
-function generateDeleteToken(namespace: string, key?: string): string {
+function generateDeleteToken(namespace: string, info: DeleteInfo, key?: string): string {
   const token = randomBytes(16).toString("hex");
   deleteTokens.set(token, {
     namespace,
     key,
     expiresAt: Date.now() + DELETE_TOKEN_TTL_MS,
+    fingerprint: info.fingerprint,
+    stateCount: info.stateCount,
+    logCount: info.logCount,
   });
   return token;
 }
 
-function consumeDeleteToken(token: string, namespace: string, key?: string): boolean {
+type DeleteTokenCheck =
+  | { ok: true; record: DeleteTokenRecord }
+  | { ok: false; reason: "invalid" };
+
+/**
+ * Consume a delete token. The token is always spent, valid or not: a rejected
+ * confirmation must force a fresh preview rather than leave a retryable token
+ * behind. Fingerprint matching is checked by the caller against freshly read
+ * state, so this only covers identity and expiry.
+ */
+function consumeDeleteToken(token: string, namespace: string, key?: string): DeleteTokenCheck {
   const entry = deleteTokens.get(token);
-  if (!entry) return false;
+  if (!entry) return { ok: false, reason: "invalid" };
   deleteTokens.delete(token);
 
-  if (entry.expiresAt < Date.now()) return false;
-  if (entry.namespace !== namespace) return false;
-  if (entry.key !== key) return false;
-  return true;
+  if (entry.expiresAt < Date.now()) return { ok: false, reason: "invalid" };
+  if (entry.namespace !== namespace) return { ok: false, reason: "invalid" };
+  if (entry.key !== key) return { ok: false, reason: "invalid" };
+  return { ok: true, record: entry };
 }
 
 // Clean expired tokens periodically. The timer must not keep one-shot consumers
@@ -5375,7 +5398,7 @@ const TOOL_DEFINITIONS = [
   {
     name: "memory_delete",
     description:
-      "Delete a specific state entry by namespace+key, or all entries in a namespace. First call without delete_token to preview what will be deleted. Then call with the returned delete_token to execute.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
+      "Delete a specific state entry by namespace+key, or all entries in a namespace. First call without delete_token to preview what will be deleted. Then call with the returned delete_token to execute. The token is bound to the exact entries the preview showed: if any of them is written, added, or removed before you confirm, the delete is refused with `preview_stale` and you must preview again.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -9538,10 +9561,39 @@ export function registerTools(
                 );
               }
 
+              // Both phases resolve the delete target the same way, so the
+              // fingerprint stored on the token and the one checked at confirm
+              // time can never describe different row sets.
+              const readDeleteTarget = (): DeleteInfo =>
+                isLibrarianEnabled()
+                  ? previewDeleteByClassification(
+                      db,
+                      namespace,
+                      getContextMaxClassification(ctx),
+                      key,
+                      ctx.principalId,
+                      allowGlobalNamespaceDelete,
+                    )
+                  : previewDelete(db, namespace, key, ctx.principalId, allowGlobalNamespaceDelete);
+
               // Execute with token
               if (delete_token) {
-                if (!consumeDeleteToken(delete_token, namespace, key)) {
+                const tokenCheck = consumeDeleteToken(delete_token, namespace, key);
+                if (!tokenCheck.ok) {
                   return errResult("delete", "invalid_token", "Delete token is invalid, expired, or doesn't match the requested namespace/key. Request a new preview first.");
+                }
+                // Refuse to delete anything the preview did not show. Without this
+                // a token minted before an update still destroys the newer, unseen
+                // revision (#266).
+                const current = readDeleteTarget();
+                if (current.fingerprint !== tokenCheck.record.fingerprint) {
+                  return errResult(
+                    "delete",
+                    "preview_stale",
+                    `The delete target changed since the preview was generated (previewed ${tokenCheck.record.stateCount} state / ${tokenCheck.record.logCount} log entries, now ${current.stateCount} state / ${current.logCount} log). ` +
+                    "The token has been discarded. Preview again and review the current contents before confirming.",
+                    { namespace, key: key ?? undefined },
+                  );
                 }
                 let deletedCount: number;
                 try {
@@ -9562,17 +9614,8 @@ export function registerTools(
               }
 
               // Preview
-              const info = isLibrarianEnabled()
-                ? previewDeleteByClassification(
-                    db,
-                    namespace,
-                    getContextMaxClassification(ctx),
-                    key,
-                    ctx.principalId,
-                    allowGlobalNamespaceDelete,
-                  )
-                : previewDelete(db, namespace, key, ctx.principalId, allowGlobalNamespaceDelete);
-              const token = generateDeleteToken(namespace, key);
+              const info = readDeleteTarget();
+              const token = generateDeleteToken(namespace, info, key);
               const target = key ? `entry "${key}" in "${namespace}"` : `all entries in "${namespace}"`;
               return okResult("delete", {
                 phase: "preview",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -48,6 +48,7 @@ import {
   previewDelete,
   previewDeleteByClassification,
   type DeleteInfo,
+  DeletePreviewStaleError,
   executeDelete,
   executeDeleteByClassification,
   listCommitments,
@@ -9561,9 +9562,9 @@ export function registerTools(
                 );
               }
 
-              // Both phases resolve the delete target the same way, so the
-              // fingerprint stored on the token and the one checked at confirm
-              // time can never describe different row sets.
+              // The preview and the in-transaction confirm check call the same
+              // functions, so the fingerprint stored on the token and the one
+              // verified at confirm time can never describe different row sets.
               const readDeleteTarget = (): DeleteInfo =>
                 isLibrarianEnabled()
                   ? previewDeleteByClassification(
@@ -9582,25 +9583,24 @@ export function registerTools(
                 if (!tokenCheck.ok) {
                   return errResult("delete", "invalid_token", "Delete token is invalid, expired, or doesn't match the requested namespace/key. Request a new preview first.");
                 }
-                // Refuse to delete anything the preview did not show. Without this
-                // a token minted before an update still destroys the newer, unseen
-                // revision (#266).
-                const current = readDeleteTarget();
-                if (current.fingerprint !== tokenCheck.record.fingerprint) {
-                  return errResult(
-                    "delete",
-                    "preview_stale",
-                    `The delete target changed since the preview was generated (previewed ${tokenCheck.record.stateCount} state / ${tokenCheck.record.logCount} log entries, now ${current.stateCount} state / ${current.logCount} log). ` +
-                    "The token has been discarded. Preview again and review the current contents before confirming.",
-                    { namespace, key: key ?? undefined },
-                  );
-                }
+                // Refuse to delete anything the preview did not show. The check
+                // runs inside the delete transaction so a concurrent writer cannot
+                // slip between verification and DELETE (#266).
                 let deletedCount: number;
                 try {
                   deletedCount = isLibrarianEnabled()
-                    ? executeDeleteByClassification(db, namespace, getContextMaxClassification(ctx), key, ctx.principalId, allowGlobalNamespaceDelete)
-                    : executeDelete(db, namespace, key, ctx.principalId, allowGlobalNamespaceDelete);
+                    ? executeDeleteByClassification(db, namespace, getContextMaxClassification(ctx), key, ctx.principalId, allowGlobalNamespaceDelete, tokenCheck.record.fingerprint)
+                    : executeDelete(db, namespace, key, ctx.principalId, allowGlobalNamespaceDelete, tokenCheck.record.fingerprint);
                 } catch (error) {
+                  if (error instanceof DeletePreviewStaleError) {
+                    return errResult(
+                      "delete",
+                      "preview_stale",
+                      `The delete target changed since the preview was generated (previewed ${tokenCheck.record.stateCount} state / ${tokenCheck.record.logCount} log entries, now ${error.current.stateCount} state / ${error.current.logCount} log). ` +
+                      "Nothing was deleted and the token has been discarded. Preview again and review the current contents before confirming.",
+                      { namespace, key: key ?? undefined },
+                    );
+                  }
                   return errResult("delete", "conflict", (error as Error).message, { namespace, key });
                 }
                 const target = key ? `entry "${key}" in "${namespace}"` : `all entries in "${namespace}"`;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -26,6 +26,7 @@ import {
   listNamespaces,
   listNamespaceContents,
   previewDelete,
+  DeletePreviewStaleError,
   executeDelete,
   getOtherKeysInNamespace,
   getNamespaceStateEntries,
@@ -947,6 +948,60 @@ describe("previewDelete + executeDelete", () => {
     const preview = previewDelete(db, "projects/test");
     expect(preview.stateCount).toBe(2);
     expect(preview.logCount).toBe(1);
+  });
+
+  // The delete-token fingerprint must notice any caller-visible mutation, not
+  // only a content rewrite. updated_at has millisecond resolution, so these
+  // tests mutate a single column directly and hold updated_at fixed — the exact
+  // situation a same-millisecond patch produces in production (#266).
+  describe("fingerprint covers every mutable field (#266)", () => {
+    const mutations: Array<[string, string]> = [
+      ["tags", "UPDATE entries SET tags = '[\"decision\"]' WHERE namespace = ? AND key = ?"],
+      ["content", "UPDATE entries SET content = 'rewritten' WHERE namespace = ? AND key = ?"],
+      ["classification", "UPDATE entries SET classification = 'client-confidential' WHERE namespace = ? AND key = ?"],
+      ["valid_until", "UPDATE entries SET valid_until = '2030-01-01T00:00:00.000Z' WHERE namespace = ? AND key = ?"],
+    ];
+
+    for (const [field, sql] of mutations) {
+      it(`changes when ${field} changes with updated_at held fixed`, () => {
+        writeState(db, "projects/fp", "target", "original", ["research"]);
+        const before = previewDelete(db, "projects/fp", "target");
+        const beforeUpdatedAt = readState(db, "projects/fp", "target")!.updated_at;
+
+        db.prepare(sql).run("projects/fp", "target");
+        // Prove the clock cannot be doing the work for us.
+        expect(readState(db, "projects/fp", "target")!.updated_at).toBe(beforeUpdatedAt);
+
+        const after = previewDelete(db, "projects/fp", "target");
+        expect(after.fingerprint).not.toBe(before.fingerprint);
+      });
+    }
+
+    it("is stable when nothing changes", () => {
+      writeState(db, "projects/fp", "target", "original", ["research"]);
+      expect(previewDelete(db, "projects/fp", "target").fingerprint).toBe(
+        previewDelete(db, "projects/fp", "target").fingerprint,
+      );
+    });
+
+    it("refuses the delete inside the transaction when the fingerprint is stale", () => {
+      writeState(db, "projects/fp", "target", "original", []);
+      const stale = previewDelete(db, "projects/fp", "target").fingerprint;
+      db.prepare("UPDATE entries SET content = 'rewritten' WHERE namespace = ? AND key = ?").run("projects/fp", "target");
+
+      expect(() =>
+        executeDelete(db, "projects/fp", "target", "default", false, stale),
+      ).toThrow(DeletePreviewStaleError);
+      // Nothing was deleted: the guard runs inside the delete transaction.
+      expect(readState(db, "projects/fp", "target")).not.toBeNull();
+    });
+
+    it("proceeds when the fingerprint still matches", () => {
+      writeState(db, "projects/fp", "target", "original", []);
+      const fresh = previewDelete(db, "projects/fp", "target").fingerprint;
+      expect(executeDelete(db, "projects/fp", "target", "default", false, fresh)).toBe(1);
+      expect(readState(db, "projects/fp", "target")).toBeNull();
+    });
   });
 
   it("executes single key deletion", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -3292,6 +3292,54 @@ describe("memory_delete", () => {
     expect(readResult.content).toContain("version two");
   });
 
+  it("rejects a preview token after a tags-only patch that kept the content (#266)", async () => {
+    // updated_at has millisecond resolution, so a metadata-only patch in the same
+    // millisecond as the preview is invisible unless every mutable field is hashed.
+    await callTool("memory_write", { namespace: "projects/test", key: "tagged", content: "content stays identical", tags: ["research"] });
+
+    const previewRaw = await callTool("memory_delete", { namespace: "projects/test", key: "tagged" });
+    const preview = parseToolResponse(previewRaw) as { delete_token: string };
+
+    await callTool("memory_write", {
+      namespace: "projects/test",
+      key: "tagged",
+      patch: { tags_add: ["decision"] },
+    });
+
+    const confirmRaw = await callTool("memory_delete", {
+      namespace: "projects/test",
+      key: "tagged",
+      delete_token: preview.delete_token,
+    });
+    const confirm = parseToolResponse(confirmRaw) as { ok: boolean; error: string };
+    expect(confirm.ok).toBe(false);
+    expect(confirm.error).toBe("preview_stale");
+
+    const readRaw = await callTool("memory_read", { namespace: "projects/test", key: "tagged" });
+    expect((parseToolResponse(readRaw) as { found: boolean }).found).toBe(true);
+  });
+
+  it("spends a stale token so it cannot be retried (#266)", async () => {
+    await callTool("memory_write", { namespace: "projects/test", key: "spent", content: "one" });
+    const previewRaw = await callTool("memory_delete", { namespace: "projects/test", key: "spent" });
+    const preview = parseToolResponse(previewRaw) as { delete_token: string };
+    await callTool("memory_write", { namespace: "projects/test", key: "spent", content: "two" });
+
+    const first = parseToolResponse(
+      await callTool("memory_delete", { namespace: "projects/test", key: "spent", delete_token: preview.delete_token }),
+    ) as { error: string };
+    expect(first.error).toBe("preview_stale");
+
+    // Replaying the same token must not work even though the entry is now stable.
+    const second = parseToolResponse(
+      await callTool("memory_delete", { namespace: "projects/test", key: "spent", delete_token: preview.delete_token }),
+    ) as { error: string };
+    expect(second.error).toBe("invalid_token");
+
+    const readRaw = await callTool("memory_read", { namespace: "projects/test", key: "spent" });
+    expect((parseToolResponse(readRaw) as { found: boolean }).found).toBe(true);
+  });
+
   it("rejects a namespace-wide preview token after a new entry appears (#266)", async () => {
     process.env.MUNIN_ALLOW_NAMESPACE_DELETE = "true";
     await callTool("memory_write", { namespace: "projects/racens", key: "a", content: "first entry" });
@@ -3312,6 +3360,34 @@ describe("memory_delete", () => {
 
     const readRaw = await callTool("memory_read", { namespace: "projects/racens", key: "b" });
     expect((parseToolResponse(readRaw) as { found: boolean }).found).toBe(true);
+    delete process.env.MUNIN_ALLOW_NAMESPACE_DELETE;
+  });
+
+  it("rejects a stale token with the librarian enabled (#266)", async () => {
+    process.env.MUNIN_LIBRARIAN_ENABLED = "true";
+    try {
+      await callTool("memory_write", { namespace: "projects/test", key: "librarian-victim", content: "version one" });
+      const preview = parseToolResponse(
+        await callTool("memory_delete", { namespace: "projects/test", key: "librarian-victim" }),
+      ) as { delete_token: string };
+
+      await callTool("memory_write", { namespace: "projects/test", key: "librarian-victim", content: "version two, never previewed" });
+
+      const confirm = parseToolResponse(
+        await callTool("memory_delete", {
+          namespace: "projects/test",
+          key: "librarian-victim",
+          delete_token: preview.delete_token,
+        }),
+      ) as { ok: boolean; error: string };
+      expect(confirm.ok).toBe(false);
+      expect(confirm.error).toBe("preview_stale");
+
+      const readRaw = await callTool("memory_read", { namespace: "projects/test", key: "librarian-victim" });
+      expect((parseToolResponse(readRaw) as { found: boolean }).found).toBe(true);
+    } finally {
+      delete process.env.MUNIN_LIBRARIAN_ENABLED;
+    }
   });
 
   it("still confirms when the target is untouched between preview and confirm (#266)", async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -3259,6 +3259,81 @@ describe("memory_delete", () => {
     expect(result.error).toBe("invalid_token");
   });
 
+  it("rejects a preview token after the target entry changed (#266)", async () => {
+    await callTool("memory_write", { namespace: "projects/test", key: "victim", content: "version one before delete preview" });
+
+    const previewRaw = await callTool("memory_delete", {
+      namespace: "projects/test",
+      key: "victim",
+    });
+    const preview = parseToolResponse(previewRaw) as { delete_token: string };
+
+    // Someone updates the entry between preview and confirm.
+    await callTool("memory_write", {
+      namespace: "projects/test",
+      key: "victim",
+      content: "version two after delete preview; the stale token must not delete this",
+    });
+
+    const confirmRaw = await callTool("memory_delete", {
+      namespace: "projects/test",
+      key: "victim",
+      delete_token: preview.delete_token,
+    });
+    const confirm = parseToolResponse(confirmRaw) as { ok: boolean; error: string; message: string };
+    expect(confirm.ok).toBe(false);
+    expect(confirm.error).toBe("preview_stale");
+    expect(confirm.message).toContain("changed since the preview");
+
+    // The newer version must survive.
+    const readRaw = await callTool("memory_read", { namespace: "projects/test", key: "victim" });
+    const readResult = parseToolResponse(readRaw) as { found: boolean; content: string };
+    expect(readResult.found).toBe(true);
+    expect(readResult.content).toContain("version two");
+  });
+
+  it("rejects a namespace-wide preview token after a new entry appears (#266)", async () => {
+    process.env.MUNIN_ALLOW_NAMESPACE_DELETE = "true";
+    await callTool("memory_write", { namespace: "projects/racens", key: "a", content: "first entry" });
+
+    const previewRaw = await callTool("memory_delete", { namespace: "projects/racens" });
+    const preview = parseToolResponse(previewRaw) as { delete_token: string };
+
+    // A second entry lands in the namespace after the operator previewed.
+    await callTool("memory_write", { namespace: "projects/racens", key: "b", content: "entry the operator never saw" });
+
+    const confirmRaw = await callTool("memory_delete", {
+      namespace: "projects/racens",
+      delete_token: preview.delete_token,
+    });
+    const confirm = parseToolResponse(confirmRaw) as { ok: boolean; error: string };
+    expect(confirm.ok).toBe(false);
+    expect(confirm.error).toBe("preview_stale");
+
+    const readRaw = await callTool("memory_read", { namespace: "projects/racens", key: "b" });
+    expect((parseToolResponse(readRaw) as { found: boolean }).found).toBe(true);
+  });
+
+  it("still confirms when the target is untouched between preview and confirm (#266)", async () => {
+    await callTool("memory_write", { namespace: "projects/test", key: "stable", content: "unchanged between preview and confirm" });
+
+    const previewRaw = await callTool("memory_delete", { namespace: "projects/test", key: "stable" });
+    const preview = parseToolResponse(previewRaw) as { delete_token: string };
+
+    // An unrelated entry changes; it must not invalidate this key-scoped token.
+    await callTool("memory_write", { namespace: "projects/test", key: "bystander", content: "unrelated write" });
+
+    const confirmRaw = await callTool("memory_delete", {
+      namespace: "projects/test",
+      key: "stable",
+      delete_token: preview.delete_token,
+    });
+    const confirm = parseToolResponse(confirmRaw) as { ok: boolean; phase: string; deleted_count: number };
+    expect(confirm.ok).toBe(true);
+    expect(confirm.phase).toBe("confirmed");
+    expect(confirm.deleted_count).toBe(1);
+  });
+
   it("rejects token used for wrong namespace", async () => {
     await callTool("memory_write", { namespace: "projects/a", key: "s", content: "c" });
     await callTool("memory_write", { namespace: "projects/b", key: "s", content: "c" });


### PR DESCRIPTION
Closes #266.

## The bug

A `memory_delete` preview token carried only `{namespace, key, expiresAt}`. Nothing tied it to the rows the preview showed, so a token minted before an update still authorised the delete afterwards:

1. `memory_write` an entry
2. `memory_delete` preview → token
3. anything rewrites the entry
4. confirm with the token from step 2

The newer revision — which the caller never saw — was destroyed, with `ok:true`, `deleted_count:1` and no warning. Found by an independent user-test agent reproducing it live against production.

## The fix

`previewDelete` / `previewDeleteByClassification` now also return a `fingerprint`: a SHA-256 over the `id`, `updated_at`, `content`, `tags`, `classification` and `valid_until` of every row in scope, in deterministic SQL order. The token stores it, and `executeDelete` / `executeDeleteByClassification` verify it **inside their own transaction** before deleting, throwing `DeletePreviewStaleError` on mismatch. The handler maps that to a new `preview_stale` error carrying previewed vs current counts, and the token is spent either way so a fresh preview is required.

Two design points worth calling out:

- **Content and metadata are in the digest, not just `updated_at`.** That column has millisecond resolution, so a rewrite — including a tags-only patch — landing in the same millisecond as the preview would otherwise be invisible. This was not theoretical: the first version of the tool-level test passed in isolation and failed in a warm full-file run, because both writes hit the same millisecond.
- **The check is inside the delete transaction.** Checking in the handler and deleting afterwards leaves a window for a second connection to commit in between, which recreates the original bug.

The namespace-wide path is covered too: an entry appearing after the preview now blocks the confirm rather than being swept up silently. Preview rows are streamed with `.iterate()` since a namespace preview now reads content for the whole namespace.

## Tests

Red/green throughout. `tests/tools.test.ts` gains six end-to-end cases (stale single-key, stale namespace-wide, stale under the librarian, token-is-spent, tags-only patch, and an untouched-target non-regression). `tests/db.test.ts` gains a unit block that pins `updated_at` and mutates one column at a time — three of those cases fail without the metadata fields in the digest, which the tool-level tests cannot demonstrate because their writes land in different milliseconds.

Gates: lint, both typechecks, build, 2,567 passed / 4 skipped, coverage above floors, benchmark gate PASS.

## Review

Cross-model review by Codex `gpt-5.6-sol` @ high on the first commit found the metadata gap and the atomicity gap, both fixed in `6db1c06`. Its third finding — the preview counts only current rows while the delete removes superseded revisions too — is pre-existing and out of scope here; filed as #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)