### PR TITLE
ci: pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       # Native ARM64 evidence for the exact user-facing path, including its own
@@ -38,8 +38,8 @@ jobs:
         # ARM64 Node in this range; the matrix is cheap drift insurance.
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: javascript-typescript
           queries: security-extended
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Closes #283

Pins all seven third-party GitHub Action references in CI and CodeQL to full immutable commit SHAs, retaining same-line release comments.

Verified against the official upstream tags:
- actions/checkout v7.0.1 → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- actions/setup-node v7.0.0 → `820762786026740c76f36085b0efc47a31fe5020`
- github/codeql-action v4.37.3 → `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (checkout, init, analyze)

Validation: YAML parse; `npm run lint`; `npm run typecheck`; `npm run typecheck:tools`; `npm run build`; `npm run test:coverage`; `npm run benchmark:ci-gate`; `npm run benchmark:ci-gate:hybrid -- --require-vec`.

M5 independent review: PASS.