### PR TITLE
Fix delete preview correction lineage scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ changelog is the canonical record of what moved.
 
 ### Fixed
 
+- **`memory_delete` previews disclose and bind the full correction lineage
+  they will remove (#281).** A delete of a corrected state entry removes its
+  current revision *and* superseded revisions, but the preview previously
+  reported and fingerprinted only the current row. `state_count` now includes
+  every state revision that confirmation can delete, with
+  `current_state_count` and `historical_state_count` making that scope explicit;
+  the token fingerprint covers the same complete set. A classification- or
+  owner-scoped delete that would cut through a correction chain now fails
+  closed with `partial_lineage` before it issues a token, rather than presenting
+  a misleading partial preview and failing only at confirmation.
+
 - **`memory_delete` preview tokens are bound to the entries they previewed
   (#266).** A token carried only `{namespace, key, expiresAt}`, so a preview
   taken before an update still authorised the delete afterwards: preview an

--- a/src/db.ts
+++ b/src/db.ts
@@ -1975,7 +1975,12 @@ export function pruneRedactionLog(
 // --- Delete operations ---
 
 export interface DeleteInfo {
+  /** Total state revisions the delete will remove, including superseded history. */
   stateCount: number;
+  /** Current state entries within stateCount. */
+  currentStateCount: number;
+  /** Superseded state revisions within stateCount. */
+  historicalStateCount: number;
   logCount: number;
   keys: string[];
   /**
@@ -1998,6 +2003,18 @@ export class DeletePreviewStaleError extends Error {
   constructor(readonly current: DeleteInfo) {
     super("Delete target changed since the preview was generated.");
     this.name = "DeletePreviewStaleError";
+  }
+}
+
+/**
+ * Raised before a classified/owner-scoped preview can mint a token when its
+ * selection cuts through a correction chain. Confirming such a preview would
+ * either fail later or, worse, conceal revisions the caller cannot review.
+ */
+export class DeletePreviewPartialLineageError extends Error {
+  constructor() {
+    super("Deletion would remove only part of a correction chain; no preview token was generated.");
+    this.name = "DeletePreviewPartialLineageError";
   }
 }
 
@@ -2055,7 +2072,7 @@ function buildOwnerClause(allowGlobal: boolean, agentId: string): { clause: stri
   return { clause: " AND COALESCE(owner_principal_id, agent_id) = ?", params: [agentId] };
 }
 
-function deleteLineageForSelection(
+function assertCompleteLineageSelection(
   db: Database.Database,
   selectionSql: string,
   params: unknown[],
@@ -2066,8 +2083,16 @@ function deleteLineageForSelection(
      LIMIT 1`,
   ).get(...params, ...params);
   if (partial) {
-    throw new Error("Deletion would remove only part of a correction chain; no entries were deleted.");
+    throw new DeletePreviewPartialLineageError();
   }
+}
+
+function deleteLineageForSelection(
+  db: Database.Database,
+  selectionSql: string,
+  params: unknown[],
+): void {
+  assertCompleteLineageSelection(db, selectionSql, params);
   db.prepare(
     `DELETE FROM entry_supersessions
      WHERE predecessor_id IN (${selectionSql}) OR successor_id IN (${selectionSql})`,
@@ -2173,34 +2198,53 @@ export function previewDelete(
 
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1`
-      : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ?`;
+      ? `SELECT ${DELETE_TARGET_COLUMNS}, is_current FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' ORDER BY id`
+      : `SELECT ${DELETE_TARGET_COLUMNS}, is_current FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id`;
     const params = allowGlobalNamespaceDelete ? [namespace, key] : [namespace, key, agentId];
-    const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
-    if (entry) hashDeleteRow(hash, entry);
+    const selectionSql = allowGlobalNamespaceDelete
+      ? "SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state'"
+      : "SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND COALESCE(owner_principal_id, agent_id) = ?";
+    assertCompleteLineageSelection(db, selectionSql, params);
+    let stateCount = 0;
+    let currentStateCount = 0;
+    for (const entry of db.prepare(sql).iterate(...params) as Iterable<DeleteTargetRow & { is_current: number }>) {
+      stateCount += 1;
+      currentStateCount += entry.is_current;
+      hashDeleteRow(hash, entry);
+    }
     return {
-      stateCount: entry ? 1 : 0,
+      stateCount,
+      currentStateCount,
+      historicalStateCount: stateCount - currentStateCount,
       logCount: 0,
-      keys: entry ? [key] : [],
+      keys: currentStateCount > 0 ? [key] : [],
       fingerprint: hash.digest("hex"),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 ORDER BY key, id`
-    : `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'state' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key, id`;
+    ? `SELECT key, ${DELETE_TARGET_COLUMNS}, is_current FROM entries WHERE namespace = ? AND entry_type = 'state' ORDER BY key, id`
+    : `SELECT key, ${DELETE_TARGET_COLUMNS}, is_current FROM entries WHERE namespace = ? AND entry_type = 'state' AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY key, id`;
   const stateParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
 
   const logSql = allowGlobalNamespaceDelete
-    ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 ORDER BY id`
-    : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' AND is_current = 1 AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id`;
+    ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' ORDER BY id`
+    : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries WHERE namespace = ? AND entry_type = 'log' AND COALESCE(owner_principal_id, agent_id) = ? ORDER BY id`;
   const logParams = allowGlobalNamespaceDelete ? [namespace] : [namespace, agentId];
 
   // Streamed, not materialised: a namespace delete may cover thousands of rows
   // and the digest needs their content, which we never want to hold at once.
+  const selectionSql = allowGlobalNamespaceDelete
+    ? "SELECT id FROM entries WHERE namespace = ?"
+    : "SELECT id FROM entries WHERE namespace = ? AND COALESCE(owner_principal_id, agent_id) = ?";
+  assertCompleteLineageSelection(db, selectionSql, stateParams);
   const keys: string[] = [];
-  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string } & DeleteTargetRow>) {
-    keys.push(row.key);
+  let stateCount = 0;
+  let currentStateCount = 0;
+  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string; is_current: number } & DeleteTargetRow>) {
+    stateCount += 1;
+    currentStateCount += row.is_current;
+    if (row.is_current === 1) keys.push(row.key);
     hashDeleteRow(hash, row);
   }
   let logCount = 0;
@@ -2210,7 +2254,9 @@ export function previewDelete(
   }
 
   return {
-    stateCount: keys.length,
+    stateCount,
+    currentStateCount,
+    historicalStateCount: stateCount - currentStateCount,
     logCount,
     keys,
     fingerprint: hash.digest("hex"),
@@ -2231,37 +2277,44 @@ export function previewDeleteByClassification(
 
   if (key) {
     const sql = allowGlobalNamespaceDelete
-      ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
+      ? `SELECT ${DELETE_TARGET_COLUMNS}, is_current FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
-           AND is_current = 1
-           AND classification IN (${placeholders})`
-      : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
+           AND classification IN (${placeholders}) ORDER BY id`
+      : `SELECT ${DELETE_TARGET_COLUMNS}, is_current FROM entries
          WHERE namespace = ? AND key = ? AND entry_type = 'state'
-           AND is_current = 1
            AND COALESCE(owner_principal_id, agent_id) = ?
-           AND classification IN (${placeholders})`;
+           AND classification IN (${placeholders}) ORDER BY id`;
     const params = allowGlobalNamespaceDelete
       ? [namespace, key, ...visibleLevels]
       : [namespace, key, agentId, ...visibleLevels];
-    const entry = db.prepare(sql).get(...params) as DeleteTargetRow | undefined;
-    if (entry) hashDeleteRow(hash, entry);
+    const selectionSql = allowGlobalNamespaceDelete
+      ? `SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND classification IN (${placeholders})`
+      : `SELECT id FROM entries WHERE namespace = ? AND key = ? AND entry_type = 'state' AND COALESCE(owner_principal_id, agent_id) = ? AND classification IN (${placeholders})`;
+    assertCompleteLineageSelection(db, selectionSql, params);
+    let stateCount = 0;
+    let currentStateCount = 0;
+    for (const entry of db.prepare(sql).iterate(...params) as Iterable<DeleteTargetRow & { is_current: number }>) {
+      stateCount += 1;
+      currentStateCount += entry.is_current;
+      hashDeleteRow(hash, entry);
+    }
     return {
-      stateCount: entry ? 1 : 0,
+      stateCount,
+      currentStateCount,
+      historicalStateCount: stateCount - currentStateCount,
       logCount: 0,
-      keys: entry ? [key] : [],
+      keys: currentStateCount > 0 ? [key] : [],
       fingerprint: hash.digest("hex"),
     };
   }
 
   const stateSql = allowGlobalNamespaceDelete
-    ? `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries
+    ? `SELECT key, ${DELETE_TARGET_COLUMNS}, is_current FROM entries
        WHERE namespace = ? AND entry_type = 'state'
-         AND is_current = 1
          AND classification IN (${placeholders})
        ORDER BY key, id`
-    : `SELECT key, ${DELETE_TARGET_COLUMNS} FROM entries
+    : `SELECT key, ${DELETE_TARGET_COLUMNS}, is_current FROM entries
        WHERE namespace = ? AND entry_type = 'state'
-         AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
          AND classification IN (${placeholders})
        ORDER BY key, id`;
@@ -2272,12 +2325,10 @@ export function previewDeleteByClassification(
   const logSql = allowGlobalNamespaceDelete
     ? `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'log'
-         AND is_current = 1
          AND classification IN (${placeholders})
        ORDER BY id`
     : `SELECT ${DELETE_TARGET_COLUMNS} FROM entries
        WHERE namespace = ? AND entry_type = 'log'
-         AND is_current = 1
          AND COALESCE(owner_principal_id, agent_id) = ?
          AND classification IN (${placeholders})
        ORDER BY id`;
@@ -2285,9 +2336,17 @@ export function previewDeleteByClassification(
     ? [namespace, ...visibleLevels]
     : [namespace, agentId, ...visibleLevels];
 
+  const selectionSql = allowGlobalNamespaceDelete
+    ? `SELECT id FROM entries WHERE namespace = ? AND classification IN (${placeholders})`
+    : `SELECT id FROM entries WHERE namespace = ? AND COALESCE(owner_principal_id, agent_id) = ? AND classification IN (${placeholders})`;
+  assertCompleteLineageSelection(db, selectionSql, stateParams);
   const keys: string[] = [];
-  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string } & DeleteTargetRow>) {
-    keys.push(row.key);
+  let stateCount = 0;
+  let currentStateCount = 0;
+  for (const row of db.prepare(stateSql).iterate(...stateParams) as Iterable<{ key: string; is_current: number } & DeleteTargetRow>) {
+    stateCount += 1;
+    currentStateCount += row.is_current;
+    if (row.is_current === 1) keys.push(row.key);
     hashDeleteRow(hash, row);
   }
   let logCount = 0;
@@ -2297,7 +2356,9 @@ export function previewDeleteByClassification(
   }
 
   return {
-    stateCount: keys.length,
+    stateCount,
+    currentStateCount,
+    historicalStateCount: stateCount - currentStateCount,
     logCount,
     keys,
     fingerprint: hash.digest("hex"),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -49,6 +49,7 @@ import {
   previewDeleteByClassification,
   type DeleteInfo,
   DeletePreviewStaleError,
+  DeletePreviewPartialLineageError,
   executeDelete,
   executeDeleteByClassification,
   listCommitments,
@@ -5399,7 +5400,7 @@ const TOOL_DEFINITIONS = [
   {
     name: "memory_delete",
     description:
-      "Delete a specific state entry by namespace+key, or all entries in a namespace. First call without delete_token to preview what will be deleted. Then call with the returned delete_token to execute. The token is bound to the exact entries the preview showed: if any of them is written, added, or removed before you confirm, the delete is refused with `preview_stale` and you must preview again.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
+      "Delete a specific state entry by namespace+key, or all entries in a namespace. First call without delete_token to preview what will be deleted. `state_count` includes current and superseded state revisions; `current_state_count` and `historical_state_count` make that destructive scope explicit. Then call with the returned delete_token to execute. The token is bound to the exact entries the preview showed: if any of them is written, added, or removed before you confirm, the delete is refused with `preview_stale` and you must preview again. If classification or ownership filtering would split a correction lineage, preview fails closed with `partial_lineage` and issues no token.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -9601,6 +9602,9 @@ export function registerTools(
                       { namespace, key: key ?? undefined },
                     );
                   }
+                  if (error instanceof DeletePreviewPartialLineageError) {
+                    return errResult("delete", "partial_lineage", error.message, { namespace, key: key ?? undefined });
+                  }
                   return errResult("delete", "conflict", (error as Error).message, { namespace, key });
                 }
                 const target = key ? `entry "${key}" in "${namespace}"` : `all entries in "${namespace}"`;
@@ -9614,7 +9618,15 @@ export function registerTools(
               }
 
               // Preview
-              const info = readDeleteTarget();
+              let info: DeleteInfo;
+              try {
+                info = readDeleteTarget();
+              } catch (error) {
+                if (error instanceof DeletePreviewPartialLineageError) {
+                  return errResult("delete", "partial_lineage", error.message, { namespace, key: key ?? undefined });
+                }
+                return errResult("delete", "conflict", (error as Error).message, { namespace, key: key ?? undefined });
+              }
               const token = generateDeleteToken(namespace, info, key);
               const target = key ? `entry "${key}" in "${namespace}"` : `all entries in "${namespace}"`;
               return okResult("delete", {
@@ -9623,6 +9635,8 @@ export function registerTools(
                 key: key ?? undefined,
                 will_delete: {
                   state_count: info.stateCount,
+                  current_state_count: info.currentStateCount,
+                  historical_state_count: info.historicalStateCount,
                   log_count: info.logCount,
                   keys: info.keys.length > 0 ? info.keys : undefined,
                 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -474,7 +474,10 @@ export interface DeletePreview {
   namespace: string;
   key?: string;
   will_delete: {
+    /** Includes every superseded revision that confirmation will remove. */
     state_count: number;
+    current_state_count: number;
+    historical_state_count: number;
     log_count: number;
     keys?: string[];
   };

--- a/tests/correction.test.ts
+++ b/tests/correction.test.ts
@@ -238,7 +238,11 @@ describe("state correction", () => {
       namespace: "projects/corrections",
       key: "deletable",
     });
-    expect((preview.will_delete as { state_count: number }).state_count).toBe(1);
+    // A key delete removes the complete correction lineage, not only the current
+    // revision surfaced by ordinary reads. The preview must disclose that scope.
+    expect((preview.will_delete as { state_count: number; current_state_count: number; historical_state_count: number }).state_count).toBe(2);
+    expect((preview.will_delete as { current_state_count: number }).current_state_count).toBe(1);
+    expect((preview.will_delete as { historical_state_count: number }).historical_state_count).toBe(1);
     const deleted = await call("memory_delete", {
       namespace: "projects/corrections",
       key: "deletable",

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -28,6 +28,7 @@ import {
   previewDelete,
   DeletePreviewStaleError,
   executeDelete,
+  supersedeState,
   getOtherKeysInNamespace,
   getNamespaceStateEntries,
   getNamespaceTagVocabulary,
@@ -1044,6 +1045,27 @@ describe("previewDelete + executeDelete", () => {
     const preview = previewDelete(db, "projects/test");
     expect(preview.stateCount).toBe(2);
     expect(preview.logCount).toBe(1);
+  });
+
+  it("counts and fingerprints every correction revision a key delete removes (#281)", () => {
+    writeState(db, "projects/fp", "corrected", "original", []);
+    const original = readState(db, "projects/fp", "corrected")!;
+    const corrected = supersedeState(
+      db, "projects/fp", "corrected", original.id, "corrected", [], "default",
+      original.updated_at, original.valid_from, undefined,
+    );
+    expect(corrected.status).toBe("superseded");
+
+    const preview = previewDelete(db, "projects/fp", "corrected");
+    expect(preview).toMatchObject({ stateCount: 2, currentStateCount: 1, historicalStateCount: 1 });
+
+    // The historical row is just as destructive a target as current truth.
+    // Hold its timestamp fixed to prove the full-row digest, not the clock,
+    // blocks a confirmation that no longer matches the preview.
+    db.prepare("UPDATE entries SET tags = '[\"changed-history\"]' WHERE id = ?").run(original.id);
+    expect(() => executeDelete(db, "projects/fp", "corrected", "default", false, preview.fingerprint))
+      .toThrow(DeletePreviewStaleError);
+    expect(readState(db, "projects/fp", "corrected")?.content).toBe("corrected");
   });
 
   // The delete-token fingerprint must notice any caller-visible mutation, not

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -6,6 +6,7 @@ import {
   computeCommitmentConfidence,
   initDatabase,
   listCommitments,
+  supersedeState,
   upsertConsolidationMetadata,
   writeState,
 } from "../src/db.js";
@@ -1671,6 +1672,37 @@ describe("Librarian Pattern A enforcement for query/list/history", () => {
     expect(result.will_delete.keys).toBeUndefined();
     expect(result.message).toContain("visible entries on this connection");
     delete process.env.MUNIN_ALLOW_NAMESPACE_DELETE;
+  });
+
+  it("refuses a classified delete preview when it can see only part of a correction lineage", async () => {
+    await callTool("memory_write", {
+      namespace: "projects/delete-partial-lineage",
+      key: "restricted-correction",
+      content: "initial internal revision",
+      classification: "internal",
+    });
+    const original = db.prepare(
+      "SELECT id, updated_at, valid_from FROM entries WHERE namespace = ? AND key = ? AND is_current = 1",
+    ).get("projects/delete-partial-lineage", "restricted-correction") as { id: string; updated_at: string; valid_from: string };
+    const corrected = supersedeState(
+      db, "projects/delete-partial-lineage", "restricted-correction", original.id,
+      "later client-confidential correction", [], "test-agent", original.updated_at, original.valid_from, undefined,
+      { classification: "client-confidential" },
+    );
+    expect(corrected.status).toBe("superseded");
+
+    const consumerOwnerCall = makeContextCallTool({
+      ...ownerContext(),
+      transportType: "consumer",
+      maxClassification: "internal",
+    });
+    const result = parseToolResponse(await consumerOwnerCall("memory_delete", {
+      namespace: "projects/delete-partial-lineage",
+      key: "restricted-correction",
+    })) as { error: string; message: string };
+
+    expect(result.error).toBe("partial_lineage");
+    expect(result.message).toContain("correction chain");
   });
 
   it("confirmed delete only removes entries within classification ceiling", async () => {


### PR DESCRIPTION
Closes #281.

## What changed

- Preview and token fingerprints now cover every state revision that a key or namespace delete removes.
- `state_count` now represents the full state deletion scope, with explicit current and historical counts.
- Classification- or ownership-scoped deletes fail closed with `partial_lineage` before issuing a token if a correction chain would be split.

## Validation

- `npm test -- --reporter=dot` (2,576 passed, 4 skipped)
- `npm run lint`
- `npm run typecheck`
- `npm run typecheck:tools`
- `npm run build`

No deployment or merge performed.