### PR TITLE
Fail closed on malformed memory tool arguments

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1669,6 +1669,24 @@ function validateNonNegativeInteger(value: unknown, fieldName: string, defaultVa
   return { ok: true, value };
 }
 
+function validateOptionalBoolean(value: unknown, fieldName: string): string | null {
+  return value === undefined || typeof value === "boolean"
+    ? null
+    : `${fieldName} must be a boolean.`;
+}
+
+function validateOptionalString(value: unknown, fieldName: string): string | null {
+  return value === undefined || typeof value === "string"
+    ? null
+    : `${fieldName} must be a string.`;
+}
+
+function validateOptionalStringArray(value: unknown, fieldName: string): string | null {
+  return value === undefined || (Array.isArray(value) && value.every((item) => typeof item === "string"))
+    ? null
+    : `${fieldName} must be an array of strings.`;
+}
+
 function filterExpiredEntries<T extends Entry | { entry: Entry }>(
   items: T[],
   includeExpired: boolean,
@@ -5110,6 +5128,7 @@ const TOOL_DEFINITIONS = [
         patch: {
           type: "object",
           description: "Partial update for an existing entry. Mutually exclusive with content. Entry must already exist.",
+          additionalProperties: false,
           properties: {
             content_append: { type: "string", description: "Text to append after existing content (separated by newline)" },
             content_prepend: { type: "string", description: "Text to prepend before existing content (separated by newline)" },
@@ -5118,6 +5137,7 @@ const TOOL_DEFINITIONS = [
           },
         },
       },
+      additionalProperties: false,
       required: ["namespace", "key"],
     },
   },
@@ -5177,6 +5197,7 @@ const TOOL_DEFINITIONS = [
           description: "Optional compare-and-swap guard. Pass the updated_at from a prior read to avoid blind overwrites. OPTIONAL — omit it for an unconditional update; it is never required to create a new tracked status.",
         },
       },
+      additionalProperties: false,
       required: ["namespace"],
     },
   },
@@ -5236,9 +5257,10 @@ const TOOL_DEFINITIONS = [
       properties: {
         id: {
           type: "string",
-          description: "The UUID of the entry to retrieve",
+          description: "Opaque entry ID to retrieve (normally a UUID returned by memory_query)",
         },
       },
+      additionalProperties: false,
       required: ["id"],
     },
   },
@@ -5312,6 +5334,7 @@ const TOOL_DEFINITIONS = [
           description: "Optional (default \"linear\"). Output ordering of ranked results. \"linear\" returns strict best-first rank order. \"boundary\" places the strongest results at the two context edges (rank 1 first, rank 2 last, rank 3 second, …) to counter the \"Lost in the Middle\" attention dip when dropping a long result list straight into context. The result set and underlying ranks are unchanged — only display order — and retrieval analytics always record the true linear rank order. No effect on filter-only browse queries.",
         },
       },
+      additionalProperties: false,
       required: [],
     },
   },
@@ -5419,7 +5442,7 @@ const TOOL_DEFINITIONS = [
   {
     name: "memory_list",
     description:
-      "Browse memory contents. Without a namespace: shows all namespaces with entry counts and last_activity_at (demo/* and completed task-run namespaces hidden by default). With a namespace: shows all state keys, log count, and the 5 most recent log entry previews.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
+      "Browse memory contents. Without a namespace: shows all namespaces with entry counts and last_activity_at (demo/* and completed task-run namespaces hidden by default). With a namespace: shows all state keys, log count, and the 5 most recent log entry previews. `limit` and `offset` apply only to the top-level namespace listing; non-default paging values with `namespace` are rejected rather than ignored.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -5441,14 +5464,15 @@ const TOOL_DEFINITIONS = [
         limit: {
           type: "integer",
           description:
-            "Optional. Max namespaces to return in the top-level listing (default 20, max 200). Ignored when a namespace is provided.",
+            "Optional. Max namespaces to return in the top-level listing (default 20, max 200). Non-default values are rejected when a namespace is provided.",
         },
         offset: {
           type: "integer",
           description:
-            "Optional. Skip first N namespaces for pagination of the top-level listing (default 0). Ignored when a namespace is provided.",
+            "Optional. Skip first N namespaces for pagination of the top-level listing (default 0). Non-default values are rejected when a namespace is provided.",
         },
       },
+      additionalProperties: false,
       required: [],
     },
   },
@@ -8861,6 +8885,19 @@ export function registerTools(
               }
               const queryArgs = (args ?? {}) as unknown as QueryParams;
               let { query, namespace, entry_type, tags, limit, search_mode, since, until } = queryArgs;
+              for (const validationError of [
+                validateOptionalString(query, "query"),
+                validateOptionalString(namespace, "namespace"),
+                validateOptionalStringArray(tags, "tags"),
+                validateOptionalBoolean(queryArgs.include_expired, "include_expired"),
+                validateOptionalBoolean(queryArgs.explain, "explain"),
+                validateOptionalBoolean(queryArgs.require_lexical_match, "require_lexical_match"),
+              ]) {
+                if (validationError) return errResult("query", "validation_error", validationError);
+              }
+              if (entry_type !== undefined && entry_type !== "state" && entry_type !== "log") {
+                return errResult("query", "validation_error", "entry_type must be 'state' or 'log'.");
+              }
               if (search_mode !== undefined && !["lexical", "semantic", "hybrid"].includes(search_mode)) {
                 return errResult("query", "validation_error", "search_mode must be 'lexical', 'semantic', or 'hybrid'.");
               }
@@ -8878,6 +8915,9 @@ export function registerTools(
               }
               since = normalizedSince?.value;
               until = normalizedUntil?.value;
+              if (since !== undefined && until !== undefined && since > until) {
+                return errResult("query", "validation_error", "since must be earlier than or equal to until.");
+              }
               const explain = queryArgs.explain === true;
               const includeExpired = queryArgs.include_expired === true;
               const requireLexicalMatch = queryArgs.require_lexical_match === true;
@@ -8901,8 +8941,8 @@ export function registerTools(
 
               // Validate the namespace filter (parity with write/read/log paths).
               // A trailing slash is permitted for prefix filters (e.g. "projects/").
-              if (namespace !== undefined && namespace !== null) {
-                const nsCheck = validateNamespace(namespace as string);
+              if (namespace !== undefined) {
+                const nsCheck = validateNamespace(namespace);
                 if (!nsCheck.valid) {
                   return errResult("query", "validation_error", nsCheck.error!);
                 }
@@ -9602,6 +9642,13 @@ export function registerTools(
                 return errResult("list", "validation_error", unknownArgumentError);
               }
               const { namespace, include_demo, include_completed_tasks, limit: rawLimit, offset: rawOffset } = (args ?? {}) as ListParams;
+              for (const validationError of [
+                validateOptionalString(namespace, "namespace"),
+                validateOptionalBoolean(include_demo, "include_demo"),
+                validateOptionalBoolean(include_completed_tasks, "include_completed_tasks"),
+              ]) {
+                if (validationError) return errResult("list", "validation_error", validationError);
+              }
               const limitResolution = resolveBoundedPositiveInteger(rawLimit, "limit", 20, 200);
               if (!limitResolution.ok) {
                 return errResult("list", "validation_error", limitResolution.error);
@@ -9637,6 +9684,9 @@ export function registerTools(
                     warning: limitResolution.warning,
                   } : {}),
                 });
+              }
+              if ((rawLimit !== undefined && rawLimit !== 20) || (rawOffset !== undefined && rawOffset !== 0)) {
+                return errResult("list", "validation_error", "limit and offset apply only to top-level namespace listings; omit them when listing one namespace.");
               }
               const nsCheck = validateNamespace(namespace);
               if (!nsCheck.valid) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1630,6 +1630,45 @@ function normalizeIsoTimestamp(value: unknown, fieldName: string): { ok: true; v
   return { ok: true, value: date.toISOString() };
 }
 
+function rejectUnknownArguments(args: unknown, allowed: readonly string[]): string | null {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return "Tool arguments must be an object.";
+  }
+  const unknown = Object.keys(args).filter((key) => !allowed.includes(key)).sort();
+  return unknown.length > 0
+    ? `Unknown argument(s): ${unknown.join(", ")}.`
+    : null;
+}
+
+function resolveBoundedPositiveInteger(
+  value: unknown,
+  fieldName: string,
+  defaultValue: number,
+  maximum: number,
+): { ok: true; requested: number; applied: number; warning?: string } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, requested: defaultValue, applied: defaultValue };
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    return { ok: false, error: `${fieldName} must be a positive integer.` };
+  }
+  if (value > maximum) {
+    return {
+      ok: true,
+      requested: value,
+      applied: maximum,
+      warning: `Requested ${fieldName} ${value} exceeds the maximum of ${maximum}; returning at most ${maximum}.`,
+    };
+  }
+  return { ok: true, requested: value, applied: value };
+}
+
+function validateNonNegativeInteger(value: unknown, fieldName: string, defaultValue: number): { ok: true; value: number } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, value: defaultValue };
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return { ok: false, error: `${fieldName} must be a non-negative integer.` };
+  }
+  return { ok: true, value };
+}
+
 function filterExpiredEntries<T extends Entry | { entry: Entry }>(
   items: T[],
   includeExpired: boolean,
@@ -5191,7 +5230,7 @@ const TOOL_DEFINITIONS = [
   {
     name: "memory_get",
     description:
-      "Retrieve the full content of a single memory entry by its UUID, including an authorized correction link when present. Use this after `memory_query` returns truncated previews or to inspect a historical superseded UUID. If you already know namespace+key and want current or as-of state, use `memory_read` instead. Works for both state and log entries.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
+      "Retrieve the full content of a single memory entry by its opaque ID (normally a UUID returned by `memory_query`), including an authorized correction link when present. Any non-empty ID is accepted as a lookup and returns `found:false` when absent, preserving safe not-found semantics for stale or externally stored IDs. If you already know namespace+key and want current or as-of state, use `memory_read` instead. Works for both state and log entries.\n\nFirst memory operation: call `memory_orient` first if it is callable. If your host/deferred tool discovery did not expose `memory_orient`, call `memory_status` or `memory_resume` as a fallback instead of stalling.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -7941,6 +7980,14 @@ export function registerTools(
           case "memory_write": {
             // eslint-disable-next-line complexity -- one handler intentionally validates the mutually-exclusive full-write, patch, correction, and tracked-status paths before mutation.
             const handleMemoryWrite = async () => {
+              const unknownArgumentError = rejectUnknownArguments(args, [
+                "namespace", "key", "content", "tags", "valid_until", "expected_updated_at",
+                "create_if_absent", "classification", "classification_override", "supersedes",
+                "valid_from", "patch",
+              ]);
+              if (unknownArgumentError) {
+                return errResult("write", "validation_error", unknownArgumentError);
+              }
               const {
                 namespace,
                 key,
@@ -7965,6 +8012,12 @@ export function registerTools(
               const keyCheck = validateKey(key);
               if (!keyCheck.valid) {
                 return errResult("write", "validation_error", keyCheck.error!);
+              }
+              if (expected_updated_at !== undefined) {
+                const timestampCheck = normalizeIsoTimestamp(expected_updated_at, "expected_updated_at");
+                if (!timestampCheck.ok) {
+                  return errResult("write", "validation_error", timestampCheck.error);
+                }
               }
 
               // Mutually exclusive: patch and content cannot both be provided
@@ -8327,6 +8380,13 @@ export function registerTools(
 
           case "memory_update_status": {
             const handleMemoryUpdateStatus = async () => {
+              const unknownArgumentError = rejectUnknownArguments(args, [
+                "namespace", "phase", "current_work", "blockers", "next_steps", "notes",
+                "lifecycle", "valid_until", "expected_updated_at", "classification", "classification_override",
+              ]);
+              if (unknownArgumentError) {
+                return errResult("update_status", "validation_error", unknownArgumentError);
+              }
               const {
                 namespace,
                 phase,
@@ -8344,6 +8404,12 @@ export function registerTools(
               const nsCheck = validateNamespace(namespace);
               if (!nsCheck.valid) {
                 return errResult("update_status", "validation_error", nsCheck.error!);
+              }
+              if (expected_updated_at !== undefined) {
+                const timestampCheck = normalizeIsoTimestamp(expected_updated_at, "expected_updated_at");
+                if (!timestampCheck.ok) {
+                  return errResult("update_status", "validation_error", timestampCheck.error);
+                }
               }
               if (!isTrackedNamespace(namespace, resolveTrackedPatterns(db, ctx))) {
                 return errResult("update_status", "validation_error", "memory_update_status only supports the caller's configured tracked namespaces (default projects/* or clients/*).");
@@ -8736,6 +8802,10 @@ export function registerTools(
 
           case "memory_get": {
             const handleMemoryGet = async () => {
+              const unknownArgumentError = rejectUnknownArguments(args, ["id"]);
+              if (unknownArgumentError) {
+                return errResult("get", "validation_error", unknownArgumentError);
+              }
               const { id } = args as unknown as GetParams;
               if (!id || typeof id !== "string") {
                 return errResult("get", "validation_error", "ID is required.");
@@ -8776,12 +8846,38 @@ export function registerTools(
           }
 
           case "memory_query": {
+            // eslint-disable-next-line complexity -- one handler validates and executes the filter-only, lexical, semantic, and hybrid retrieval paths.
             const handleMemoryQuery = async () => {
               // Wall-clock start for the retrieval-latency metric (#161). Recorded
               // onto the retrieval_event so memory_health can report p50/p95.
               const queryStartedAt = Date.now();
+              const unknownArgumentError = rejectUnknownArguments(args, [
+                "query", "namespace", "entry_type", "tags", "limit", "search_mode",
+                "search_recency_weight", "include_expired", "explain", "since", "until",
+                "require_lexical_match", "serialization",
+              ]);
+              if (unknownArgumentError) {
+                return errResult("query", "validation_error", unknownArgumentError);
+              }
               const queryArgs = (args ?? {}) as unknown as QueryParams;
-              const { query, namespace, entry_type, tags, limit, search_mode, since, until } = queryArgs;
+              let { query, namespace, entry_type, tags, limit, search_mode, since, until } = queryArgs;
+              if (search_mode !== undefined && !["lexical", "semantic", "hybrid"].includes(search_mode)) {
+                return errResult("query", "validation_error", "search_mode must be 'lexical', 'semantic', or 'hybrid'.");
+              }
+              const normalizedSince = since === undefined ? undefined : normalizeIsoTimestamp(since, "since");
+              if (normalizedSince !== undefined && !normalizedSince.ok) {
+                return errResult("query", "validation_error", normalizedSince.error);
+              }
+              const normalizedUntil = until === undefined ? undefined : normalizeIsoTimestamp(until, "until");
+              if (normalizedUntil !== undefined && !normalizedUntil.ok) {
+                return errResult("query", "validation_error", normalizedUntil.error);
+              }
+              const limitResolution = resolveBoundedPositiveInteger(limit, "limit", 10, MAX_QUERY_LIMIT);
+              if (!limitResolution.ok) {
+                return errResult("query", "validation_error", limitResolution.error);
+              }
+              since = normalizedSince?.value;
+              until = normalizedUntil?.value;
               const explain = queryArgs.explain === true;
               const includeExpired = queryArgs.include_expired === true;
               const requireLexicalMatch = queryArgs.require_lexical_match === true;
@@ -8818,7 +8914,7 @@ export function registerTools(
                 if (!namespace && (!tags || tags.length === 0) && !since && !until && !entry_type) {
                   return errResult("query", "validation_error", "Provide either a 'query' string for search, or at least one filter (namespace, tags, entry_type, since, until) to browse.");
                 }
-                const requestedLimit = Math.min(Math.max(limit ?? 10, 1), 50);
+                const requestedLimit = limitResolution.applied;
                 const internalFilterLimit = Math.min(requestedLimit * QUERY_RERANK_OVERFETCH_MULTIPLIER, 50);
                 let filterResults = queryEntriesByFilter(db, {
                   namespace,
@@ -8870,6 +8966,11 @@ export function registerTools(
                   total: formatted.length,
                   redacted_count: redactedCount,
                   search_mode: "filter",
+                  ...(limitResolution.warning ? {
+                    requested_limit: limitResolution.requested,
+                    limit_applied: limitResolution.applied,
+                    warning: limitResolution.warning,
+                  } : {}),
                   retrieval: {
                     reranked: false,
                     relaxed_lexical: false,
@@ -8884,7 +8985,7 @@ export function registerTools(
                 });
               }
 
-              const requestedLimit = Math.min(Math.max(limit ?? 10, 1), 50);
+              const requestedLimit = limitResolution.applied;
               const internalLimit = Math.min(requestedLimit * QUERY_RERANK_OVERFETCH_MULTIPLIER, 50);
               const queryParams: QueryParams = {
                 query,
@@ -8901,13 +9002,10 @@ export function registerTools(
               };
               const requestedMode: SearchMode = search_mode ?? "hybrid";
               let actualMode: SearchMode = requestedMode;
-              let warning: string | undefined;
+              let warning: string | undefined = limitResolution.warning;
               // The storage layer clamps to MAX_QUERY_LIMIT, so an over-limit
               // request used to return fewer rows than asked for with no signal
               // — indistinguishable from "that is all there was". Say so.
-              if (typeof limit === "number" && Number.isFinite(limit) && limit > MAX_QUERY_LIMIT) {
-                warning = `Requested limit ${limit} exceeds the maximum of ${MAX_QUERY_LIMIT}; returning at most ${MAX_QUERY_LIMIT} results. Narrow with filters or since/until rather than paging.`;
-              }
               let fallbackReason: string | null = null;
               let relaxedLexical = false;
               let expiredFilteredCount = 0;
@@ -9126,12 +9224,17 @@ export function registerTools(
                 redacted_count: redactedCount,
                 query,
                 search_mode: requestedMode,
+                ...(limitResolution.warning ? {
+                  requested_limit: limitResolution.requested,
+                  limit_applied: limitResolution.applied,
+                } : {}),
               };
               if (actualMode !== requestedMode) {
                 response.search_mode_actual = actualMode;
               }
-              if (warning) {
-                response.warning = warning;
+              const responseWarnings = [...new Set([limitResolution.warning, warning].filter(Boolean))];
+              if (responseWarnings.length > 0) {
+                response.warning = responseWarnings.join(" ");
               }
               response.retrieval = {
                 reranked: true,
@@ -9492,10 +9595,24 @@ export function registerTools(
 
           case "memory_list": {
             const handleMemoryList = async () => {
+              const unknownArgumentError = rejectUnknownArguments(args, [
+                "namespace", "include_demo", "include_completed_tasks", "limit", "offset",
+              ]);
+              if (unknownArgumentError) {
+                return errResult("list", "validation_error", unknownArgumentError);
+              }
               const { namespace, include_demo, include_completed_tasks, limit: rawLimit, offset: rawOffset } = (args ?? {}) as ListParams;
+              const limitResolution = resolveBoundedPositiveInteger(rawLimit, "limit", 20, 200);
+              if (!limitResolution.ok) {
+                return errResult("list", "validation_error", limitResolution.error);
+              }
+              const offsetResolution = validateNonNegativeInteger(rawOffset, "offset", 0);
+              if (!offsetResolution.ok) {
+                return errResult("list", "validation_error", offsetResolution.error);
+              }
               if (!namespace) {
-                const resolvedLimit = Math.min(Math.max(1, typeof rawLimit === "number" ? rawLimit : 20), 200);
-                const resolvedOffset = Math.max(0, typeof rawOffset === "number" ? rawOffset : 0);
+                const resolvedLimit = limitResolution.applied;
+                const resolvedOffset = offsetResolution.value;
                 const allNamespaces = listVisibleNamespaces(db, ctx);
                 const completedTasks = include_completed_tasks ? new Set<string>() : getCompletedTaskNamespaces(db);
                 const filtered = allNamespaces.filter((ns) => {
@@ -9509,7 +9626,17 @@ export function registerTools(
                   ...ns,
                   last_activity_at_local: toLocalDisplay(ns.last_activity_at),
                 }));
-                return okResult("list", { namespaces: namespacesWithLocal, total, returned: namespacesWithLocal.length, has_more });
+                return okResult("list", {
+                  namespaces: namespacesWithLocal,
+                  total,
+                  returned: namespacesWithLocal.length,
+                  has_more,
+                  ...(limitResolution.warning ? {
+                    requested_limit: limitResolution.requested,
+                    limit_applied: limitResolution.applied,
+                    warning: limitResolution.warning,
+                  } : {}),
+                });
               }
               const nsCheck = validateNamespace(namespace);
               if (!nsCheck.valid) {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -158,6 +158,29 @@ describe("memory_write", () => {
     expect(result.hint).toContain("architecture");
   });
 
+  it("rejects malformed expected_updated_at before evaluating CAS conflicts (#269)", async () => {
+    await callTool("memory_write", {
+      namespace: "projects/cas-timestamp",
+      key: "status",
+      content: "Current value",
+    });
+    const raw = await callTool("memory_write", {
+      namespace: "projects/cas-timestamp",
+      key: "status",
+      content: "Must not write",
+      expected_updated_at: "yesterday",
+    });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("expected_updated_at");
+
+    const read = parseToolResponse(await callTool("memory_read", {
+      namespace: "projects/cas-timestamp",
+      key: "status",
+    })) as { content: string };
+    expect(read.content).toBe("Current value");
+  });
+
   it("rejects invalid namespace", async () => {
     const raw = await callTool("memory_write", {
       namespace: "/bad",
@@ -452,6 +475,22 @@ describe("memory_write patch", () => {
 });
 
 describe("memory_update_status", () => {
+  it("rejects malformed expected_updated_at before evaluating CAS conflicts (#269)", async () => {
+    await callTool("memory_update_status", {
+      namespace: "projects/status-cas-timestamp",
+      phase: "Active",
+      lifecycle: "active",
+    });
+    const raw = await callTool("memory_update_status", {
+      namespace: "projects/status-cas-timestamp",
+      current_work: "Must not write",
+      expected_updated_at: "yesterday",
+    });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("expected_updated_at");
+  });
+
   it("rejects a trailing slash namespace at the handler boundary", async () => {
     const raw = await callTool("memory_update_status", {
       namespace: "projects/status-tool/",
@@ -1329,6 +1368,12 @@ describe("memory_get", () => {
     const raw = await callTool("memory_get", { id: "nonexistent" });
     const result = parseToolResponse(raw) as { found: boolean };
     expect(result.found).toBe(false);
+  });
+
+  it("keeps non-empty opaque IDs as ordinary lookup misses (#269 compatibility)", async () => {
+    const raw = await callTool("memory_get", { id: "not-a-uuid" });
+    const result = parseToolResponse(raw) as { ok: boolean; found: boolean };
+    expect(result).toMatchObject({ ok: true, found: false });
   });
 
   it("returns expired flag on memory_get for expired state entries", async () => {
@@ -2478,6 +2523,57 @@ describe("memory_query", () => {
     expect(result.results[0].provenance.principal_id).toBe("owner");
   });
 
+  it.each(["yesterday", "not-a-date"])("rejects malformed since timestamps (%s) (#269)", async (since) => {
+    const raw = await callTool("memory_query", { namespace: "projects/alpha", since });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("since");
+    expect(result.message).toContain("ISO 8601");
+  });
+
+  it("rejects malformed until timestamps (#269)", async () => {
+    const raw = await callTool("memory_query", { namespace: "projects/alpha", until: "not-a-date" });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("until");
+  });
+
+  it("rejects an unknown search_mode rather than returning an empty success (#269)", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", search_mode: "vector" });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("lexical");
+    expect(result.message).toContain("semantic");
+    expect(result.message).toContain("hybrid");
+  });
+
+  it("rejects an invalid query limit rather than silently clamping it (#269)", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", limit: -1 });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("limit");
+  });
+
+  it("reports query limit clamping with requested and applied values (#269)", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", search_mode: "lexical", limit: 51 });
+    const result = parseToolResponse(raw) as {
+      requested_limit: number;
+      limit_applied: number;
+      warning: string;
+    };
+    expect(result.requested_limit).toBe(51);
+    expect(result.limit_applied).toBe(50);
+    expect(result.warning).toContain("51");
+    expect(result.warning).toContain("50");
+  });
+
+  it("rejects unknown query arguments rather than ignoring them (#269)", async () => {
+    const raw = await callTool("memory_query", { query: "SQLite", offset: 50 });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("offset");
+  });
+
   describe("boundary serialization", () => {
     async function seedBoundaryCorpus() {
       for (let i = 0; i < 5; i++) {
@@ -3273,6 +3369,32 @@ describe("memory_list", () => {
     const raw = await callTool("memory_list", {});
     const result = parseToolResponse(raw) as { namespaces: Array<{ namespace: string }> };
     expect(result.namespaces).toHaveLength(2);
+  });
+
+  it("reports list limit clamping explicitly (#269)", async () => {
+    for (let i = 0; i < 3; i++) {
+      await callTool("memory_write", { namespace: `projects/list-clamp-${i}`, key: "status", content: "c" });
+    }
+    const raw = await callTool("memory_list", { limit: 999 });
+    const result = parseToolResponse(raw) as { requested_limit: number; limit_applied: number; warning: string };
+    expect(result.requested_limit).toBe(999);
+    expect(result.limit_applied).toBe(200);
+    expect(result.warning).toContain("999");
+    expect(result.warning).toContain("200");
+  });
+
+  it("rejects negative list offsets rather than treating them as zero (#269)", async () => {
+    const raw = await callTool("memory_list", { offset: -1 });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("offset");
+  });
+
+  it("rejects unknown list arguments rather than ignoring them (#269)", async () => {
+    const raw = await callTool("memory_list", { cursor: 5 });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("cursor");
   });
 
   it("includes last_activity_at per namespace", async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2574,6 +2574,34 @@ describe("memory_query", () => {
     expect(result.message).toContain("offset");
   });
 
+  it.each([
+    [{ query: 42, namespace: "projects/alpha" }, "query"],
+    [{ query: "SQLite", namespace: 42 }, "namespace"],
+    [{ query: "SQLite", entry_type: "event" }, "entry_type"],
+    [{ query: "SQLite", tags: "active" }, "tags"],
+    [{ query: "SQLite", include_expired: "true" }, "include_expired"],
+    [{ query: "SQLite", explain: "true" }, "explain"],
+    [{ query: "SQLite", require_lexical_match: "true" }, "require_lexical_match"],
+    [{ query: "SQLite", search_recency_weight: "high" }, "search_recency_weight"],
+  ])("rejects malformed known query argument %s (#269)", async (args, field) => {
+    const raw = await callTool("memory_query", args as Record<string, unknown>);
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message.toLowerCase()).toContain(field.toLowerCase());
+  });
+
+  it("rejects an inverted query time range (#269)", async () => {
+    const raw = await callTool("memory_query", {
+      namespace: "projects/alpha",
+      since: "2027-01-02T00:00:00Z",
+      until: "2027-01-01T00:00:00Z",
+    });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("since");
+    expect(result.message).toContain("until");
+  });
+
   describe("boundary serialization", () => {
     async function seedBoundaryCorpus() {
       for (let i = 0; i < 5; i++) {
@@ -3395,6 +3423,24 @@ describe("memory_list", () => {
     const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
     expect(result).toMatchObject({ ok: false, error: "validation_error" });
     expect(result.message).toContain("cursor");
+  });
+
+  it.each([
+    [{ namespace: 42 }, "namespace"],
+    [{ include_demo: "true" }, "include_demo"],
+    [{ include_completed_tasks: "true" }, "include_completed_tasks"],
+  ])("rejects malformed known list argument %s (#269)", async (args, field) => {
+    const raw = await callTool("memory_list", args as Record<string, unknown>);
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message.toLowerCase()).toContain(field.toLowerCase());
+  });
+
+  it("rejects top-level pagination arguments when listing one namespace (#269)", async () => {
+    const raw = await callTool("memory_list", { namespace: "projects/alpha", limit: 1 });
+    const result = parseToolResponse(raw) as { ok: boolean; error: string; message: string };
+    expect(result).toMatchObject({ ok: false, error: "validation_error" });
+    expect(result.message).toContain("top-level");
   });
 
   it("includes last_activity_at per namespace", async () => {
@@ -6443,6 +6489,26 @@ describe("compare-and-swap (memory_write)", () => {
     expect(memoryWrite?.inputSchema.properties).toMatchObject({
       create_if_absent: { type: "boolean" },
     });
+  });
+
+  it("advertises closed argument objects for the #269 validated tools", async () => {
+    const handler = (
+      server as unknown as { _requestHandlers: Map<string, Function> }
+    )._requestHandlers?.get("tools/list");
+    const toolList = await handler!({ method: "tools/list", params: {} });
+    const toolsByName = new Map(
+      (toolList as {
+        tools: Array<{
+          name: string;
+          inputSchema: { additionalProperties?: boolean; properties?: Record<string, { additionalProperties?: boolean }> };
+        }>;
+      }).tools.map((tool) => [tool.name, tool]),
+    );
+
+    for (const toolName of ["memory_query", "memory_list", "memory_get", "memory_write", "memory_update_status"]) {
+      expect(toolsByName.get(toolName)?.inputSchema.additionalProperties).toBe(false);
+    }
+    expect(toolsByName.get("memory_write")?.inputSchema.properties?.patch?.additionalProperties).toBe(false);
   });
 
   it("advertises valid_until as string-or-null for memory_write and memory_update_status", async () => {


### PR DESCRIPTION
Closes #269

## Behaviour
- `memory_query` rejects malformed `since`/`until`, unknown search modes, invalid limits, and unknown arguments before retrieval. Over-limit requests retain documented clamping and report `requested_limit`, `limit_applied`, and a warning.
- `memory_list` rejects invalid/unknown pagination arguments and reports explicit clamping metadata.
- `memory_write` and `memory_update_status` validate `expected_updated_at` as ISO 8601 before CAS/conflict paths.
- `memory_get` deliberately keeps non-empty IDs as opaque, lenient lookups (`found:false` when absent); its public tool contract now documents that compatibility choice.

## Verification
- Red/green tests cover every observed #269 case plus both documented clamping paths and opaque-ID compatibility.
- `npm test`: 2,595 passed / 4 skipped
- `npm run test:coverage`, lint, both typechecks, build, and benchmark CI gate passed.

## M5
A bounded `mellum` analysis was used. Its general validation recommendations were checked and applied where compatible; its unrelated proposed search-mode names contradicted Munin’s existing public enum and were rejected.