### PR TITLE
fix: restore Munin home deployment contract

### DIFF
--- a/systemd/munin-memory.service
+++ b/systemd/munin-memory.service
@@ -1,28 +1,28 @@
 # Install-ready unit for the public Grimnir registry example. Unlike the root
 # portable template, this file contains no rendering placeholders because the
 # Grimnir fleet deployer installs registry-declared units byte-for-byte. The
-# registered production identity uses the /home/grimnir layout.
+# registered production identity uses the /home/magnus layout.
 [Unit]
 Description=Munin Memory MCP Server
 After=network.target
 
 [Service]
 Type=simple
-User=grimnir
-WorkingDirectory=/home/grimnir/munin-memory
+User=magnus
+WorkingDirectory=/home/magnus/munin-memory
 ExecStart=/usr/bin/node dist/index.js
 Restart=always
 RestartSec=5
 Environment=MUNIN_TRANSPORT=http
 Environment=MUNIN_HTTP_PORT=3030
 Environment=MUNIN_HTTP_HOST=127.0.0.1
-Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db
-EnvironmentFile=/home/grimnir/munin-memory/.env
+Environment=MUNIN_MEMORY_DB_PATH=/home/magnus/.munin-memory/memory.db
+EnvironmentFile=/home/magnus/munin-memory/.env
 
 # Sandboxing
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/grimnir/.munin-memory
+ReadWritePaths=/home/magnus/.munin-memory
 NoNewPrivileges=true
 PrivateTmp=true
 

--- a/systemd/munin-memory.service
+++ b/systemd/munin-memory.service
@@ -1,6 +1,7 @@
 # Install-ready unit for the public Grimnir registry example. Unlike the root
 # portable template, this file contains no rendering placeholders because the
-# Grimnir fleet deployer installs registry-declared units byte-for-byte.
+# Grimnir fleet deployer installs registry-declared units byte-for-byte. The
+# registered production identity uses the /home/grimnir layout.
 [Unit]
 Description=Munin Memory MCP Server
 After=network.target
@@ -8,20 +9,20 @@ After=network.target
 [Service]
 Type=simple
 User=grimnir
-WorkingDirectory=/srv/grimnir/munin-memory
+WorkingDirectory=/home/grimnir/munin-memory
 ExecStart=/usr/bin/node dist/index.js
 Restart=always
 RestartSec=5
 Environment=MUNIN_TRANSPORT=http
 Environment=MUNIN_HTTP_PORT=3030
 Environment=MUNIN_HTTP_HOST=127.0.0.1
-Environment=MUNIN_MEMORY_DB_PATH=/var/lib/grimnir/munin-memory/memory.db
-EnvironmentFile=/srv/grimnir/munin-memory/.env
+Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db
+EnvironmentFile=/home/grimnir/munin-memory/.env
 
 # Sandboxing
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/grimnir/munin-memory
+ProtectHome=read-only
+ReadWritePaths=/home/grimnir/.munin-memory
 NoNewPrivileges=true
 PrivateTmp=true
 

--- a/tests/fixtures/grimnir-munin-memory-registry.json
+++ b/tests/fixtures/grimnir-munin-memory-registry.json
@@ -1,0 +1,27 @@
+{
+  "name": "munin-memory",
+  "workload_id": "workload-munin-memory",
+  "target_node_id": "node-huginmunin",
+  "workload_contract": {
+    "kind": "workload-requirement",
+    "schema_version": "v1",
+    "producer": "munin-memory",
+    "digest": "sha256:754071860f784ef02c74951e56d857fb30ff1a5724bec28d45cc091bb5441804"
+  },
+  "repo": "munin-memory",
+  "host": "huginmunin.local",
+  "port": 3030,
+  "deploy": true,
+  "scan": true,
+  "deploy_path": "/home/magnus/munin-memory",
+  "persistent_paths": [
+    "/home/magnus/.munin-memory"
+  ],
+  "needs_build": true,
+  "systemd_units": [
+    {
+      "name": "munin-memory",
+      "type": "service"
+    }
+  ]
+}

--- a/tests/systemd-unit-contract.test.ts
+++ b/tests/systemd-unit-contract.test.ts
@@ -13,6 +13,11 @@ const offsiteTemplate = readFileSync(join(repoRoot, "munin-offsite.service"), "u
 const opsInstaller = readFileSync(join(repoRoot, "scripts", "install-ops.sh"), "utf8");
 const fleetUnitPath = join(repoRoot, "systemd", "munin-memory.service");
 const snapshotScriptPath = join(repoRoot, "scripts", "snapshot-benchmark-db.sh");
+// Verbatim Grimnir services.json component fixture. Keep this aligned with the
+// registered deploy and persistence authorities.
+const grimnirRegistry = JSON.parse(
+  readFileSync(join(repoRoot, "tests", "fixtures", "grimnir-munin-memory-registry.json"), "utf8"),
+) as { name: string; deploy_path: string; persistent_paths: string[]; systemd_units: Array<{ name: string; type: string }> };
 
 function activeLines(unit: string): string[] {
   return unit
@@ -50,15 +55,24 @@ describe("systemd deployment-unit contract", () => {
     }
   });
 
-  it("ships an install-ready public-safe unit for the Grimnir fleet deployer", () => {
+  it("ships an install-ready unit that resolves under the registered Grimnir paths", () => {
     expect(existsSync(fleetUnitPath)).toBe(true);
     const fleetUnit = readFileSync(fleetUnitPath, "utf8");
+    const persistentPath = grimnirRegistry.persistent_paths[0];
     expect(fleetUnit).not.toMatch(/^[^#;\n]*<[A-Za-z][A-Za-z0-9_-]*>/m);
-    expect(fleetUnit).toContain("WorkingDirectory=/home/grimnir/munin-memory");
-    expect(fleetUnit).toContain("Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db");
-    expect(fleetUnit).toContain("EnvironmentFile=/home/grimnir/munin-memory/.env");
-    expect(fleetUnit).toContain("ReadWritePaths=/home/grimnir/.munin-memory");
+    expect(grimnirRegistry).toMatchObject({
+      name: "munin-memory",
+      deploy_path: "/home/magnus/munin-memory",
+      persistent_paths: ["/home/magnus/.munin-memory"],
+      systemd_units: [{ name: "munin-memory", type: "service" }],
+    });
+    expect(fleetUnit).toContain("User=magnus");
+    expect(fleetUnit).toContain(`WorkingDirectory=${grimnirRegistry.deploy_path}`);
+    expect(fleetUnit).toContain(`Environment=MUNIN_MEMORY_DB_PATH=${persistentPath}/memory.db`);
+    expect(fleetUnit).toContain(`EnvironmentFile=${grimnirRegistry.deploy_path}/.env`);
+    expect(fleetUnit).toContain(`ReadWritePaths=${persistentPath}`);
     expect(fleetUnit).not.toContain("/srv/grimnir/");
+    expect(fleetUnit).not.toContain("/home/grimnir/");
   });
 
   it("enforces the shared hardening directives on both the template and the fleet unit", () => {
@@ -132,10 +146,10 @@ describe("systemd deployment-unit contract", () => {
   });
 
   it("allows only the declared fleet/template divergences", () => {
-    // The install-ready fleet unit deliberately binds the registered `grimnir`
-    // service identity to its current /home deployment layout. Any divergence
-    // NOT listed here — including a silently dropped hardening directive or a
-    // reintroduced /srv path — fails the contract.
+    // The install-ready fleet unit deliberately binds the registered `magnus`
+    // service identity to Grimnir's current deploy and persistent paths. Any
+    // divergence NOT listed here — including a silently dropped hardening
+    // directive or either rejected legacy path — fails the contract.
     const fleetUnit = readFileSync(fleetUnitPath, "utf8");
     const fleetSet = new Set(activeLines(fleetUnit));
     const templateSet = new Set(activeLines(publicTemplate));
@@ -145,11 +159,11 @@ describe("systemd deployment-unit contract", () => {
 
     expect(fleetOnly).toEqual(
       [
-        "User=grimnir",
-        "WorkingDirectory=/home/grimnir/munin-memory",
-        "Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db",
-        "EnvironmentFile=/home/grimnir/munin-memory/.env",
-        "ReadWritePaths=/home/grimnir/.munin-memory",
+        "User=magnus",
+        "WorkingDirectory=/home/magnus/munin-memory",
+        "Environment=MUNIN_MEMORY_DB_PATH=/home/magnus/.munin-memory/memory.db",
+        "EnvironmentFile=/home/magnus/munin-memory/.env",
+        "ReadWritePaths=/home/magnus/.munin-memory",
       ].sort(),
     );
     expect(templateOnly).toEqual(

--- a/tests/systemd-unit-contract.test.ts
+++ b/tests/systemd-unit-contract.test.ts
@@ -54,9 +54,11 @@ describe("systemd deployment-unit contract", () => {
     expect(existsSync(fleetUnitPath)).toBe(true);
     const fleetUnit = readFileSync(fleetUnitPath, "utf8");
     expect(fleetUnit).not.toMatch(/^[^#;\n]*<[A-Za-z][A-Za-z0-9_-]*>/m);
-    expect(fleetUnit).toContain("WorkingDirectory=/srv/grimnir/munin-memory");
-    expect(fleetUnit).toContain("ReadWritePaths=/var/lib/grimnir/munin-memory");
-    expect(fleetUnit).not.toMatch(/\/home\/[a-z0-9._-]+\//i);
+    expect(fleetUnit).toContain("WorkingDirectory=/home/grimnir/munin-memory");
+    expect(fleetUnit).toContain("Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db");
+    expect(fleetUnit).toContain("EnvironmentFile=/home/grimnir/munin-memory/.env");
+    expect(fleetUnit).toContain("ReadWritePaths=/home/grimnir/.munin-memory");
+    expect(fleetUnit).not.toContain("/srv/grimnir/");
   });
 
   it("enforces the shared hardening directives on both the template and the fleet unit", () => {
@@ -130,9 +132,10 @@ describe("systemd deployment-unit contract", () => {
   });
 
   it("allows only the declared fleet/template divergences", () => {
-    // Replaces the old exact line-equality check, which the intentional
-    // /srv/grimnir relocation broke. Any divergence NOT listed here — including a
-    // silently dropped hardening directive — fails the contract.
+    // The install-ready fleet unit deliberately binds the registered `grimnir`
+    // service identity to its current /home deployment layout. Any divergence
+    // NOT listed here — including a silently dropped hardening directive or a
+    // reintroduced /srv path — fails the contract.
     const fleetUnit = readFileSync(fleetUnitPath, "utf8");
     const fleetSet = new Set(activeLines(fleetUnit));
     const templateSet = new Set(activeLines(publicTemplate));
@@ -143,11 +146,10 @@ describe("systemd deployment-unit contract", () => {
     expect(fleetOnly).toEqual(
       [
         "User=grimnir",
-        "WorkingDirectory=/srv/grimnir/munin-memory",
-        "Environment=MUNIN_MEMORY_DB_PATH=/var/lib/grimnir/munin-memory/memory.db",
-        "EnvironmentFile=/srv/grimnir/munin-memory/.env",
-        "ProtectHome=true",
-        "ReadWritePaths=/var/lib/grimnir/munin-memory",
+        "WorkingDirectory=/home/grimnir/munin-memory",
+        "Environment=MUNIN_MEMORY_DB_PATH=/home/grimnir/.munin-memory/memory.db",
+        "EnvironmentFile=/home/grimnir/munin-memory/.env",
+        "ReadWritePaths=/home/grimnir/.munin-memory",
       ].sort(),
     );
     expect(templateOnly).toEqual(
@@ -155,7 +157,6 @@ describe("systemd deployment-unit contract", () => {
         "User=<user>",
         "WorkingDirectory=/home/<user>/<install-dir>",
         "EnvironmentFile=/home/<user>/<install-dir>/.env",
-        "ProtectHome=read-only",
         "ReadWritePaths=/home/<user>/.munin-memory",
       ].sort(),
     );


### PR DESCRIPTION
## Summary
- reconcile the tracked Grimnir fleet unit with the authoritative registered identity: `User=magnus`, deploy path `/home/magnus/munin-memory`, persistent state `/home/magnus/.munin-memory`
- bind working directory, environment file, database path, and systemd write grant to that single registry record
- add a verbatim Grimnir `services.json` Munin component fixture; the contract requires every runtime path to resolve from it and rejects both `/srv/grimnir` and the rejected `/home/grimnir` intermediate layout

## Why
The old unit encoded an unfinished `/srv` relocation while the registry and live service use `/home/magnus`. The prior PR head briefly used an unverified third layout; this follow-up corrects the PR head to the exact registry identity. A future `/srv` migration remains a separate planned operation with preflight and rollback.

## Validation
- root review caught the earlier incorrect identity before any merge or deploy
- focused systemd registry contract: 9/9
- lint, typecheck, tool typecheck, build
- full suite: 2,616 passed / 4 skipped
- coverage: 2,616 passed / 4 skipped; statements 89.01%, branches 83.21%, functions 92.87%, lines 90.21%
- retrieval benchmark gate: PASS
- M5 review retried: mellum returned blank; coding-model retry received gateway HTTP 503. No M5 approval is claimed.

Closes #293