### PR TITLE
fix: clarify memory_query linear serialization contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changelog is the canonical record of what moved.
 ### Changed
 
 - **MCP tool metadata now provides server-level instructions and expressive input schemas (#257).** The server publishes fallback-safe first-operation guidance, while tool schemas expose relevant grammar, examples, limits, and lifecycle vocabulary.
+- **`memory_query` serialization metadata now describes reranked linear order (#252).** `linear` preserves the result order after structural reranking; visible lexical, semantic, and hybrid retrieval signals may differ from a result's final position. `boundary` remains a display-only transform applied afterward, and retrieval analytics continue to record the linear order.
 - **`memory_update_status` now supports non-mutating sandbox validation via `validate_only: true` (#275).**
   The normal mutation path is unchanged: real `memory_update_status` writes still require one
   of the caller's tracked namespaces and still create the usual state/audit/commitment effects.

--- a/src/internal/retrieval-shared.ts
+++ b/src/internal/retrieval-shared.ts
@@ -467,12 +467,12 @@ export function boundarySerialize<T>(items: T[]): T[] {
   return [...front, ...back];
 }
 
-/** Serialization mode: "linear" preserves rank order, "boundary" reorders for LLM attention. */
+/** Serialization mode: "linear" preserves the supplied (already reranked) order, "boundary" reorders for LLM attention. */
 export type SerializationMode = "linear" | "boundary";
 
 /**
  * Apply a serialization mode to an ordered list of items.
- * "linear" = identity (preserves rank order).
+ * "linear" = identity (preserves the supplied order).
  * "boundary" = boundarySerialize (reorders for LLM primacy/recency effect).
  */
 export function serializeOrder<T>(items: T[], mode: SerializationMode): T[] {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6807,7 +6807,7 @@ const TOOL_DEFINITIONS = [
         serialization: {
           type: "string",
           enum: ["linear", "boundary"],
-          description: "Optional (default \"linear\"). Output ordering of ranked results. \"linear\" returns strict best-first rank order. \"boundary\" places the strongest results at the two context edges (rank 1 first, rank 2 last, rank 3 second, …) to counter the \"Lost in the Middle\" attention dip when dropping a long result list straight into context. The result set and underlying ranks are unchanged — only display order — and retrieval analytics always record the true linear rank order. No effect on filter-only browse queries.",
+          description: "Optional (default \"linear\"). Output ordering of ranked results. \"linear\" preserves the order after structural reranking; the visible lexical_rank, semantic_rank, and hybrid_score signals may differ from a result's final position. \"boundary\" places the strongest results from that reranked order at the two context edges (first result first, second result last, third result second, …) to counter the \"Lost in the Middle\" attention dip when dropping a long result list straight into context. The result set and underlying retrieval signals are unchanged — only display order — and retrieval analytics record the same linear order before any boundary transform. No effect on filter-only browse queries.",
         },
       },
       additionalProperties: false,
@@ -11027,7 +11027,7 @@ export function registerTools(
               }
 
               // Boundary serialization is purely a display-order transform, applied
-              // AFTER analytics so retrieval_events keep the true linear rank order
+              // AFTER analytics so retrieval_events keep the reranked linear order
               // (outcome correlation must not see the reordered list).
               if (serialization === "boundary") {
                 response.results = boundarySerialize(formatted);

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,11 +108,14 @@ export interface QueryParams {
   require_lexical_match?: boolean;
   /**
    * Output ordering of ranked search results. `"linear"` (default) returns
-   * strict best-first rank order. `"boundary"` places the strongest results at
-   * the two context edges (rank 1 first, rank 2 last, rank 3 second, …) to
-   * counter the "Lost in the Middle" attention dip in long contexts. The set of
-   * results and their underlying ranks are unchanged — only display order — and
-   * retrieval analytics always record the true linear rank order. No effect on
+   * the order after structural reranking; visible `lexical_rank`,
+   * `semantic_rank`, and `hybrid_score` signals may differ from a result's
+   * final position. `"boundary"` places the strongest results from that
+   * reranked order at the two context edges (first result first, second result
+   * last, third result second, …) to counter the "Lost in the Middle" attention
+   * dip in long contexts. The set of results and their underlying retrieval
+   * signals are unchanged — only display order — and retrieval analytics record
+   * the same linear order before any boundary transform. No effect on
    * filter-only browse queries.
    */
   serialization?: "linear" | "boundary";

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -9500,6 +9500,29 @@ describe("compare-and-swap (memory_write)", () => {
     expect(memoryHistory?.inputSchema.properties?.namespace?.description).toContain("returns only descendants under that literal prefix");
   });
 
+  it("documents that linear serialization preserves reranked order", async () => {
+    const handler = (
+      server as unknown as { _requestHandlers: Map<string, Function> }
+    )._requestHandlers?.get("tools/list");
+    const toolList = await handler!({ method: "tools/list", params: {} });
+    const memoryQuery = (
+      toolList as {
+        tools: Array<{
+          name: string;
+          inputSchema: { properties?: Record<string, SchemaNode> };
+        }>;
+      }
+    ).tools.find((tool) => tool.name === "memory_query");
+
+    const description = memoryQuery?.inputSchema.properties?.serialization?.description ?? "";
+    expect(description).toContain('"linear" preserves the order after structural reranking');
+    expect(description).toContain("lexical_rank");
+    expect(description).toContain("semantic_rank");
+    expect(description).toContain("hybrid_score");
+    expect(description).toContain("may differ from a result's final position");
+    expect(description).not.toContain('"linear" returns strict best-first rank order');
+  });
+
   it("advertises closed argument objects for the #269 validated tools", async () => {
     const handler = (
       server as unknown as { _requestHandlers: Map<string, Function> }


### PR DESCRIPTION
## Summary

- Correct the `memory_query.serialization` MCP schema wording so `linear` preserves the order after structural reranking.
- Explain that visible `lexical_rank`, `semantic_rank`, and `hybrid_score` signals may differ from a result's final position.
- Align the public `QueryParams` and serialization-helper comments, add a schema regression, and record the user-visible correction in the changelog.

## Scope

This is a contract/documentation correction only. It does not change ranking, recency defaults, response fields, or retrieval architecture.

Closes #252

## Verification

- Focused red/green: `npm test -- tests/tools.test.ts -t 'documents that linear serialization preserves reranked order'` (failed on the stale wording, then passed).
- `npm test -- tests/tools.test.ts tests/tool-metadata.test.ts` (500 passed).
- `npm run lint`.
- `npm run typecheck`.
- `npm run typecheck:tools`.
- `npm run build`.
- `npm test` (2,815 passed / 4 skipped).
- `npm run test:coverage` (2,815 passed / 4 skipped; 89.63% statements, 84.37% branches, 93.31% functions, 90.86% lines).
- `npm run benchmark:ci-gate` (PASS).
- `git diff --check`.

Exact head: `41c4ddf9665c42bbdc32e9133a94414009375fc7`.