### PR TITLE
fix: scope retrieval insights before aggregation

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -3578,8 +3578,9 @@ export function getInsightsByEntry(
   const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
 
   // Build namespace filter clause for the scoped entry set. Keeping this filter
-  // in its own CTE means unrelated entries never enter json_each() expansion or
-  // the event/outcome joins below.
+  // in its own materialized CTE means the namespace index is consulted before
+  // result_ids are expanded. An unscoped, untracked call intentionally keeps a
+  // LEFT JOIN below so deleted entries remain visible as anonymous rows.
   let nsFilter = "";
   const nsParams: unknown[] = [];
   if (namespace) {
@@ -3598,13 +3599,54 @@ export function getInsightsByEntry(
     ? trackedPatternsToSqlLike(trackedPatterns, "e.namespace")
     : { clause: "", params: [] as string[] };
   const trackedFilter = tracked.clause ? `AND ${tracked.clause}` : "";
+  const hasEntryScope = Boolean(namespace || restrictToTracked);
+
+  // result_namespaces is a denormalized event hint, so only use it to discard
+  // events that are provably outside the requested scope. Empty metadata is a
+  // legacy shape and must remain eligible; the entry-id join below is the
+  // authoritative match. This prevents expanding result_ids for unrelated
+  // events without changing behavior for older telemetry rows.
+  let eventScopeFilter = "";
+  const eventScopeParams: unknown[] = [];
+  if (hasEntryScope) {
+    const eventScopeParts: string[] = [];
+    if (namespace) {
+      if (namespace.endsWith("/")) {
+        const filter = buildNamespacePrefixRangeFilter("rn.value", namespace);
+        eventScopeParts.push(filter.clause);
+        eventScopeParams.push(...filter.params);
+      } else {
+        eventScopeParts.push("rn.value = ?");
+        eventScopeParams.push(namespace);
+      }
+    }
+    if (restrictToTracked) {
+      const eventTracked = trackedPatternsToSqlLike(trackedPatterns, "rn.value");
+      eventScopeParts.push(eventTracked.clause);
+      eventScopeParams.push(...eventTracked.params);
+    }
+    const eventScopeClause = eventScopeParts.length > 0
+      ? eventScopeParts.length === 1
+        ? eventScopeParts[0]
+        : `(${eventScopeParts.join(" AND ")})`
+      : "1";
+    eventScopeFilter = `
+        AND (
+          json_array_length(rev.result_namespaces) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM json_each(rev.result_namespaces) AS rn
+            WHERE ${eventScopeClause}
+          )
+        )`;
+  }
 
   // Optional rolling-window filter on impression event timestamp
   const sinceFilter = since ? "AND rev.timestamp >= ?" : "";
   const sinceParams: unknown[] = since ? [since] : [];
 
-  const sql = `
-    WITH scoped_entries AS (
+  const scopedEntriesCte = hasEntryScope ? `
+    scoped_entries AS MATERIALIZED (
       SELECT
         e.id,
         e.namespace,
@@ -3619,37 +3661,39 @@ export function getInsightsByEntry(
       WHERE TRUE
         ${nsFilter}
         ${trackedFilter}
-    ),
-    impressions_cte AS (
-      -- One row per (entry_id, event_id) from query/attention events with results
+    ),` : "";
+  const scopedImpressions = hasEntryScope
+    ? `
       SELECT
         se.id AS entry_id,
-        rev.id AS event_id
-      FROM scoped_entries se
-      JOIN retrieval_events rev
-      JOIN json_each(rev.result_ids) AS e_json ON e_json.value = se.id
+        ce.event_id
+      FROM candidate_events ce
+      CROSS JOIN json_each(ce.result_ids) AS e_json
+      JOIN scoped_entries se ON se.id = e_json.value`
+    : `
+      SELECT
+        e_json.value AS entry_id,
+        ce.event_id
+      FROM candidate_events ce
+      CROSS JOIN json_each(ce.result_ids) AS e_json`;
+  const entryJoin = hasEntryScope
+    ? "JOIN scoped_entries e ON e.id = imp.entry_id"
+    : "LEFT JOIN entries e ON e.id = imp.entry_id";
+
+  const sql = `
+    WITH${scopedEntriesCte}
+    candidate_events AS MATERIALIZED (
+      -- Apply indexed event/time predicates before JSON expansion. There is no
+      -- native SQLite index for array members, so json_each() is unavoidable
+      -- for the remaining candidate events.
+      SELECT rev.id AS event_id, rev.result_ids
+      FROM retrieval_events rev
       WHERE rev.tool_name IN ('memory_query', 'memory_attention')
         AND json_array_length(rev.result_ids) > 0
         ${sinceFilter}
+        ${eventScopeFilter}
     ),
-    outcomes_cte AS (
-      -- Keep outcomes tied to the same retrieval events as the scoped
-      -- impressions. Explicitly namespace-scoped write/log outcomes are
-      -- matched to the source entry namespace below; NULL namespaces retain
-      -- the legacy event-level association.
-      SELECT ro.entry_id, ro.retrieval_event_id, ro.outcome_type, ro.namespace, ro.timestamp
-      FROM retrieval_outcomes ro
-      JOIN (SELECT DISTINCT event_id FROM impressions_cte) imp_events
-        ON imp_events.event_id = ro.retrieval_event_id
-      WHERE ro.outcome_type IN (
-        'opened_result', 'write_in_result_namespace', 'log_in_result_namespace'
-      )
-    ),
-    opens_cte AS (
-      SELECT oc.entry_id, oc.retrieval_event_id
-      FROM outcomes_cte oc
-      WHERE oc.outcome_type = 'opened_result'
-        AND oc.entry_id IS NOT NULL
+    impressions_cte AS (${scopedImpressions}
     )
     SELECT
       imp.entry_id,
@@ -3660,39 +3704,39 @@ export function getInsightsByEntry(
       SUBSTR(e.content, 1, 60) AS content_preview,
       e.tags AS tags,
       COUNT(DISTINCT imp.event_id) AS impressions,
-      COUNT(DISTINCT op.retrieval_event_id) AS opens,
+      COUNT(DISTINCT ro_open.retrieval_event_id) AS opens,
       COUNT(DISTINCT CASE WHEN ro_w.outcome_type = 'write_in_result_namespace' THEN ro_w.retrieval_event_id END) AS write_outcomes,
       COUNT(DISTINCT CASE WHEN ro_l.outcome_type = 'log_in_result_namespace' THEN ro_l.retrieval_event_id END) AS log_outcomes,
       -- followthrough_events: distinct impression events where ANY follow-through action occurred.
-      -- Counting a single combined column avoids double-counting events that have multiple
-      -- outcome types (e.g. both opened_result AND write_in_result_namespace), which would
-      -- inflate (opens + write_outcomes + log_outcomes) / impressions above 1.0.
       COUNT(DISTINCT CASE
-        WHEN op.retrieval_event_id IS NOT NULL
+        WHEN ro_open.retrieval_event_id IS NOT NULL
           OR ro_w.retrieval_event_id IS NOT NULL
           OR ro_l.retrieval_event_id IS NOT NULL
         THEN imp.event_id
       END) AS followthrough_events,
       COUNT(DISTINCT CASE
-        WHEN op.retrieval_event_id IS NOT NULL
+        WHEN ro_open.retrieval_event_id IS NOT NULL
           AND e.updated_at IS NOT NULL
           AND (julianday(ro_open.timestamp) - julianday(e.updated_at)) > 14
-        THEN op.retrieval_event_id
+        THEN ro_open.retrieval_event_id
       END) AS opened_when_stale_count,
       e.created_at,
       COALESCE(e.updated_at, '') AS updated_at
     FROM impressions_cte imp
-    JOIN scoped_entries e ON e.id = imp.entry_id
-    LEFT JOIN opens_cte op ON op.entry_id = imp.entry_id AND op.retrieval_event_id = imp.event_id
-    LEFT JOIN outcomes_cte ro_open ON ro_open.entry_id = imp.entry_id
+    ${entryJoin}
+    -- Direct event-keyed joins keep outcome lookups on
+    -- idx_retrieval_outcomes_event; do not materialize a broad outcomes CTE.
+    LEFT JOIN retrieval_outcomes ro_open ON ro_open.retrieval_event_id = imp.event_id
       AND ro_open.outcome_type = 'opened_result'
-      AND ro_open.retrieval_event_id = imp.event_id
-    LEFT JOIN outcomes_cte ro_w ON ro_w.retrieval_event_id = imp.event_id
+      AND ro_open.entry_id = imp.entry_id
+    LEFT JOIN retrieval_outcomes ro_w ON ro_w.retrieval_event_id = imp.event_id
       AND ro_w.outcome_type = 'write_in_result_namespace'
-      AND (ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
-    LEFT JOIN outcomes_cte ro_l ON ro_l.retrieval_event_id = imp.event_id
+      -- A deleted entry has no namespace, so preserve the historical unscoped
+      -- event-level association for its anonymous row.
+      AND (e.namespace IS NULL OR ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
+    LEFT JOIN retrieval_outcomes ro_l ON ro_l.retrieval_event_id = imp.event_id
       AND ro_l.outcome_type = 'log_in_result_namespace'
-      AND (ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
+      AND (e.namespace IS NULL OR ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
     GROUP BY imp.entry_id, e.namespace, e.updated_at
     HAVING COUNT(DISTINCT imp.event_id) >= ?
     ORDER BY impressions DESC
@@ -3701,7 +3745,7 @@ export function getInsightsByEntry(
 
   return db
     .prepare(sql)
-    .all(...nsParams, ...tracked.params, ...sinceParams, minImpressions, clampedLimit) as EntryInsightRow[];
+    .all(...nsParams, ...tracked.params, ...sinceParams, ...eventScopeParams, minImpressions, clampedLimit) as EntryInsightRow[];
 }
 
 /**
@@ -5233,40 +5277,44 @@ export function countUnusedSurfaces(
     ? trackedPatternsToSqlLike(trackedPatterns, "e.namespace")
     : { clause: "", params: [] as string[] };
   const trackedFilter = tracked.clause ? `AND ${tracked.clause}` : "";
+  const eventTracked = restrictToTracked
+    ? trackedPatternsToSqlLike(trackedPatterns, "rn.value")
+    : { clause: "", params: [] as string[] };
+  const eventScopeFilter = restrictToTracked
+    ? `
+        AND (
+          json_array_length(rev.result_namespaces) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM json_each(rev.result_namespaces) AS rn
+            WHERE ${eventTracked.clause}
+          )
+        )`
+    : "";
 
   const sinceFilter = since ? "AND rev.timestamp >= ?" : "";
   const sinceParams: unknown[] = since ? [since] : [];
 
   const sql = `
-    WITH scoped_entries AS (
+    WITH scoped_entries AS MATERIALIZED (
       SELECT e.id, e.namespace
       FROM entries e
       WHERE TRUE
         ${trackedFilter}
     ),
-    impressions_cte AS (
-      SELECT se.id AS entry_id, rev.id AS event_id
-      FROM scoped_entries se
-      JOIN retrieval_events rev
-      JOIN json_each(rev.result_ids) AS e_json ON e_json.value = se.id
+    candidate_events AS MATERIALIZED (
+      SELECT rev.id AS event_id, rev.result_ids
+      FROM retrieval_events rev
       WHERE rev.tool_name IN ('memory_query', 'memory_attention')
         AND json_array_length(rev.result_ids) > 0
         ${sinceFilter}
+        ${eventScopeFilter}
     ),
-    outcomes_cte AS (
-      SELECT ro.entry_id, ro.retrieval_event_id, ro.outcome_type, ro.namespace
-      FROM retrieval_outcomes ro
-      JOIN (SELECT DISTINCT event_id FROM impressions_cte) imp_events
-        ON imp_events.event_id = ro.retrieval_event_id
-      WHERE ro.outcome_type IN (
-        'opened_result', 'write_in_result_namespace', 'log_in_result_namespace'
-      )
-    ),
-    opens_cte AS (
-      SELECT oc.entry_id, oc.retrieval_event_id
-      FROM outcomes_cte oc
-      WHERE oc.outcome_type = 'opened_result'
-        AND oc.entry_id IS NOT NULL
+    impressions_cte AS (
+      SELECT se.id AS entry_id, ce.event_id
+      FROM candidate_events ce
+      CROSS JOIN json_each(ce.result_ids) AS e_json
+      JOIN scoped_entries se ON se.id = e_json.value
     ),
     per_entry AS (
       SELECT
@@ -5280,13 +5328,15 @@ export function countUnusedSurfaces(
         END) AS followthrough_events
       FROM impressions_cte imp
       JOIN scoped_entries e ON e.id = imp.entry_id
-      LEFT JOIN opens_cte op ON op.entry_id = imp.entry_id AND op.retrieval_event_id = imp.event_id
-      LEFT JOIN outcomes_cte ro_w ON ro_w.retrieval_event_id = imp.event_id
+      LEFT JOIN retrieval_outcomes op ON op.retrieval_event_id = imp.event_id
+        AND op.outcome_type = 'opened_result'
+        AND op.entry_id = imp.entry_id
+      LEFT JOIN retrieval_outcomes ro_w ON ro_w.retrieval_event_id = imp.event_id
         AND ro_w.outcome_type = 'write_in_result_namespace'
-        AND (ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
-      LEFT JOIN outcomes_cte ro_l ON ro_l.retrieval_event_id = imp.event_id
+        AND (e.namespace IS NULL OR ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
+      LEFT JOIN retrieval_outcomes ro_l ON ro_l.retrieval_event_id = imp.event_id
         AND ro_l.outcome_type = 'log_in_result_namespace'
-        AND (ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
+        AND (e.namespace IS NULL OR ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
       GROUP BY imp.entry_id
     )
     SELECT COUNT(*) AS cnt
@@ -5296,7 +5346,7 @@ export function countUnusedSurfaces(
 
   const row = db
     .prepare(sql)
-    .get(...tracked.params, ...sinceParams, minImpressions) as { cnt: number } | undefined;
+    .get(...tracked.params, ...sinceParams, ...eventTracked.params, minImpressions) as { cnt: number } | undefined;
   return row?.cnt ?? 0;
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -3577,7 +3577,9 @@ export function getInsightsByEntry(
 ): EntryInsightRow[] {
   const clampedLimit = Math.min(Math.max(limit, 1), MAX_QUERY_LIMIT);
 
-  // Build namespace filter clause (applies to e.namespace from LEFT JOIN entries)
+  // Build namespace filter clause for the scoped entry set. Keeping this filter
+  // in its own CTE means unrelated entries never enter json_each() expansion or
+  // the event/outcome joins below.
   let nsFilter = "";
   const nsParams: unknown[] = [];
   if (namespace) {
@@ -3602,22 +3604,52 @@ export function getInsightsByEntry(
   const sinceParams: unknown[] = since ? [since] : [];
 
   const sql = `
-    WITH impressions_cte AS (
+    WITH scoped_entries AS (
+      SELECT
+        e.id,
+        e.namespace,
+        e.key,
+        e.entry_type,
+        e.classification,
+        e.content,
+        e.tags,
+        e.created_at,
+        e.updated_at
+      FROM entries e
+      WHERE TRUE
+        ${nsFilter}
+        ${trackedFilter}
+    ),
+    impressions_cte AS (
       -- One row per (entry_id, event_id) from query/attention events with results
       SELECT
-        e_json.value AS entry_id,
+        se.id AS entry_id,
         rev.id AS event_id
-      FROM retrieval_events rev,
-           json_each(rev.result_ids) AS e_json
+      FROM scoped_entries se
+      JOIN retrieval_events rev
+      JOIN json_each(rev.result_ids) AS e_json ON e_json.value = se.id
       WHERE rev.tool_name IN ('memory_query', 'memory_attention')
         AND json_array_length(rev.result_ids) > 0
         ${sinceFilter}
     ),
-    opens_cte AS (
-      SELECT ro.entry_id, ro.retrieval_event_id
+    outcomes_cte AS (
+      -- Keep outcomes tied to the same retrieval events as the scoped
+      -- impressions. Explicitly namespace-scoped write/log outcomes are
+      -- matched to the source entry namespace below; NULL namespaces retain
+      -- the legacy event-level association.
+      SELECT ro.entry_id, ro.retrieval_event_id, ro.outcome_type, ro.namespace, ro.timestamp
       FROM retrieval_outcomes ro
-      WHERE ro.outcome_type = 'opened_result'
-        AND ro.entry_id IS NOT NULL
+      JOIN (SELECT DISTINCT event_id FROM impressions_cte) imp_events
+        ON imp_events.event_id = ro.retrieval_event_id
+      WHERE ro.outcome_type IN (
+        'opened_result', 'write_in_result_namespace', 'log_in_result_namespace'
+      )
+    ),
+    opens_cte AS (
+      SELECT oc.entry_id, oc.retrieval_event_id
+      FROM outcomes_cte oc
+      WHERE oc.outcome_type = 'opened_result'
+        AND oc.entry_id IS NOT NULL
     )
     SELECT
       imp.entry_id,
@@ -3650,18 +3682,17 @@ export function getInsightsByEntry(
       e.created_at,
       COALESCE(e.updated_at, '') AS updated_at
     FROM impressions_cte imp
-    LEFT JOIN entries e ON e.id = imp.entry_id
+    JOIN scoped_entries e ON e.id = imp.entry_id
     LEFT JOIN opens_cte op ON op.entry_id = imp.entry_id AND op.retrieval_event_id = imp.event_id
-    LEFT JOIN retrieval_outcomes ro_open ON ro_open.entry_id = imp.entry_id
+    LEFT JOIN outcomes_cte ro_open ON ro_open.entry_id = imp.entry_id
       AND ro_open.outcome_type = 'opened_result'
       AND ro_open.retrieval_event_id = imp.event_id
-    LEFT JOIN retrieval_outcomes ro_w ON ro_w.retrieval_event_id = imp.event_id
+    LEFT JOIN outcomes_cte ro_w ON ro_w.retrieval_event_id = imp.event_id
       AND ro_w.outcome_type = 'write_in_result_namespace'
-    LEFT JOIN retrieval_outcomes ro_l ON ro_l.retrieval_event_id = imp.event_id
+      AND (ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
+    LEFT JOIN outcomes_cte ro_l ON ro_l.retrieval_event_id = imp.event_id
       AND ro_l.outcome_type = 'log_in_result_namespace'
-    WHERE TRUE
-      ${nsFilter}
-      ${trackedFilter}
+      AND (ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
     GROUP BY imp.entry_id, e.namespace, e.updated_at
     HAVING COUNT(DISTINCT imp.event_id) >= ?
     ORDER BY impressions DESC
@@ -3670,7 +3701,7 @@ export function getInsightsByEntry(
 
   return db
     .prepare(sql)
-    .all(...sinceParams, ...nsParams, ...tracked.params, minImpressions, clampedLimit) as EntryInsightRow[];
+    .all(...nsParams, ...tracked.params, ...sinceParams, minImpressions, clampedLimit) as EntryInsightRow[];
 }
 
 /**
@@ -5207,19 +5238,35 @@ export function countUnusedSurfaces(
   const sinceParams: unknown[] = since ? [since] : [];
 
   const sql = `
-    WITH impressions_cte AS (
-      SELECT e_json.value AS entry_id, rev.id AS event_id
-      FROM retrieval_events rev,
-           json_each(rev.result_ids) AS e_json
+    WITH scoped_entries AS (
+      SELECT e.id, e.namespace
+      FROM entries e
+      WHERE TRUE
+        ${trackedFilter}
+    ),
+    impressions_cte AS (
+      SELECT se.id AS entry_id, rev.id AS event_id
+      FROM scoped_entries se
+      JOIN retrieval_events rev
+      JOIN json_each(rev.result_ids) AS e_json ON e_json.value = se.id
       WHERE rev.tool_name IN ('memory_query', 'memory_attention')
         AND json_array_length(rev.result_ids) > 0
         ${sinceFilter}
     ),
-    opens_cte AS (
-      SELECT ro.entry_id, ro.retrieval_event_id
+    outcomes_cte AS (
+      SELECT ro.entry_id, ro.retrieval_event_id, ro.outcome_type, ro.namespace
       FROM retrieval_outcomes ro
-      WHERE ro.outcome_type = 'opened_result'
-        AND ro.entry_id IS NOT NULL
+      JOIN (SELECT DISTINCT event_id FROM impressions_cte) imp_events
+        ON imp_events.event_id = ro.retrieval_event_id
+      WHERE ro.outcome_type IN (
+        'opened_result', 'write_in_result_namespace', 'log_in_result_namespace'
+      )
+    ),
+    opens_cte AS (
+      SELECT oc.entry_id, oc.retrieval_event_id
+      FROM outcomes_cte oc
+      WHERE oc.outcome_type = 'opened_result'
+        AND oc.entry_id IS NOT NULL
     ),
     per_entry AS (
       SELECT
@@ -5232,14 +5279,14 @@ export function countUnusedSurfaces(
           THEN imp.event_id
         END) AS followthrough_events
       FROM impressions_cte imp
-      LEFT JOIN entries e ON e.id = imp.entry_id
+      JOIN scoped_entries e ON e.id = imp.entry_id
       LEFT JOIN opens_cte op ON op.entry_id = imp.entry_id AND op.retrieval_event_id = imp.event_id
-      LEFT JOIN retrieval_outcomes ro_w ON ro_w.retrieval_event_id = imp.event_id
+      LEFT JOIN outcomes_cte ro_w ON ro_w.retrieval_event_id = imp.event_id
         AND ro_w.outcome_type = 'write_in_result_namespace'
-      LEFT JOIN retrieval_outcomes ro_l ON ro_l.retrieval_event_id = imp.event_id
+        AND (ro_w.namespace IS NULL OR ro_w.namespace = e.namespace)
+      LEFT JOIN outcomes_cte ro_l ON ro_l.retrieval_event_id = imp.event_id
         AND ro_l.outcome_type = 'log_in_result_namespace'
-      WHERE TRUE
-        ${trackedFilter}
+        AND (ro_l.namespace IS NULL OR ro_l.namespace = e.namespace)
       GROUP BY imp.entry_id
     )
     SELECT COUNT(*) AS cnt
@@ -5249,7 +5296,7 @@ export function countUnusedSurfaces(
 
   const row = db
     .prepare(sql)
-    .get(...sinceParams, ...tracked.params, minImpressions) as { cnt: number } | undefined;
+    .get(...tracked.params, ...sinceParams, minImpressions) as { cnt: number } | undefined;
   return row?.cnt ?? 0;
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7611,7 +7611,7 @@ const TOOL_DEFINITIONS = [
   {
     name: "memory_insights",
     description:
-      "Return per-entry retrieval analytics: how often each entry was retrieved (impressions), opened (opens), followed by writes or logs, and whether it was stale when opened. Useful for understanding which memories are most actionable and which are frequently stale. Requires at least min_impressions retrieval events (default 3) to appear in results; when nothing clears the threshold the response carries an explanatory `message` rather than a bare empty array.",
+      "Return per-entry retrieval analytics: how often each entry was retrieved (impressions), opened (opens), followed by writes or logs, and whether it was stale when opened. Useful for understanding which memories are most actionable and which are frequently stale. Requires at least min_impressions retrieval events (default 3) to appear in results; when nothing clears the threshold the response carries an explanatory `message` rather than a bare empty array. The response's `aggregates` object is intentionally global across namespaces and is labeled with a global scope; only `entries` is namespace-filtered.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -12515,6 +12515,9 @@ export function registerTools(
                   `${rawAgg.multi_event_sessions} multi-event sessions).`
                 : "All sessions had multiple events; raw and adjusted rates are equivalent.";
               const aggregates: RetrievalAggregates = {
+                // The per-entry rows honor insightsArgs.namespace; these health
+                // aggregates intentionally remain global and say so explicitly.
+                scope: "global",
                 period_start: rawAgg.period_start,
                 period_end: rawAgg.period_end,
                 total_events: rawAgg.total_events,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -9164,11 +9164,15 @@ export function registerTools(
                   readableProposal.source_untrusted
                   || approvalError?.untrusted_content === true
                 );
+                // Terminal or otherwise non-approvable proposals may retain their
+                // payload for audit/undo purposes, but their exact operation is
+                // no longer eligible for review-preview disclosure.
+                const showExactOperation = approvalEffect.approvalStatus !== "not_approvable";
                 return okResult("review", {
                   proposal_id: proposal.id,
                   status: readableProposal.status,
                   ...(persistedStatus ? { persisted_status: persistedStatus } : {}),
-                  ...(readableProposal.current_operation
+                  ...(showExactOperation && readableProposal.current_operation
                     ? { exact_operation: readableProposal.current_operation }
                     : {}),
                   classification: readableProposal.classification,

--- a/src/types.ts
+++ b/src/types.ts
@@ -836,6 +836,8 @@ export interface RetrievalFeedbackRow {
 }
 
 export interface RetrievalAggregates {
+  /** These aggregates cover all retrieval events and are not namespace-filtered. */
+  scope: "global";
   period_start: string;
   period_end: string;
   total_events: number;

--- a/tests/retrieval-tools.test.ts
+++ b/tests/retrieval-tools.test.ts
@@ -280,6 +280,7 @@ describe("memory_insights tool", () => {
     const raw = await callTool("memory_insights");
     const result = parseToolResponse(raw) as {
       aggregates: {
+        scope: "global";
         reformulation_rate: number;
         reformulation_rate_adjusted: number;
         reformulation_explanation: string;
@@ -289,6 +290,7 @@ describe("memory_insights tool", () => {
     };
 
     expect(result.aggregates).toBeDefined();
+    expect(result.aggregates.scope).toBe("global");
     expect(result.aggregates.reformulation_rate).toBeTypeOf("number");
     expect(result.aggregates.reformulation_rate_adjusted).toBeTypeOf("number");
     expect(result.aggregates.reformulation_explanation).toBeTypeOf("string");

--- a/tests/retrieval.test.ts
+++ b/tests/retrieval.test.ts
@@ -371,6 +371,75 @@ describe("getInsightsByEntry", () => {
     expect(projectsOnly.some((r) => r.entry_id === entryB.id)).toBe(false);
   });
 
+  it("scopes entries before expansion and keeps same-event outcomes in their namespace", () => {
+    writeState(db, "projects/scoped-insights", "status", "scoped target", ["active"]);
+    writeState(db, "clients/unrelated", "status", "unrelated small", ["active"]);
+
+    const target = db
+      .prepare("SELECT id FROM entries WHERE namespace = 'projects/scoped-insights' AND key = 'status'")
+      .get() as { id: string };
+    const unrelated = db
+      .prepare("SELECT id FROM entries WHERE namespace = 'clients/unrelated' AND key = 'status'")
+      .get() as { id: string };
+
+    // The first event contains results from both namespaces. Its write outcome
+    // belongs to the unrelated namespace and must not count for the target.
+    logRetrievalEvent(db, {
+      sessionId: "session-scoped-insights-cross-namespace",
+      toolName: "memory_query",
+      queryText: "scoped",
+      resultIds: [target.id, unrelated.id],
+      resultNamespaces: ["projects/scoped-insights", "clients/unrelated"],
+      resultRanks: [1, 2],
+    });
+    logRetrievalOutcome(db, "session-scoped-insights-cross-namespace", {
+      outcomeType: "write_in_result_namespace",
+      namespace: "clients/unrelated",
+    });
+
+    // A same-namespace outcome on another event should still be associated.
+    logRetrievalEvent(db, {
+      sessionId: "session-scoped-insights-same-namespace",
+      toolName: "memory_query",
+      queryText: "scoped",
+      resultIds: [target.id],
+      resultNamespaces: ["projects/scoped-insights"],
+      resultRanks: [1],
+    });
+    logRetrievalOutcome(db, "session-scoped-insights-same-namespace", {
+      outcomeType: "write_in_result_namespace",
+      namespace: "projects/scoped-insights",
+    });
+
+    // Keep a larger unrelated corpus in the fixture so the namespace-scoped
+    // path is exercised against more than one result/event.
+    for (let index = 0; index < 64; index += 1) {
+      const namespace = `clients/unrelated-${index}`;
+      writeState(db, namespace, "status", `unrelated large ${index}`, ["active"]);
+      const entry = db
+        .prepare("SELECT id FROM entries WHERE namespace = ? AND key = 'status'")
+        .get(namespace) as { id: string };
+      logRetrievalEvent(db, {
+        sessionId: `session-scoped-insights-unrelated-${index}`,
+        toolName: "memory_query",
+        queryText: "unrelated",
+        resultIds: [entry.id],
+        resultNamespaces: [namespace],
+        resultRanks: [1],
+      });
+    }
+
+    const prefixRows = getInsightsByEntry(db, "projects/", 1, 1);
+    expect(prefixRows).toHaveLength(1);
+    expect(prefixRows[0].entry_id).toBe(target.id);
+    expect(prefixRows[0].impressions).toBe(2);
+    expect(prefixRows[0].write_outcomes).toBe(1);
+    expect(prefixRows[0].followthrough_events).toBe(1);
+
+    const exactRows = getInsightsByEntry(db, "projects/scoped-insights", 1, 1);
+    expect(exactRows.map((row) => row.entry_id)).toEqual([target.id]);
+  });
+
   it("respects min_impressions threshold", () => {
     writeState(db, "projects/low-impressions", "status", "low", ["active"]);
     const entry = db

--- a/tests/retrieval.test.ts
+++ b/tests/retrieval.test.ts
@@ -371,6 +371,50 @@ describe("getInsightsByEntry", () => {
     expect(projectsOnly.some((r) => r.entry_id === entryB.id)).toBe(false);
   });
 
+  it("keeps deleted retrieval results as anonymous rows only when unscoped", () => {
+    writeState(db, "projects/deleted-insight", "status", "will be deleted", ["active"]);
+    const entry = db
+      .prepare("SELECT id FROM entries WHERE namespace = 'projects/deleted-insight' AND key = 'status'")
+      .get() as { id: string };
+
+    logRetrievalEvent(db, {
+      sessionId: "session-insights-orphan",
+      toolName: "memory_query",
+      queryText: "deleted",
+      resultIds: [entry.id],
+      resultNamespaces: ["projects/deleted-insight"],
+      resultRanks: [1],
+    });
+    logRetrievalOutcome(db, "session-insights-orphan", {
+      outcomeType: "opened_result",
+      entryId: entry.id,
+      namespace: "projects/deleted-insight",
+    });
+    logRetrievalOutcome(db, "session-insights-orphan", {
+      outcomeType: "write_in_result_namespace",
+      namespace: "projects/deleted-insight",
+    });
+    db.prepare("DELETE FROM entries WHERE id = ?").run(entry.id);
+
+    const unscoped = getInsightsByEntry(db, undefined, 1, 20);
+    const orphan = unscoped.find((row) => row.entry_id === entry.id);
+    expect(orphan).toMatchObject({
+      entry_id: entry.id,
+      namespace: null,
+      key: null,
+      content_preview: null,
+      impressions: 1,
+      opens: 1,
+      write_outcomes: 1,
+      followthrough_events: 1,
+    });
+    expect(orphan?.updated_at).toBe("");
+
+    // A namespace scope has no surviving entry namespace to match, so the
+    // anonymous historical row must not cross that boundary.
+    expect(getInsightsByEntry(db, "projects/", 1, 20)).toEqual([]);
+  });
+
   it("scopes entries before expansion and keeps same-event outcomes in their namespace", () => {
     writeState(db, "projects/scoped-insights", "status", "scoped target", ["active"]);
     writeState(db, "clients/unrelated", "status", "unrelated small", ["active"]);

--- a/tests/review-tools.test.ts
+++ b/tests/review-tools.test.ts
@@ -2399,6 +2399,7 @@ describe("reviewed undo", () => {
         },
       });
       expect(preview).not.toHaveProperty("exact_operation");
+      expect(JSON.stringify(preview)).not.toContain("Replacement architecture");
 
       const rejected = await call("memory_review", {
         action: "approve",


### PR DESCRIPTION
Fixes #276 code-path latency and namespace leakage. Scopes event/outcome aggregation before expansion while retaining unscoped orphan insight semantics. Validation: focused tests, typecheck, lint, query-plan checks.